### PR TITLE
Add prompt for updating agent workspace

### DIFF
--- a/.agent/prompts/update-agent-workspace.md
+++ b/.agent/prompts/update-agent-workspace.md
@@ -1,0 +1,27 @@
+# Update Agent Workspace
+
+This is a daily maintenance task to iteratively improve the `.agent/` workspace.
+
+## Goal
+
+Analyze recent changes, recurring patterns, or missing automation in the repository, and implement *one small, easily reviewable* improvement to the `.agent/` folder (e.g., a new skill, a refined prompt, or updated core instructions).
+
+## Requirements
+
+1. **Scope:** Keep the change small and focused. The resulting PR must be easy for a human to review in less than 5 minutes.
+2. **Relevance:** The improvement must be grounded in actual recent activity in the repository, or clear gaps in existing `.agent/` documentation/tools.
+3. **Format:** Adhere to the established structure of `.agent/` (e.g., `core/`, `prompts/`, `skills/`, `tools/`).
+4. **Documentation:** If adding a new prompt or skill, ensure its purpose and usage are clear.
+
+## Workflow
+
+1. Briefly review recent commits or pull requests to identify recurring tasks or friction points.
+2. Review the current state of `.agent/`.
+3. Propose a single, specific addition or modification (e.g., "Add a `skills/update-dependencies/SKILL.md`").
+4. Implement the change.
+5. Create a descriptive commit message and PR for the human reviewer.
+
+## Expected Output
+
+- A single, self-contained change to a file within the `.agent/` directory.
+- A concise summary of why the change is beneficial based on recent repo context.

--- a/.agent/prompts/update-agent-workspace.md
+++ b/.agent/prompts/update-agent-workspace.md
@@ -1,6 +1,6 @@
 # Update Agent Workspace
 
-This is a daily maintenance task to iteratively improve the `.agent/` workspace.
+You are an agent responsible for iteratively improving the `.agent/` workspace in this repository.
 
 ## Goal
 


### PR DESCRIPTION
This adds a new prompt file, `.agent/prompts/update-agent-workspace.md`, intended for a daily automated task. The agent will read this prompt to identify and implement one small, reviewable improvement (such as a new skill, a refined prompt, or updated core instructions) to the `.agent/` directory based on recent repository activity.

---
*PR created automatically by Jules for task [11409287272523961013](https://jules.google.com/task/11409287272523961013) started by @Rfluid*