### PR TITLE
⚡ Bolt: Optimize transport frame decryption to use zero-copy allocation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-14 - Transport payload decryption zero-copy allocation optimization
+**Learning:** Decrypting received TransportFrames created unnecessary memory pressure due to buffer allocation. In an async daemon doing heavy network I/O, allocating strings or slices in a hot path causes bottlenecks.
+**Action:** Always favor using `AeadInPlace` in `aes-gcm` (or similar cipher crates) so you can directly decrypt the payload within its original slice over allocating copies of the slice for the cipher output.

--- a/crates/pim-crypto/src/session.rs
+++ b/crates/pim-crypto/src/session.rs
@@ -86,6 +86,25 @@ impl SessionCipher {
         Ok(plaintext)
     }
 
+    /// Decrypts a frame in-place, avoiding an allocation.
+    /// Returns an error if the nonce is replayed, or if decryption fails.
+    pub fn decrypt_in_place_detached(&self, nonce_bytes: &[u8; 12], payload: &mut [u8], tag_bytes: &[u8; 16]) -> Result<(), SessionError> {
+        let counter = u32::from_be_bytes(nonce_bytes[8..12].try_into().unwrap()) as u64;
+        let last = self.last_recv_counter.load(Ordering::SeqCst);
+        if last != u64::MAX && counter <= last {
+            return Err(SessionError::ReplayedNonce);
+        }
+
+        let nonce = Nonce::from_slice(nonce_bytes);
+        let tag = aes_gcm::aead::Tag::<aes_gcm::Aes256Gcm>::from_slice(tag_bytes);
+        aes_gcm::aead::AeadInPlace::decrypt_in_place_detached(&self.cipher, nonce, b"", payload, tag)
+            .map_err(|_| SessionError::DecryptionFailed)?;
+
+        self.last_recv_counter.store(counter, Ordering::SeqCst);
+        Ok(())
+    }
+
+
     /// Build a 12-byte nonce from the prefix and counter.
     fn build_nonce(&self, counter: u32) -> [u8; 12] {
         let mut nonce = [0u8; 12];

--- a/crates/pim-daemon/src/main.rs
+++ b/crates/pim-daemon/src/main.rs
@@ -102,14 +102,9 @@ impl Session {
         transport_frame_from_encrypted(ef)
     }
 
-    fn decrypt_frame(&self, frame: &TransportFrame) -> Result<Vec<u8>> {
-        let mut ct = frame.payload.clone();
-        ct.extend_from_slice(&frame.tag);
-        let ef = EncryptedFrame {
-            nonce: frame.nonce,
-            ciphertext: ct,
-        };
-        Ok(self.recv.decrypt(&ef)?)
+    fn decrypt_frame(&self, mut frame: TransportFrame) -> Result<TransportFrame> {
+        self.recv.decrypt_in_place_detached(&frame.nonce, &mut frame.payload, &frame.tag)?;
+        Ok(frame)
     }
 }
 
@@ -1668,11 +1663,11 @@ async fn run_event_loop(state: Arc<DaemonState>) -> Result<()> {
                             warn!(%from_peer, "data frame before session; dropping");
                             continue;
                         };
-                        let plaintext = match session.decrypt_frame(&frame) {
-                            Ok(p) => p,
+                        let frame = match session.decrypt_frame(frame) {
+                            Ok(f) => f,
                             Err(e) => { warn!(%from_peer, "decrypt: {e}"); continue; }
                         };
-                        let mut buf = BytesMut::from(plaintext.as_slice());
+                        let mut buf = BytesMut::from(frame.payload.as_slice());
                         let mesh = match MeshDataFrame::decode(&mut buf) {
                             Ok(m) => m,
                             Err(e) => { warn!(%from_peer, "mesh decode: {e}"); continue; }


### PR DESCRIPTION
⚡ Bolt: Optimize transport frame decryption to use zero-copy allocation

💡 What: Changed the `SessionCipher::decrypt` usage to an in-place version `decrypt_in_place_detached` leveraging `AeadInPlace`. This avoids allocating a new memory buffer and copying the payload bytes during frame decryption.
🎯 Why: Decrypting received TransportFrames on the network loop is a hot path. The previous implementation called `clone()` on the payload vector and `extend_from_slice` on the tag, which unnecessarily pressured the memory allocator and slowed down decryption throughput.
📊 Impact: Reduces memory allocations by 1 per received data frame, lowering GC/allocator pressure and speeding up the hot receive path.
🔬 Measurement: Run `cargo test --workspace` to ensure no regression in crypto and daemon functionality. The tests now exercise the `decrypt_frame` implementation using `decrypt_in_place_detached` directly on the received payload slice.

---
*PR created automatically by Jules for task [13856173204739277188](https://jules.google.com/task/13856173204739277188) started by @Rfluid*