### PR TITLE
🛡️ Sentinel: [HIGH] Fix private key file permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-09 - [Secure File Permissions for Private Keys]
+**Vulnerability:** The node's private Ed25519 signing key (`node.key`) was written using `std::fs::write`, which falls back to the system's default `umask` and can leave the key world-readable.
+**Learning:** Relying on default file permissions when writing sensitive cryptographic material creates a risk of exposing the key to other local users.
+**Prevention:** Explicitly use `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o600)` on Unix systems to ensure strict file access permissions when writing secrets.

--- a/crates/pim-crypto/src/identity.rs
+++ b/crates/pim-crypto/src/identity.rs
@@ -38,7 +38,19 @@ impl Identity {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        std::fs::write(path, self.signing_key.to_bytes())
+
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        use std::io::Write;
+        let mut file = options.open(path)?;
+        file.write_all(&self.signing_key.to_bytes())
     }
 
     /// Load an identity from a private key file.


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Secure private key file permissions

**Severity:** HIGH
**Vulnerability:** The node's private Ed25519 signing key (`node.key`) was written using `std::fs::write`, falling back to the default system `umask`. This could potentially leave the sensitive key file world-readable.
**Impact:** A malicious local user could read the key and impersonate the node on the mesh.
**Fix:** Modified `Identity::save` to explicitly use `OpenOptions` and set `0o600` (read/write by owner only) permissions when creating or overwriting the file on Unix platforms via `OpenOptionsExt`.
**Verification:** Added to `.jules/sentinel.md` journal. `cargo test --workspace` passes cleanly.

---
*PR created automatically by Jules for task [11505512053432890069](https://jules.google.com/task/11505512053432890069) started by @Rfluid*