### PR TITLE
🛡️ Sentinel: [HIGH] Secure file permissions for config and daemon state

### DIFF
--- a/crates/pim-cli/src/main.rs
+++ b/crates/pim-cli/src/main.rs
@@ -363,8 +363,22 @@ fn cmd_config_generate(
                 path.display()
             );
         }
-        std::fs::write(&path, rendered)
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        use std::io::Write;
+        let mut file = options
+            .open(&path)
+            .with_context(|| format!("failed to open config file {}", path.display()))?;
+        file.write_all(rendered.as_bytes())
             .with_context(|| format!("failed to write config template to {}", path.display()))?;
+
         println!("Wrote config template to {}", path.display());
     } else {
         print!("{rendered}");


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Generated config files (`pim init`) and daemon state files (`trusted-peers.toml`) were written using default file permissions, making them potentially readable by other unprivileged users on the same system. These files can contain sensitive information like the `shared_key` for discovery.
🎯 Impact: Unauthorized local users could read sensitive node configuration and connection information, potentially compromising the mesh network access controls.
🔧 Fix: Used explicit `OpenOptions` with `0o600` (read/write by owner only) permissions when writing these files in `pim-cli` and `pim-daemon`.
✅ Verification: Ensure tests pass and the daemon/cli continue to compile and work as expected. Verify newly created files have correct permissions.

---
*PR created automatically by Jules for task [1362734879496620083](https://jules.google.com/task/1362734879496620083) started by @Rfluid*