### PR TITLE
Update review-change.md to check against project learnings

### DIFF
--- a/.agent/prompts/review-change.md
+++ b/.agent/prompts/review-change.md
@@ -5,15 +5,17 @@ Review a change in this repository.
 Priorities:
 
 1. Behavioral regressions in the changed code path
-2. Incorrect crate ownership or cross-layer leakage
-3. Missing validation, tests, or failure handling
-4. Backward-compatibility issues in config or operator workflow
-5. Documentation drift
+2. Security or performance regressions against known project learnings
+3. Incorrect crate ownership or cross-layer leakage
+4. Missing validation, tests, or failure handling
+5. Backward-compatibility issues in config or operator workflow
+6. Documentation drift
 
 Focus questions:
 
 - Does the change belong in the crate where it was implemented?
 - Does it preserve existing invariants and runtime expectations?
+- Does the change avoid regressions against the security and performance learnings recorded in `.jules/sentinel.md` and `.jules/bolt.md`?
 - Are failure paths, cleanup, and defaults handled safely?
 - Is the verification scope appropriate for the risk of the change?
 - Does the implementation still match the relevant guidance in `README.md` or `./docs`?


### PR DESCRIPTION
This updates the review change prompt to make sure future code changes are evaluated against the known learnings accumulated in the `.jules/` directory, minimizing the chance of reintroducing known vulnerabilities or performance issues.

---
*PR created automatically by Jules for task [3967055226695292826](https://jules.google.com/task/3967055226695292826) started by @Rfluid*