### PR TITLE
Docs: Add secure file permissions rule to CONVENTIONS.md

### DIFF
--- a/.agent/core/CONVENTIONS.md
+++ b/.agent/core/CONVENTIONS.md
@@ -13,6 +13,7 @@ These conventions are specific to this repository and should guide agent work.
 7. Default new features to opt-in when they change runtime behavior or dependencies.
 8. Prefer asynchronous file I/O via `tokio::fs` over synchronous `std::fs` in async contexts.
 9. Use top-level `#[cfg]` attributes for cross-platform logic instead of internal `#[cfg]` blocks.
+10. Explicitly use `OpenOptions` with strict permissions (e.g., `mode(0o600)` on Unix) when writing sensitive data, rather than relying on default system umasks.
 
 ## Repo Design Bias
 


### PR DESCRIPTION
Based on recent activity in the repository (`0a6e0cd 🛡️ Sentinel: [HIGH] Secure private key file permissions`), I noticed that the node's private Ed25519 signing key was being written using `std::fs::write` which defaults to the system umask. This vulnerability was fixed by explicitly using `OpenOptions` and `0o600` permissions.

To prevent agents from making similar mistakes in the future, I have updated `.agent/core/CONVENTIONS.md` to include a new general rule:
"Explicitly use `OpenOptions` with strict permissions (e.g., `mode(0o600)` on Unix) when writing sensitive data, rather than relying on default system umasks."

This ensures any new code generated that writes sensitive files will have the correct permissions. I have verified that tests and clippy still pass cleanly after this change.

---
*PR created automatically by Jules for task [2896289958209677536](https://jules.google.com/task/2896289958209677536) started by @Rfluid*