### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure file permissions in daemon atomic_write

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The node's private Ed25519 signing key (`node.key`) was written using `std::fs::write`, which falls back to the system's default `umask` and can leave the key world-readable.
 **Learning:** Relying on default file permissions when writing sensitive cryptographic material creates a risk of exposing the key to other local users.
 **Prevention:** Explicitly use `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o600)` on Unix systems to ensure strict file access permissions when writing secrets.
+
+## 2024-05-24 - [Secure File Permissions for Daemon Files]
+**Vulnerability:** The daemon's `atomic_write` function used `tokio::fs::write`, which relies on the system's default `umask`. This function is used to write sensitive files like the trust store, potentially making them world-readable.
+**Learning:** Relying on default file permissions when writing runtime configuration or trust stores creates a risk of exposing sensitive peer identities or network state to other local users.
+**Prevention:** Explicitly use `tokio::fs::OpenOptions` with `mode(0o600)` on Unix systems and `tokio::io::AsyncWriteExt` to ensure strict file access permissions when performing asynchronous writes of sensitive data.

--- a/crates/pim-daemon/src/main.rs
+++ b/crates/pim-daemon/src/main.rs
@@ -827,8 +827,21 @@ async fn run_stats_writer(state: Arc<DaemonState>) {
 }
 
 async fn atomic_write(path: &str, content: &[u8]) -> io::Result<()> {
+    use tokio::io::AsyncWriteExt;
     let tmp = format!("{path}.tmp");
-    tokio::fs::write(&tmp, content).await?;
+
+    // Unconditionally remove the temp file to ensure O_CREAT respects the mode
+    let _ = tokio::fs::remove_file(&tmp).await;
+
+    let mut options = tokio::fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        options.mode(0o600);
+    }
+    let mut file = options.open(&tmp).await?;
+    file.write_all(content).await?;
+    file.flush().await?;
     tokio::fs::rename(&tmp, path).await?;
     Ok(())
 }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The daemon's `atomic_write` function used `tokio::fs::write`, which relies on the system's default `umask`. This function is used to write sensitive files like the trust store, potentially making them world-readable.
🎯 Impact: Other users on the same machine could read sensitive data like peer trust store details.
🔧 Fix: Replaced `tokio::fs::write` with explicitly configured `tokio::fs::OpenOptions` and `AsyncWriteExt`, setting the creation mode to `0o600` on Unix systems to ensure strict file access permissions. Added a learning about this to `.jules/sentinel.md`.
✅ Verification: Ran `cargo test --workspace` and `cargo clippy --workspace -- -D warnings` to verify no functionality was broken and no warnings were introduced.

---
*PR created automatically by Jules for task [4491979771183427726](https://jules.google.com/task/4491979771183427726) started by @Rfluid*