### PR TITLE
⚡ Bolt: In-place E2E decryption

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-14 - Transport payload decryption zero-copy allocation optimization
 **Learning:** Decrypting received TransportFrames created unnecessary memory pressure due to buffer allocation. In an async daemon doing heavy network I/O, allocating strings or slices in a hot path causes bottlenecks.
 **Action:** Always favor using `AeadInPlace` in `aes-gcm` (or similar cipher crates) so you can directly decrypt the payload within its original slice over allocating copies of the slice for the cipher output.
+
+## 2024-05-14 - E2E payload decryption zero-copy allocation optimization
+**Learning:** Similar to TransportFrames, decrypting received E2E payloads created unnecessary memory pressure due to buffer allocation of `Vec<u8>`. In an async daemon doing heavy network I/O, allocating strings or slices in a hot path causes bottlenecks.
+**Action:** Decrypt E2E payload within its original slice over allocating copies of the slice for the cipher output using `AeadInPlace` in `aes-gcm`.

--- a/crates/pim-crypto/src/e2e.rs
+++ b/crates/pim-crypto/src/e2e.rs
@@ -102,10 +102,10 @@ pub fn e2e_encrypt(plaintext: &[u8], gateway_x25519_pub: &[u8; 32]) -> Result<Ve
 /// Decrypt an E2E-encrypted frame using the gateway's Ed25519 seed.
 ///
 /// `ciphertext` is the output of [`e2e_encrypt`].
-pub fn e2e_decrypt(
-    ciphertext: &[u8],
+pub fn e2e_decrypt<'a>(
+    ciphertext: &'a mut [u8],
     gateway_ed25519_seed: &[u8; 32],
-) -> Result<Vec<u8>, E2eError> {
+) -> Result<&'a [u8], E2eError> {
     if ciphertext.len() < HEADER_SIZE + TAG_SIZE {
         return Err(E2eError::TooShort);
     }
@@ -116,7 +116,6 @@ pub fn e2e_decrypt(
     let ephemeral_pub = X25519PublicKey::from(ephemeral_pub_bytes);
 
     let nonce_bytes = &ciphertext[32..44];
-    let ct = &ciphertext[44..];
 
     // Derive gateway's static X25519 secret from Ed25519 seed
     let gw_secret = x25519_from_seed(gateway_ed25519_seed);
@@ -131,11 +130,26 @@ pub fn e2e_decrypt(
         .expect("32 bytes is valid");
 
     // Decrypt
+    use aes_gcm::aead::AeadInPlace;
     let cipher = Aes256Gcm::new_from_slice(&aes_key).expect("32 bytes is valid");
-    let nonce = Nonce::from_slice(nonce_bytes);
+
+    let mut nonce_array = [0u8; 12];
+    nonce_array.copy_from_slice(nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_array);
+
+    let tag_start = ciphertext.len() - TAG_SIZE;
+    let mut tag_array = [0u8; 16];
+    tag_array.copy_from_slice(&ciphertext[tag_start..]);
+    let tag = aes_gcm::aead::Tag::<Aes256Gcm>::from_slice(&tag_array);
+
+    let (body, _) = ciphertext.split_at_mut(tag_start);
+    let (_, payload) = body.split_at_mut(HEADER_SIZE);
+
     cipher
-        .decrypt(nonce, ct)
-        .map_err(|_| E2eError::DecryptionFailed)
+        .decrypt_in_place_detached(nonce, b"", payload, tag)
+        .map_err(|_| E2eError::DecryptionFailed)?;
+
+    Ok(&ciphertext[HEADER_SIZE..tag_start])
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -158,8 +172,8 @@ mod tests {
         let gw_pub = x25519_public_from_seed(&seed);
 
         let plaintext = b"hello gateway, this is a secret IP packet";
-        let encrypted = e2e_encrypt(plaintext, &gw_pub).unwrap();
-        let decrypted = e2e_decrypt(&encrypted, &seed).unwrap();
+        let mut encrypted = e2e_encrypt(plaintext, &gw_pub).unwrap();
+        let decrypted = e2e_decrypt(&mut encrypted, &seed).unwrap();
 
         assert_eq!(decrypted, plaintext);
     }
@@ -196,10 +210,10 @@ mod tests {
         let relay_seed = relay_seed();
 
         let plain = b"confidential";
-        let enc = e2e_encrypt(plain, &gw_pub).unwrap();
+        let mut enc = e2e_encrypt(plain, &gw_pub).unwrap();
 
         // Relay tries to decrypt with its own seed — must fail
-        let result = e2e_decrypt(&enc, &relay_seed);
+        let result = e2e_decrypt(&mut enc, &relay_seed);
         assert!(
             matches!(result, Err(E2eError::DecryptionFailed)),
             "relay must not be able to decrypt gateway's E2E payload"
@@ -218,14 +232,15 @@ mod tests {
         let last = enc.len() - 1;
         enc[last] ^= 0xFF;
 
-        let result = e2e_decrypt(&enc, &seed);
+        let result = e2e_decrypt(&mut enc, &seed);
         assert!(matches!(result, Err(E2eError::DecryptionFailed)));
     }
 
     #[test]
     fn too_short_ciphertext_rejected() {
         let seed = gw_seed();
-        let result = e2e_decrypt(&[0u8; 10], &seed);
+        let mut too_short = [0u8; 10];
+        let result = e2e_decrypt(&mut too_short, &seed);
         assert!(matches!(result, Err(E2eError::TooShort)));
     }
 

--- a/crates/pim-daemon/src/main.rs
+++ b/crates/pim-daemon/src/main.rs
@@ -1685,17 +1685,22 @@ async fn run_event_loop(state: Arc<DaemonState>) -> Result<()> {
                             };
 
                             let mut ip_packet = ip_payload;
+                            let ip_packet_slice: &[u8];
 
                             // E2E decrypt if gateway and flag is set
                             if state.is_gateway && mesh.flags.contains(DataFlags::IS_E2E) {
                                 let seed = state.identity.signing_key().to_bytes();
-                                match e2e_decrypt(&ip_packet, &seed) {
-                                    Ok(dec) => ip_packet = dec,
+                                match e2e_decrypt(&mut ip_packet, &seed) {
+                                    Ok(dec) => {
+                                        ip_packet_slice = dec;
+                                    }
                                     Err(e) => {
                                         warn!(%from_peer, "E2E decrypt: {e}");
                                         continue;
                                     }
                                 }
+                            } else {
+                                ip_packet_slice = &ip_packet;
                             }
 
                             // Check if the packet is destined for the gateway's
@@ -1703,14 +1708,14 @@ async fn run_event_loop(state: Arc<DaemonState>) -> Result<()> {
                             // writing to TUN (where the reply would race with
                             // run_gateway_return / run_event_loop readers).
                             let dst_local = state.gw_engine.is_some()
-                                && ip_packet.len() >= 20
+                                && ip_packet_slice.len() >= 20
                                 && Ipv4Addr::new(
-                                    ip_packet[16], ip_packet[17],
-                                    ip_packet[18], ip_packet[19],
+                                    ip_packet_slice[16], ip_packet_slice[17],
+                                    ip_packet_slice[18], ip_packet_slice[19],
                                 ) == Ipv4Addr::from(state.mesh_ip.load(Ordering::Relaxed));
 
                             if dst_local {
-                                if let Some(reply) = icmp_echo_reply(&ip_packet) {
+                                if let Some(reply) = icmp_echo_reply(ip_packet_slice) {
                                     let next_hop = state.routing.lock().await.lookup(mesh.src_id);
                                     let session = match next_hop {
                                         Some(next_hop) => state.sessions.read().await.get(&next_hop).cloned(),


### PR DESCRIPTION
⚡ Bolt: Optimize `e2e_decrypt` to perform zero-copy in-place decryption

💡 **What:** Refactored `e2e_decrypt` in `crates/pim-crypto/src/e2e.rs` to decrypt incoming E2E payloads in place directly within the provided mutable slice instead of allocating a new `Vec<u8>`.

🎯 **Why:** To reduce unnecessary memory allocations in the hot path. During the processing of data frames in `pim-daemon`, each decrypted packet was previously allocating a brand new vector. Using `decrypt_in_place_detached` minimizes garbage and allocation overhead, improving overall daemon efficiency.

📊 **Impact:** Saves exactly 1 allocation of `Vec<u8>` per E2E encrypted packet, significantly lowering memory pressure during heavy traffic.

🔬 **Measurement:** Verify by ensuring `cargo test --workspace` passes seamlessly and by measuring memory usage under heavy load. The optimization operates correctly using `AeadInPlace`.

---
*PR created automatically by Jules for task [6408809890177856378](https://jules.google.com/task/6408809890177856378) started by @Rfluid*