### PR TITLE
Update `implement-change.md` prompt to require checking project learnings

### DIFF
--- a/.agent/prompts/implement-change.md
+++ b/.agent/prompts/implement-change.md
@@ -6,6 +6,7 @@ Requirements:
 
 - Trace the current behavior before editing.
 - Pull broader repository context from `README.md` and `./docs` before inventing new assumptions.
+- Review `.jules/sentinel.md` and `.jules/bolt.md` to ensure the change avoids regressions against known security and performance project learnings.
 - Change the smallest reasonable surface that solves the task.
 - Preserve crate boundaries unless the task clearly requires otherwise.
 - Keep config and operator-facing behavior backward compatible where practical.


### PR DESCRIPTION
Adds explicit instruction for agents to review the `.jules/sentinel.md` (security) and `.jules/bolt.md` (performance) journals as a requirement before implementing a change, rather than only evaluating them during the review step.

---
*PR created automatically by Jules for task [1611184795524835939](https://jules.google.com/task/1611184795524835939) started by @Rfluid*