### PR TITLE
⚡ Bolt: E2E encryption zero-copy allocation optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-14 - E2E payload decryption zero-copy allocation optimization
 **Learning:** Similar to TransportFrames, decrypting received E2E payloads created unnecessary memory pressure due to buffer allocation of `Vec<u8>`. In an async daemon doing heavy network I/O, allocating strings or slices in a hot path causes bottlenecks.
 **Action:** Decrypt E2E payload within its original slice over allocating copies of the slice for the cipher output using `AeadInPlace` in `aes-gcm`.
+## 2024-05-15 - E2E payload encryption zero-copy allocation optimization
+**Learning:** E2E payload encryption created unnecessary memory pressure due to buffer allocation. In an async daemon doing heavy network I/O, allocating intermediate strings or slices in a hot path causes bottlenecks. We refactored `e2e_encrypt` to use `encrypt_in_place_detached` directly on the pre-allocated output buffer instead of allocating an intermediate vector for the ciphertext.
+**Action:** Favor using `AeadInPlace` for encryption when appending to an existing or pre-allocated buffer to avoid unnecessary memory allocations.

--- a/crates/pim-crypto/src/e2e.rs
+++ b/crates/pim-crypto/src/e2e.rs
@@ -11,7 +11,7 @@
 //! The gateway's static X25519 key is derived from its Ed25519 seed via HKDF
 //! so that no separate key file is needed.
 
-use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::aead::KeyInit;
 use aes_gcm::{Aes256Gcm, Nonce};
 use hkdf::Hkdf;
 use rand::rngs::OsRng;
@@ -86,17 +86,21 @@ pub fn e2e_encrypt(plaintext: &[u8], gateway_x25519_pub: &[u8; 32]) -> Result<Ve
     rand::RngCore::fill_bytes(&mut OsRng, &mut nonce_bytes);
     let nonce = Nonce::from_slice(&nonce_bytes);
 
-    // AES-256-GCM encrypt
+    // AES-256-GCM encrypt in-place
     let cipher = derive_e2e_cipher(&shared_secret);
-    let ciphertext_with_tag = cipher
-        .encrypt(nonce, plaintext)
-        .map_err(|_| E2eError::EncryptionFailed)?;
 
-    // Assemble: ephemeral_pub || nonce || ciphertext_with_tag
-    let mut out = Vec::with_capacity(HEADER_SIZE + ciphertext_with_tag.len());
+    // Assemble directly into the output buffer to avoid intermediate allocations
+    let mut out = Vec::with_capacity(HEADER_SIZE + plaintext.len() + TAG_SIZE);
     out.extend_from_slice(&ephemeral_pub.to_bytes());
     out.extend_from_slice(&nonce_bytes);
-    out.extend_from_slice(&ciphertext_with_tag);
+    out.extend_from_slice(plaintext);
+
+    use aes_gcm::aead::AeadInPlace;
+    let tag = cipher
+        .encrypt_in_place_detached(nonce, b"", &mut out[HEADER_SIZE..])
+        .map_err(|_| E2eError::EncryptionFailed)?;
+
+    out.extend_from_slice(&tag);
 
     Ok(out)
 }


### PR DESCRIPTION
💡 What: Refactored `e2e_encrypt` to use `encrypt_in_place_detached` from the `AeadInPlace` trait.
🎯 Why: To eliminate an intermediate buffer allocation (`Vec<u8>`) on the hot path for internet-bound traffic in the async daemon.
📊 Impact: Reduces memory allocation pressure and fragmentation during E2E encryption, saving one allocation and copy per packet.
🔬 Measurement: Observe memory profiling and GC/allocation overhead during heavy E2E internet traffic.

Recorded learning in `.jules/bolt.md` to prefer in-place encryption to avoid unnecessary intermediate allocations when constructing network frames.

---
*PR created automatically by Jules for task [12752620758204439190](https://jules.google.com/task/12752620758204439190) started by @Rfluid*