### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix secure file permissions for the daemon PID file

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The daemon's `atomic_write` function used `tokio::fs::write`, which relies on the system's default `umask`. This function is used to write sensitive files like the trust store, potentially making them world-readable.
 **Learning:** Relying on default file permissions when writing runtime configuration or trust stores creates a risk of exposing sensitive peer identities or network state to other local users.
 **Prevention:** Explicitly use `tokio::fs::OpenOptions` with `mode(0o600)` on Unix systems and `tokio::io::AsyncWriteExt` to ensure strict file access permissions when performing asynchronous writes of sensitive data.
+
+## 2024-05-27 - [Secure File Permissions for Daemon PID File]
+**Vulnerability:** The daemon's pid file was written using `std::fs::write`, which relies on the system's default `umask` and may leave the file world-writable.
+**Learning:** Relying on default file permissions when writing sensitive files creates a risk of giving other local users arbitrary modification access to system processes files.
+**Prevention:** Explicitly use `std::fs::OpenOptions` with `mode(0o644)` on Unix systems to ensure strict file access permissions when writing system process files.

--- a/crates/pim-daemon/src/main.rs
+++ b/crates/pim-daemon/src/main.rs
@@ -2558,8 +2558,19 @@ async fn main() -> Result<()> {
         Config::load(std::path::Path::new(&config_path)).context("failed to load config")?;
     info!(config = %config_path, node = %config.node.name, "daemon starting");
 
-    std::fs::write(&pid_file, std::process::id().to_string())
-        .context("failed to write PID file")?;
+    {
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o644);
+        }
+        let mut file = options.open(&pid_file).context("failed to open PID file")?;
+        use std::io::Write;
+        file.write_all(std::process::id().to_string().as_bytes())
+            .context("failed to write PID file")?;
+    }
 
     let key_path = expand_tilde(&config.security.key_file);
     let identity = Arc::new(


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix secure file permissions for the daemon PID file

🚨 Severity: MEDIUM
💡 Vulnerability: The daemon's PID file (`/run/pim.pid`) was written using `std::fs::write`, which relies on the system's default `umask`. If the `umask` is overly permissive, the file may be left world-writable.
🎯 Impact: A malicious local user could alter the PID file, tricking the CLI into killing or signaling the wrong process, possibly leading to a Denial of Service (DoS).
🔧 Fix: Replaced `std::fs::write` with an explicitly configured `std::fs::OpenOptions` that strictly ensures the file's permissions are created securely as `0o644`.
✅ Verification: Ran the workspace test suite and verified there are no unused-import linter warnings, along with verifying no regressions. Also, logged the learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4546743298718423801](https://jules.google.com/task/4546743298718423801) started by @Rfluid*