### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure PID file permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The daemon's `atomic_write` function used `tokio::fs::write`, which relies on the system's default `umask`. This function is used to write sensitive files like the trust store, potentially making them world-readable.
 **Learning:** Relying on default file permissions when writing runtime configuration or trust stores creates a risk of exposing sensitive peer identities or network state to other local users.
 **Prevention:** Explicitly use `tokio::fs::OpenOptions` with `mode(0o600)` on Unix systems and `tokio::io::AsyncWriteExt` to ensure strict file access permissions when performing asynchronous writes of sensitive data.
+
+## 2024-06-25 - [Secure File Permissions for System Files]
+**Vulnerability:** The daemon's PID file (`pid_file`) was written using `std::fs::write`, which falls back to the system's default `umask`. Under a permissive umask (e.g., `0000`), this could leave the PID file world-writable, allowing unprivileged users to spoof the PID.
+**Learning:** Relying on default file permissions when writing non-sensitive system files (like PID files) can still create security risks, such as local DoS or privilege escalation, if the files are used by other system services.
+**Prevention:** Explicitly use `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o644)` on Unix systems to ensure strict file access permissions (owner writable, group/others readable) when writing system files.

--- a/crates/pim-daemon/src/main.rs
+++ b/crates/pim-daemon/src/main.rs
@@ -2558,7 +2558,19 @@ async fn main() -> Result<()> {
         Config::load(std::path::Path::new(&config_path)).context("failed to load config")?;
     info!(config = %config_path, node = %config.node.name, "daemon starting");
 
-    std::fs::write(&pid_file, std::process::id().to_string())
+    let mut pid_options = std::fs::OpenOptions::new();
+    pid_options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        pid_options.mode(0o644);
+    }
+    let mut pid_f = pid_options
+        .open(&pid_file)
+        .context("failed to open PID file")?;
+    use std::io::Write;
+    pid_f
+        .write_all(std::process::id().to_string().as_bytes())
         .context("failed to write PID file")?;
 
     let key_path = expand_tilde(&config.security.key_file);


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The daemon's PID file (`pid_file`) was previously written using `std::fs::write`, which creates files with default `0o666` permissions modified only by the system's `umask`. In environments with a permissive umask (e.g., `0000`), the PID file would be created world-writable.
🎯 **Impact:** If the PID file is world-writable, any local user could modify it to point to a different process ID. This could allow unprivileged users to cause a local Denial of Service (DoS) by tricking system services or stop scripts into killing the wrong processes.
🔧 **Fix:** Replaced the `std::fs::write` call with explicit `std::fs::OpenOptions` configuration, ensuring that on Unix platforms the file is created with `.mode(0o644)` (owner-writable, world-readable) regardless of the system umask.
✅ **Verification:** Verified by checking that `cargo clippy --workspace -- -D warnings` and `cargo test --workspace` both pass successfully. Also verified the file is now created with mode `644`.

Journaled this learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7466068476093992844](https://jules.google.com/task/7466068476093992844) started by @Rfluid*