### PR TITLE
⚡ Bolt: Zero-copy transport frame encryption

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-05-15 - E2E payload encryption zero-copy allocation optimization
 **Learning:** E2E payload encryption created unnecessary memory pressure due to buffer allocation. In an async daemon doing heavy network I/O, allocating intermediate strings or slices in a hot path causes bottlenecks. We refactored `e2e_encrypt` to use `encrypt_in_place_detached` directly on the pre-allocated output buffer instead of allocating an intermediate vector for the ciphertext.
 **Action:** Favor using `AeadInPlace` for encryption when appending to an existing or pre-allocated buffer to avoid unnecessary memory allocations.
+
+## 2024-05-16 - Transport payload encryption zero-copy allocation optimization
+**Learning:** Similar to our findings with E2E encryption, transport payload encryption created unnecessary memory pressure due to extra buffer allocations in `Session::encrypt_frame` and `transport_frame_from_encrypted`. In a hot path, this causes bottlenecks.
+**Action:** Favor using `AeadInPlace::encrypt_in_place_detached` when you need to retain the original plaintext byte-slice structure but place it within a new wrapper (like `TransportFrame`), eliminating unnecessary temporary buffer creations.

--- a/crates/pim-crypto/src/session.rs
+++ b/crates/pim-crypto/src/session.rs
@@ -286,7 +286,9 @@ mod tests {
 
         assert_ne!(buffer, plaintext);
 
-        cipher.decrypt_in_place_detached(&nonce_bytes, &mut buffer, &tag_bytes).unwrap();
+        cipher
+            .decrypt_in_place_detached(&nonce_bytes, &mut buffer, &tag_bytes)
+            .unwrap();
 
         assert_eq!(buffer, plaintext);
     }

--- a/crates/pim-crypto/src/session.rs
+++ b/crates/pim-crypto/src/session.rs
@@ -86,6 +86,34 @@ impl SessionCipher {
         Ok(plaintext)
     }
 
+    /// Encrypts plaintext in-place, returning the generated nonce and tag.
+    /// Returns an error if the nonce counter is exhausted or encryption fails.
+    pub fn encrypt_in_place_detached(
+        &self,
+        payload: &mut [u8],
+    ) -> Result<([u8; 12], [u8; 16]), SessionError> {
+        let count = self.counter.fetch_add(1, Ordering::SeqCst);
+        if count >= MAX_NONCE_COUNTER {
+            return Err(SessionError::NonceExhausted);
+        }
+
+        let nonce_bytes = self.build_nonce(count);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        let tag = aes_gcm::aead::AeadInPlace::encrypt_in_place_detached(
+            &self.cipher,
+            nonce,
+            b"",
+            payload,
+        )
+        .map_err(|_| SessionError::EncryptionFailed)?;
+
+        let mut tag_bytes = [0u8; 16];
+        tag_bytes.copy_from_slice(&tag);
+
+        Ok((nonce_bytes, tag_bytes))
+    }
+
     /// Decrypts a frame in-place, avoiding an allocation.
     /// Returns an error if the nonce is replayed, or if decryption fails.
     pub fn decrypt_in_place_detached(
@@ -246,5 +274,20 @@ mod tests {
         let encrypted = cipher.encrypt(&plaintext).unwrap();
         let decrypted = cipher.decrypt(&encrypted).unwrap();
         assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn encrypt_in_place_detached_round_trip() {
+        let cipher = SessionCipher::new(&test_key(), test_prefix());
+        let plaintext = b"hello proximity mesh";
+
+        let mut buffer = plaintext.to_vec();
+        let (nonce_bytes, tag_bytes) = cipher.encrypt_in_place_detached(&mut buffer).unwrap();
+
+        assert_ne!(buffer, plaintext);
+
+        cipher.decrypt_in_place_detached(&nonce_bytes, &mut buffer, &tag_bytes).unwrap();
+
+        assert_eq!(buffer, plaintext);
     }
 }

--- a/crates/pim-daemon/src/main.rs
+++ b/crates/pim-daemon/src/main.rs
@@ -64,8 +64,8 @@ use pim_core::{
     DiscoveryConfig, FrameCodec, NodeId, PeerEndpointConfig,
 };
 use pim_crypto::{
-    e2e_decrypt_in_place, e2e_encrypt, x25519_public_from_seed, HandshakeConfirm,
-    HandshakeInit, HandshakeResponse, Handshaker, Identity, SessionCipher,
+    e2e_decrypt_in_place, e2e_encrypt, x25519_public_from_seed, HandshakeConfirm, HandshakeInit,
+    HandshakeResponse, Handshaker, Identity, SessionCipher,
 };
 use pim_discovery::{DiscoveryService, NodeCapabilities, PeerRecord, PeerTable};
 use pim_gateway::{GatewayEngine, IpPool};

--- a/crates/pim-daemon/src/main.rs
+++ b/crates/pim-daemon/src/main.rs
@@ -64,7 +64,7 @@ use pim_core::{
     DiscoveryConfig, FrameCodec, NodeId, PeerEndpointConfig,
 };
 use pim_crypto::{
-    e2e_decrypt_in_place, e2e_encrypt, x25519_public_from_seed, EncryptedFrame, HandshakeConfirm,
+    e2e_decrypt_in_place, e2e_encrypt, x25519_public_from_seed, HandshakeConfirm,
     HandshakeInit, HandshakeResponse, Handshaker, Identity, SessionCipher,
 };
 use pim_discovery::{DiscoveryService, NodeCapabilities, PeerRecord, PeerTable};
@@ -98,8 +98,15 @@ struct Session {
 
 impl Session {
     fn encrypt_frame(&self, plaintext: &[u8]) -> Result<TransportFrame> {
-        let ef = self.send.encrypt(plaintext)?;
-        transport_frame_from_encrypted(ef)
+        let mut payload = plaintext.to_vec();
+        let (nonce, tag) = self.send.encrypt_in_place_detached(&mut payload)?;
+
+        Ok(TransportFrame {
+            frame_type: FrameType::Data,
+            nonce,
+            payload,
+            tag,
+        })
     }
 
     fn decrypt_frame(&self, mut frame: TransportFrame) -> Result<TransportFrame> {
@@ -107,22 +114,6 @@ impl Session {
             .decrypt_in_place_detached(&frame.nonce, &mut frame.payload, &frame.tag)?;
         Ok(frame)
     }
-}
-
-fn transport_frame_from_encrypted(ef: EncryptedFrame) -> Result<TransportFrame> {
-    let ct_len = ef.ciphertext.len();
-    if ct_len < 16 {
-        bail!("encrypted frame too short to contain GCM tag");
-    }
-    let tag_offset = ct_len - 16;
-    let mut tag = [0u8; 16];
-    tag.copy_from_slice(&ef.ciphertext[tag_offset..]);
-    Ok(TransportFrame {
-        frame_type: FrameType::Data,
-        nonce: ef.nonce,
-        payload: ef.ciphertext[..tag_offset].to_vec(),
-        tag,
-    })
 }
 
 // ── Nonce prefix ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
💡 What: Implemented `encrypt_in_place_detached` in `SessionCipher` to encrypt payloads directly within an already allocated buffer using `AeadInPlace::encrypt_in_place_detached`. Refactored `Session::encrypt_frame` to use this new method.

🎯 Why: Previously, `Session::encrypt_frame` allocated memory for the `EncryptedFrame` ciphertext inside `self.send.encrypt()`. Afterwards, `transport_frame_from_encrypted` allocated *another* `Vec<u8>` for the `TransportFrame` payload by cloning the ciphertext minus the tag. This created unnecessary memory pressure and allocation overhead on a critical hot path (network I/O frame encryption).

📊 Impact: Reduces memory allocations per outgoing transport frame by half. The plaintext is now copied only once directly into the `TransportFrame` payload buffer and encrypted in place, completely avoiding the intermediate `EncryptedFrame` allocation.

🔬 Measurement: Verify correctness with `cargo test --workspace` (including the newly added `encrypt_in_place_detached_round_trip` unit test). Benchmark memory allocations during sustained high-throughput transmission.

---
*PR created automatically by Jules for task [9080485738733943050](https://jules.google.com/task/9080485738733943050) started by @Rfluid*