### PR TITLE
⚡ Bolt: [performance improvement] Implement zero-copy buffer optimization in TCP send path

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,14 +1,24 @@
 ## 2024-05-14 - Transport payload decryption zero-copy allocation optimization
+
 **Learning:** Decrypting received TransportFrames created unnecessary memory pressure due to buffer allocation. In an async daemon doing heavy network I/O, allocating strings or slices in a hot path causes bottlenecks.
 **Action:** Always favor using `AeadInPlace` in `aes-gcm` (or similar cipher crates) so you can directly decrypt the payload within its original slice over allocating copies of the slice for the cipher output.
 
 ## 2024-05-14 - E2E payload decryption zero-copy allocation optimization
+
 **Learning:** Similar to TransportFrames, decrypting received E2E payloads created unnecessary memory pressure due to buffer allocation of `Vec<u8>`. In an async daemon doing heavy network I/O, allocating strings or slices in a hot path causes bottlenecks.
 **Action:** Decrypt E2E payload within its original slice over allocating copies of the slice for the cipher output using `AeadInPlace` in `aes-gcm`.
+
 ## 2024-05-15 - E2E payload encryption zero-copy allocation optimization
+
 **Learning:** E2E payload encryption created unnecessary memory pressure due to buffer allocation. In an async daemon doing heavy network I/O, allocating intermediate strings or slices in a hot path causes bottlenecks. We refactored `e2e_encrypt` to use `encrypt_in_place_detached` directly on the pre-allocated output buffer instead of allocating an intermediate vector for the ciphertext.
 **Action:** Favor using `AeadInPlace` for encryption when appending to an existing or pre-allocated buffer to avoid unnecessary memory allocations.
 
 ## 2024-05-16 - Transport payload encryption zero-copy allocation optimization
+
 **Learning:** Similar to our findings with E2E encryption, transport payload encryption created unnecessary memory pressure due to extra buffer allocations in `Session::encrypt_frame` and `transport_frame_from_encrypted`. In a hot path, this causes bottlenecks.
 **Action:** Favor using `AeadInPlace::encrypt_in_place_detached` when you need to retain the original plaintext byte-slice structure but place it within a new wrapper (like `TransportFrame`), eliminating unnecessary temporary buffer creations.
+
+## 2024-05-16 - Transport write buffer zero-copy allocation optimization
+
+**Learning:** Transport write queues were creating unnecessary memory allocations in the hot path. Serializing frames via `BytesMut` then converting them using `.to_vec()` caused extra allocations on every outgoing packet. Using `freeze()` transforms `BytesMut` into `Bytes` with zero copying.
+**Action:** Use `Bytes::freeze()` rather than `.to_vec()` to pass buffers between async tasks without unnecessary memory allocations.

--- a/crates/pim-transport/src/tcp.rs
+++ b/crates/pim-transport/src/tcp.rs
@@ -32,7 +32,7 @@ pub struct TcpTransport {
 
 /// Handle for writing to a peer's TCP stream.
 struct PeerWriter {
-    tx: mpsc::Sender<Vec<u8>>,
+    tx: mpsc::Sender<bytes::Bytes>,
     current_id: Arc<RwLock<NodeId>>,
 }
 
@@ -109,7 +109,7 @@ impl TcpTransport {
         let current_id = Arc::new(RwLock::new(peer_id));
 
         // Write task: receives serialized frames via channel and writes to socket
-        let (write_tx, mut write_rx) = mpsc::channel::<Vec<u8>>(64);
+        let (write_tx, mut write_rx) = mpsc::channel::<bytes::Bytes>(64);
         let write_id = current_id.clone();
         tokio::spawn(async move {
             let mut writer = write_half;
@@ -226,7 +226,7 @@ impl Transport for TcpTransport {
 
         // Non-blocking: return Congested instead of blocking when the write
         // queue is full.  Callers apply priority-based drop policy.
-        writer.tx.try_send(wire_buf.to_vec()).map_err(|e| match e {
+        writer.tx.try_send(wire_buf.freeze()).map_err(|e| match e {
             tokio::sync::mpsc::error::TrySendError::Full(_) => TransportError::Congested(*peer),
             tokio::sync::mpsc::error::TrySendError::Closed(_) => {
                 TransportError::SendFailed("write channel closed".into())


### PR DESCRIPTION
💡 **What:** Changed the `mpsc::Sender` type in `crates/pim-transport/src/tcp.rs` from `Vec<u8>` to `bytes::Bytes` and updated the `try_send` call to use `wire_buf.freeze()` instead of `wire_buf.to_vec()`.
🎯 **Why:** In the `send` method of `TcpTransport`, `wire_buf` is a `BytesMut` buffer used for length-delimiting frames. Previously, `wire_buf.to_vec()` was called before sending the payload across the async channel to the TCP write task. This unnecessarily allocated a new heap string slice and copied the data. Using `.freeze()` seamlessly transforms the `BytesMut` struct into an immutable `Bytes` slice, passing the underlying memory without copying. This is especially important for an async daemon performing heavy network I/O.
📊 **Impact:** Removes a `Vec` allocation and data copy from every single outgoing TCP packet on the hot path, notably reducing memory pressure and overall latency.
🔬 **Measurement:** `cargo test --workspace` verifies all tests still pass with zero-copy messaging in place. Check `pim status --verbose` in a high-throughput Docker network lab to measure latency changes.

---
*PR created automatically by Jules for task [10288145504758318393](https://jules.google.com/task/10288145504758318393) started by @Rfluid*