### PR TITLE
Add secure-code-sentinel skill to agent workspace

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -34,6 +34,7 @@ tools rather than in the default core guidance.
 Current examples:
 
 - `skills/add-connection-mechanism/SKILL.md` — workflow for adding a new peer connectivity mechanism
+- `skills/secure-code-sentinel/SKILL.md` — workflow for security fixes and logging learnings
 - `skills/write-docker-tests/SKILL.md` — workflow for adding or extending Docker-based tests
 - `prompts/implement-connectivity-mechanism.md` — targeted prompt for transport or discovery work
 - `prompts/review-connectivity-change.md` — targeted review prompt for connectivity-sensitive changes

--- a/.agent/skills/README.md
+++ b/.agent/skills/README.md
@@ -9,6 +9,7 @@ Examples:
 - Docker test debugging
 - networking regression review
 - Docker test authoring
+- security and sentinel workflows
 
 Use `core/` and generic prompts as the default baseline. Put feature-specific
 guidance here when it would otherwise make the shared agent workflow too narrow.

--- a/.agent/skills/secure-code-sentinel/SKILL.md
+++ b/.agent/skills/secure-code-sentinel/SKILL.md
@@ -1,0 +1,39 @@
+# Secure Code Sentinel Workflow
+
+Use this skill when performing security-focused fixes or reviews (the "Sentinel" workflow) to ensure consistency in PR formatting and codebase learning documentation.
+
+## Requirements
+
+1. **Avoid Exposing Critical Vulnerabilities in PRs:** Never expose critical vulnerability details in public PR descriptions.
+2. **Limit Scope:** Ensure fixes are kept under 50 lines unless explicitly instructed otherwise.
+3. **Avoid Large Refactors:** Avoid making large, breaking security refactors in a single pass.
+4. **Permissions:** When handling sensitive file permissions (e.g. PID files, config files, keys), strictly adhere to the secure file permission conventions using `OpenOptionsExt::mode(0o600)` or similar as required by the OS.
+
+## PR Formatting
+
+When creating a security-focused PR, adhere to the following template:
+
+**Title Format:**
+- For severe issues: `🛡️ Sentinel: [CRITICAL] Fix [vulnerability]` or `🛡️ Sentinel: [HIGH] Fix [vulnerability]`
+- For enhancements or lower severity: `🛡️ Sentinel: [security improvement]`
+
+**PR Description Sections:**
+Must include the following exact sections:
+- `Severity`
+- `Vulnerability`
+- `Impact`
+- `Fix`
+- `Verification`
+
+## Logging to `.jules/sentinel.md`
+
+Whenever you complete a Sentinel task that involves a critical security learning, you must document it in `.jules/sentinel.md`. Do not journal routine fixes.
+
+**Format for logging:**
+
+```markdown
+## YYYY-MM-DD - [Title]
+**Vulnerability:** [What you found]
+**Learning:** [Why it existed]
+**Prevention:** [How to avoid next time]
+```


### PR DESCRIPTION
# Add secure-code-sentinel skill to agent workspace

Added `.agent/skills/secure-code-sentinel/SKILL.md` to codify the Sentinel security workflow. 

This addresses a recurring pattern of security fixes (e.g. Sentinel: [HIGH] Secure file permissions...) by standardizing the PR format and how to properly log critical security learnings to `.jules/sentinel.md`.

Updates were also made to the following READMEs to ensure the new skill is easily discoverable:
- `.agent/README.md`
- `.agent/skills/README.md`

---
*PR created automatically by Jules for task [3215386704505303347](https://jules.google.com/task/3215386704505303347) started by @Rfluid*