### PR TITLE
Align macOS docs with actual supported scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ The codebase is currently centered on a Linux daemon, a small CLI, and Docker-ba
 - `pim-daemon` runtime that handles peer sessions, routing, fragmentation, metrics, and gateway NAT
 - Docker Compose labs for single-hop, relay, discovery, resilience, and multi-gateway scenarios
 
+## Platform Support Matrix
+
+| Capability | Linux | macOS |
+| --- | --- | --- |
+| Client runtime | Supported | Supported |
+| Relay runtime | Supported | Supported |
+| Gateway runtime and NAT | Supported | Not supported |
+| Wi-Fi Direct backend | Supported | Not supported |
+| Bluetooth PAN backend | Supported | Not supported |
+| `pim config generate client` | Supported | Supported |
+| `pim config generate relay` | Supported | Supported |
+| `pim config generate gateway` | Supported | Not supported |
+| Docker integration labs | Supported | Not supported |
+
+On macOS, stay within the client or relay roles, use a `utunN` interface such as `utun0`, and leave Wi-Fi Direct, Bluetooth PAN, and gateway mode disabled.
+
 ## Repository Layout
 
 ```text
@@ -68,6 +84,8 @@ pim config generate relay
 pim config generate gateway
 pim config generate relay gateway
 ```
+
+On macOS, use only the `client` and `relay` variants. Gateway config generation is Linux-only because gateway runtime support is Linux-only.
 
 Write directly to a file:
 
@@ -150,6 +168,8 @@ Then create `/etc/pim/pim.toml`. The easiest starting point is:
 sudo pim config generate client --output /etc/pim/pim.toml
 ```
 
+On macOS, keep the generated `utunN` interface name, leave gateway mode disabled, and do not enable Wi-Fi Direct or Bluetooth PAN.
+
 You can also start from a minimal static client example:
 
 ```toml
@@ -186,7 +206,7 @@ address = "gateway.example.internal:9100"
 label = "gateway"
 ```
 
-For a gateway node, set `gateway.enabled = true`, choose the gateway mesh IP, and point `nat_interface` at the internet-facing interface.
+For a Linux gateway node, set `gateway.enabled = true`, choose the gateway mesh IP, and point `nat_interface` at the internet-facing interface.
 
 ## Uninstall
 

--- a/docs/getting-started/client-usage.md
+++ b/docs/getting-started/client-usage.md
@@ -3,6 +3,12 @@
 This guide shows how to run a PIM node as a client and how to choose the right
 interfaces for different peer connectivity mechanisms.
 
+Platform scope:
+
+- Linux supports TCP, LAN discovery, Wi-Fi Direct, and Bluetooth PAN client paths.
+- macOS supports the client dataplane and routing via `utunN`, plus TCP and LAN discovery.
+- macOS does not currently support Wi-Fi Direct or Bluetooth PAN in PIM.
+
 The key distinction is:
 
 - `[interface].name`: the local TUN interface, usually `pim0`
@@ -19,6 +25,8 @@ The client host should have:
 - a writable config file such as `/etc/pim/pim.toml`
 - at least one intended peer-connectivity path, such as LAN discovery, Wi-Fi Direct, Bluetooth PAN, or static peers
 
+On macOS, narrow that last item to LAN discovery and static TCP peers. Keep Wi-Fi Direct and Bluetooth disabled in the generated config.
+
 Generate a starter client config:
 
 ```bash
@@ -27,17 +35,19 @@ pim config generate client --output /etc/pim/pim.toml
 
 ## List Candidate Network Interfaces
 
-List all network interfaces:
+List all network interfaces on Linux:
 
 ```bash
 ip -br link
 ```
 
-Show IPv4 addresses:
+Show IPv4 addresses on Linux:
 
 ```bash
 ip -br -4 addr
 ```
+
+On macOS, use `ifconfig -l` to list interfaces and `ifconfig <ifname>` to inspect a candidate interface.
 
 These commands help identify:
 
@@ -50,6 +60,12 @@ internet, check:
 
 ```bash
 ip route get 1.1.1.1
+```
+
+On macOS, the nearest equivalent is:
+
+```bash
+route -n get default
 ```
 
 That route is not configured into the PIM client TOML the way it is for a
@@ -86,6 +102,7 @@ Notes:
 - `mesh_ip = "auto"` lets the daemon request an address from a reachable gateway
 - a client does not need a `[gateway]` section enabled
 - a plain client usually does not set `relay.enabled = true`
+- on macOS, set `[interface].name` to a `utunN` name such as `utun0`
 
 ## UDP Discovery Plus Auto-Connect
 
@@ -125,6 +142,8 @@ label = "relay-a"
 This can be combined with discovery, Wi-Fi Direct, and Bluetooth PAN.
 
 ## Wi-Fi Direct Client
+
+Linux only. This backend is not currently supported on macOS.
 
 Use Wi-Fi Direct when the client should discover peers through a Wi-Fi P2P
 radio link.
@@ -171,6 +190,8 @@ wpa_cli -i wlan0 p2p_find
 ```
 
 ## Bluetooth PAN Client
+
+Linux only. This backend is not currently supported on macOS.
 
 Use Bluetooth when the client should discover peers over a Bluetooth PAN link
 and then hand off to the normal TCP transport.
@@ -254,6 +275,8 @@ A client can combine mechanisms. For example:
 - Wi-Fi Direct for nearby devices
 - Bluetooth PAN for short-range fallback
 - static TCP peers for known relays or gateways
+
+On macOS, limit this to LAN discovery plus static TCP peers.
 
 Example:
 

--- a/docs/getting-started/gateway-usage.md
+++ b/docs/getting-started/gateway-usage.md
@@ -1,5 +1,7 @@
 # Gateway Usage
 
+Gateway mode is Linux-only. This guide does not apply to macOS hosts because PIM does not currently support macOS internet egress/NAT.
+
 This guide shows how to run a PIM node as a gateway and how to choose the right
 interfaces for different peer connectivity mechanisms.
 
@@ -23,6 +25,8 @@ Generate a starter gateway config:
 ```bash
 pim config generate gateway --output /etc/pim/pim.toml
 ```
+
+If you are on macOS, stop here and use a client or relay configuration instead.
 
 ## Discover the Internet-Facing Interface
 
@@ -148,6 +152,8 @@ Notes:
 
 ## Wi-Fi Direct Gateway
 
+Linux only.
+
 Use Wi-Fi Direct when the gateway should form P2P Wi-Fi groups and let peers
 connect through the resulting link.
 
@@ -203,6 +209,8 @@ formation; you configure the parent Wi-Fi interface, not the transient `p2p-*`
 name.
 
 ## Bluetooth PAN Gateway
+
+Linux only.
 
 Use Bluetooth when peers are expected to connect over a Bluetooth PAN link and
 then hand off to the normal TCP transport.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -2,6 +2,19 @@
 
 This project supports client and relay nodes on Linux and macOS. Gateway mode remains Linux-only because the daemon still depends on Linux NAT and raw-socket behavior for internet egress.
 
+## Supported Scope By Platform
+
+| Capability | Linux | macOS |
+| --- | --- | --- |
+| Client node | Supported | Supported |
+| Relay node | Supported | Supported |
+| Gateway node | Supported | Not supported |
+| Wi-Fi Direct | Supported | Not supported |
+| Bluetooth PAN | Supported | Not supported |
+| Docker lab flows | Supported | Not supported |
+
+On macOS, use PIM as a client or relay only. Plan on a `utunN` interface name, and do not expect gateway, Wi-Fi Direct, Bluetooth PAN, or Docker lab workflows to work there.
+
 ## Requirements
 
 Host requirements:
@@ -98,7 +111,7 @@ If you prefer not to install globally, you can run the binaries directly from `t
 
 ## Prepare A Config File
 
-Create `/etc/pim/pim.toml`. On macOS, use a `utunN` interface name such as `utun0`. Start from the examples in [configuration.md](configuration.md).
+Create `/etc/pim/pim.toml`. On macOS, use a `utunN` interface name such as `utun0`, keep `[gateway].enabled = false`, and leave Wi-Fi Direct and Bluetooth sections disabled. Start from the examples in [configuration.md](configuration.md).
 
 ## Verify The CLI
 
@@ -109,6 +122,8 @@ pim status --help
 ```
 
 ## Verify A Full Development Environment
+
+These checks are Linux-oriented. The Docker-based development environment is not part of the supported macOS path.
 
 Unit tests:
 


### PR DESCRIPTION
## Summary
- add an explicit Linux/macOS support matrix to the top-level docs
- narrow macOS guidance to client and relay usage with `utunN`
- mark gateway, Wi-Fi Direct, Bluetooth PAN, and Docker lab flows as Linux-only where users start from the docs

## Why
The repository already ships macOS artifacts and has some macOS-aware runtime/config behavior, but the getting-started docs still mixed supported macOS paths with Linux-only features and commands. This made the actual support boundary unclear for new macOS users.

Closes #57
Part of #52

## Validation
- `bash scripts/test-config-generators.sh`