### PR TITLE
Add macOS CI validation coverage

### DIFF
--- a/.github/workflows/quality-and-security.yml
+++ b/.github/workflows/quality-and-security.yml
@@ -42,10 +42,43 @@ jobs:
             - name: Check config generators
               run: scripts/test-config-generators.sh
 
+    platform-validation:
+        name: Platform Validation (${{ matrix.label }})
+        runs-on: ${{ matrix.runner }}
+        needs: lint-and-test
+
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - label: linux
+                      runner: ubuntu-latest
+                    - label: macos
+                      runner: macos-15
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+
+            - name: Install Rust toolchain
+              uses: dtolnay/rust-toolchain@1.94.0
+
+            - name: Cache cargo artifacts
+              uses: Swatinem/rust-cache@v2
+
+            - name: Run tests
+              run: cargo test --workspace --locked
+
+            - name: Check config generators
+              run: scripts/test-config-generators.sh
+
+            - name: Build release binaries
+              run: cargo build --workspace --release --locked
+
     security:
         name: Dependency Security Scan (cargo-audit)
         runs-on: ubuntu-latest
-        needs: lint-and-test
+        needs: platform-validation
 
         steps:
             - name: Checkout repository
@@ -62,21 +95,3 @@ jobs:
 
             - name: Run cargo-audit
               run: cargo audit
-
-    build:
-        name: Production Build Validation
-        runs-on: ubuntu-latest
-        needs: [lint-and-test, security]
-
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v6
-
-            - name: Install Rust toolchain
-              uses: dtolnay/rust-toolchain@1.94.0
-
-            - name: Cache cargo artifacts
-              uses: Swatinem/rust-cache@v2
-
-            - name: Build release binaries
-              run: cargo build --workspace --release --locked

--- a/docs/operations/testing.md
+++ b/docs/operations/testing.md
@@ -2,6 +2,8 @@
 
 PIM uses two practical test layers in this repository: Rust tests for crate-level behavior and Docker-based end-to-end scenarios for multi-node networking.
 
+GitHub Actions also validates the supported macOS path separately from the Linux Docker labs. The CI matrix builds and tests the workspace on both Linux and macOS, then runs `scripts/test-config-generators.sh` to confirm the generated config guidance matches the host platform.
+
 ## Test Layers
 
 ### Unit and crate-level tests
@@ -99,6 +101,37 @@ make sh-p1-client
 pim status --verbose
 make down-p1
 ```
+
+## macOS Validation
+
+The supported macOS scope is narrower than Linux:
+
+- supported: client and relay roles, native `utunN` interface naming, config generation, workspace build, and unit tests
+- not supported: gateway NAT, Wi-Fi Direct, Bluetooth PAN, and Docker lab workflows
+
+CI covers the supported macOS build and config-generation path, but host-level runtime validation still needs a real macOS machine with the privileges required to create a TUN interface and update routes.
+
+Recommended manual smoke checks on macOS:
+
+```bash
+cargo build --workspace --release
+cargo test --workspace
+scripts/test-config-generators.sh
+sudo target/release/pim config generate client --output /tmp/pim-client.toml --force
+sudo target/release/pim config generate relay --output /tmp/pim-relay.toml --force
+sudo target/release/pim up --config /tmp/pim-client.toml
+sudo target/release/pim status --verbose
+sudo target/release/pim down
+```
+
+Unsupported-path check on macOS:
+
+```bash
+cp docker/configs/gateway.toml /tmp/pim-gateway.toml
+target/release/pim-daemon --config /tmp/pim-gateway.toml
+```
+
+That command should fail clearly when `[gateway].enabled = true`, confirming the non-Linux gateway restriction remains explicit.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- add a native Linux/macOS validation matrix to the quality workflow
- run workspace tests, config-generator checks, and release builds on macOS before merges
- document the remaining manual macOS host smoke checks and unsupported-path verification

## Why
The release workflow already publishes macOS artifacts, but the main validation workflow only exercised Linux. That left a gap between published macOS binaries and the evidence that supported macOS paths still build and test cleanly.

Closes #58
Part of #52

## Validation
- `bash scripts/test-config-generators.sh`