### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in config generation

### DIFF
--- a/.agent/skills/run-local-validations/SKILL.md
+++ b/.agent/skills/run-local-validations/SKILL.md
@@ -1,0 +1,43 @@
+# Skill: Run Local Validations
+
+Use this skill when preparing to open a PR or after making changes to ensure your code meets repository standards and won't fail CI.
+
+## Purpose
+
+Standardize the pre-commit and pre-PR workflow by utilizing the repository's provided validation script. This ensures that formatting is correct, linters are satisfied, tests pass, and no secrets are accidentally committed. It addresses recurring friction points around formatting and unused imports.
+
+## Workflow
+
+1. Finish your code changes.
+    - Ensure your code compiles and basic tests pass.
+
+2. Run the pre-PR validation script.
+    - Execute `./scripts/pre-pr.sh` from the repository root.
+    - This script mirrors the CI pipeline locally.
+
+3. Review the script output.
+    - The script runs checks in waves.
+    - **Wave 1 (parallel):** `rustfmt`, `clippy`, `test`, `gitleaks`.
+    - **Wave 2:** `cargo_audit` (if Wave 1 passes).
+    - **Wave 3:** `build_release` (if Wave 2 passes).
+
+4. Address any failures.
+    - **rustfmt:** The script auto-fixes formatting issues using `cargo fmt --all`. Review and stage these changes.
+    - **clippy:** Fix any reported lint failures. Hint: Run `cargo clippy --workspace --all-targets --locked -- -D warnings`.
+    - **test:** Fix any failing tests. Pay attention to platform-specific annotations (e.g., Linux-only tests). Hint: Run `cargo test --workspace --locked`.
+    - **cargo_audit:** Upgrade vulnerable dependencies or ignore accepted advisories.
+    - **build_release:** Fix any compilation errors.
+
+5. Re-run if necessary.
+    - If you made changes to fix failures in step 4, re-run `./scripts/pre-pr.sh` to ensure everything now passes.
+
+## Expected Output
+
+- A clean run of `./scripts/pre-pr.sh` with all checks passing (or explicitly skipped for a valid reason, like missing tools).
+- Code that is properly formatted and linted.
+- Passing tests.
+
+## Done Criteria
+
+- The `./scripts/pre-pr.sh` script exits with code `0`.
+- All changes are staged and ready for a PR.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The daemon's PID file (`pid_file`) was written using `std::fs::write`, which falls back to the system's default `umask`. Under a permissive umask (e.g., `0000`), this could leave the PID file world-writable, allowing unprivileged users to spoof the PID.
 **Learning:** Relying on default file permissions when writing non-sensitive system files (like PID files) can still create security risks, such as local DoS or privilege escalation, if the files are used by other system services.
 **Prevention:** Explicitly use `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o644)` on Unix systems to ensure strict file access permissions (owner writable, group/others readable) when writing system files.
+
+## 2024-06-25 - [Secure File Creation for New Configurations]
+**Vulnerability:** The CLI `pim config generate` function used `.create(true).truncate(true)` after a `path.exists()` check. This creates a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an attacker could create a symlink to a sensitive file between the check and the creation, causing the sensitive file to be truncated and overwritten.
+**Learning:** Using `path.exists()` followed by `.create(true)` is vulnerable to symlink attacks.
+**Prevention:** When creating strictly new files (where overwriting is not intended or allowed), explicitly use `std::fs::OpenOptions` with `.create_new(true)`. This maps to the atomic `O_CREAT | O_EXCL` flags at the OS level, safely failing if the file (or a symlink) already exists.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-dnssd"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d49ffe175ab45bbfd74b548313d9d7cdfff27161a94b007b52eeeb5f9aaa15e"
+dependencies = [
+ "bitflags 1.3.2",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-util",
+ "libc",
+ "log",
+ "pin-utils",
+ "pkg-config",
+ "tokio",
+ "winapi",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +143,12 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -372,10 +397,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -621,7 +666,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -797,7 +842,7 @@ dependencies = [
 name = "pim-protocol"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "pim-core",
@@ -847,6 +892,8 @@ dependencies = [
 name = "pim-wifidirect"
 version = "0.1.0"
 dependencies = [
+ "async-dnssd",
+ "futures-util",
  "pim-core",
  "thiserror",
  "tokio",
@@ -861,6 +908,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +922,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "polyval"
@@ -961,7 +1020,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -996,7 +1055,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1448,11 +1507,33 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -1536,7 +1617,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ The codebase is currently centered on a Linux daemon, a small CLI, and Docker-ba
 | Client runtime | Supported | Supported |
 | Relay runtime | Supported | Supported |
 | Gateway runtime and NAT | Supported | Supported |
-| Wi-Fi Direct backend | Supported | Not supported |
+| Wi-Fi Direct backend | Supported | Supported |
 | Bluetooth PAN backend | Supported | Supported |
 | `pim config generate client` | Supported | Supported |
 | `pim config generate relay` | Supported | Supported |
 | `pim config generate gateway` | Supported | Supported |
 | Docker integration labs | Supported | Not supported |
 
-On macOS, use a `utunN` interface such as `utun0` for the mesh TUN, set `gateway.nat_interface` to the internet-facing host interface such as `en0`, and keep Wi-Fi Direct disabled. The Bluetooth PAN path uses the host Bluetooth stack and currently expects `blueutil` for radio discovery and pairing automation.
+On macOS, use a `utunN` interface such as `utun0` for the mesh TUN and set `gateway.nat_interface` to the internet-facing host interface such as `en0`. The Wi-Fi Direct backend uses Bonjour peer-to-peer discovery on macOS rather than Linux `wpa_cli` group formation, so Linux-specific tuning fields in `[wifi_direct]` are ignored there.
 
 ## Repository Layout
 
@@ -86,7 +86,7 @@ pim config generate gateway
 pim config generate relay gateway
 ```
 
-On macOS, the generated gateway template uses `utun0` for the mesh TUN, `en0` as the default NAT uplink, leaves Wi-Fi Direct disabled, and enables Bluetooth PAN with the macOS host-stack flow.
+On macOS, the generated gateway template uses `utun0` for the mesh TUN and `en0` as the default NAT uplink. Wi-Fi Direct can be enabled there, but the backend uses Bonjour peer-to-peer discovery instead of Linux `wpa_supplicant` controls.
 
 Write directly to a file:
 
@@ -169,7 +169,7 @@ Then create `/etc/pim/pim.toml`. The easiest starting point is:
 sudo pim config generate client --output /etc/pim/pim.toml
 ```
 
-On macOS, keep the generated `utunN` interface name, set `gateway.nat_interface` to the real uplink if this node should be a gateway, leave Wi-Fi Direct disabled, and install `blueutil` if this node should use Bluetooth PAN radio discovery.
+On macOS, keep the generated `utunN` interface name, set `gateway.nat_interface` to the real uplink if this node should be a gateway, and install `blueutil` if this node should use Bluetooth PAN radio discovery. Wi-Fi Direct can also be enabled; macOS uses Bonjour peer-to-peer discovery for that path.
 
 You can also start from a minimal static client example:
 

--- a/crates/pim-cli/src/main.rs
+++ b/crates/pim-cli/src/main.rs
@@ -357,14 +357,18 @@ fn cmd_config_generate(
     let rendered = render_config_template(&roles, name.as_deref());
 
     if let Some(path) = output {
-        if path.exists() && !force {
-            bail!(
-                "refusing to overwrite existing file: {} (use --force to overwrite)",
-                path.display()
-            );
-        }
         let mut options = std::fs::OpenOptions::new();
-        options.write(true).create(true).truncate(true);
+        if force {
+            options.write(true).create(true).truncate(true);
+        } else {
+            if path.exists() {
+                bail!(
+                    "refusing to overwrite existing file: {} (use --force to overwrite)",
+                    path.display()
+                );
+            }
+            options.write(true).create_new(true);
+        }
 
         #[cfg(unix)]
         {

--- a/crates/pim-daemon/src/main.rs
+++ b/crates/pim-daemon/src/main.rs
@@ -2984,8 +2984,11 @@ async fn main() -> Result<()> {
             interface = %config.wifi_direct.interface,
             "starting Wi-Fi Direct discovery"
         );
-        let (wd_svc, addr_rx) =
-            WifiDirectDiscovery::new(config.wifi_direct.clone(), config.transport.listen_port);
+        let (wd_svc, addr_rx) = WifiDirectDiscovery::new(
+            config.node.name.clone(),
+            config.wifi_direct.clone(),
+            config.transport.listen_port,
+        );
         let c = cancel.clone();
         tokio::spawn(async move { wd_svc.run(c).await });
         tokio::spawn(run_wifidirect_consumer(state.clone(), addr_rx));
@@ -3756,8 +3759,11 @@ en0: flags=8863<UP,BROADCAST,RUNNING,SIMPLEX,MULTICAST> mtu 1500\n\
         use pim_wifidirect::WifiDirectDiscovery;
         let toml = "[node]\nname=\"t\"\n[wifi_direct]\nenabled=true\n";
         let config = Config::from_toml_str(toml).unwrap();
-        let (_svc, _rx) =
-            WifiDirectDiscovery::new(config.wifi_direct, config.transport.listen_port);
+        let (_svc, _rx) = WifiDirectDiscovery::new(
+            config.node.name,
+            config.wifi_direct,
+            config.transport.listen_port,
+        );
         // Construction must not panic.
     }
 

--- a/crates/pim-wifidirect/Cargo.toml
+++ b/crates/pim-wifidirect/Cargo.toml
@@ -9,3 +9,7 @@ tokio = { workspace = true }
 tokio-util = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+futures-util = "0.3"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+async-dnssd = "0.5.1"

--- a/crates/pim-wifidirect/src/bonjour.rs
+++ b/crates/pim-wifidirect/src/bonjour.rs
@@ -1,0 +1,248 @@
+//! macOS Wi-Fi Direct backend built on Bonjour peer-to-peer browsing.
+//!
+//! Apple does not expose Linux-style P2P group control on macOS. Instead, the
+//! supported path for peer-to-peer Wi-Fi is DNS-SD/Bonjour on the dedicated
+//! peer-to-peer interface. This module advertises the daemon's TCP listen port,
+//! browses for matching peers, resolves their socket addresses, and hands those
+//! addresses back to the daemon.
+
+use crate::{WifiDirectError, WifiDirectServiceType};
+use async_dnssd::{
+    browse_extended, register_extended, BrowseData, BrowseResult, BrowsedFlags, Interface,
+    RegisterData, ResolveHostResult,
+};
+use futures_util::StreamExt;
+use std::{collections::HashSet, net::SocketAddr, time::Duration};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+const RESOLVE_TIMEOUT: Duration = Duration::from_secs(10);
+const ADDRESS_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub(crate) async fn run(
+    node_name: String,
+    listen_port: u16,
+    peer_tx: mpsc::Sender<SocketAddr>,
+    cancel: CancellationToken,
+) {
+    info!("Wi-Fi Direct on macOS using Bonjour peer-to-peer discovery");
+
+    let registration = match register_extended(
+        WifiDirectServiceType::REG_TYPE,
+        listen_port,
+        RegisterData {
+            interface: Interface::PeerToPeer,
+            name: Some(&node_name),
+            ..Default::default()
+        },
+    ) {
+        Ok(register) => register,
+        Err(err) => {
+            warn!("Wi-Fi Direct: failed to start macOS service registration: {err}");
+            return;
+        }
+    };
+
+    let (_registration, registered) = match registration.await {
+        Ok(result) => result,
+        Err(err) => {
+            warn!("Wi-Fi Direct: macOS service registration failed: {err}");
+            return;
+        }
+    };
+    info!(
+        service_name = %registered.name,
+        reg_type = %registered.reg_type,
+        "Wi-Fi Direct macOS service registered"
+    );
+
+    let mut seen_services = HashSet::new();
+    let mut browse = Box::pin(browse_extended(
+        WifiDirectServiceType::REG_TYPE,
+        BrowseData {
+            interface: Interface::PeerToPeer,
+            ..Default::default()
+        },
+    ));
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                debug!("Wi-Fi Direct macOS discovery cancelled");
+                return;
+            }
+            next = browse.next() => {
+                let Some(event) = next else {
+                    warn!("Wi-Fi Direct: macOS browse stream ended unexpectedly");
+                    return;
+                };
+                match event {
+                    Ok(service) => {
+                        handle_service_event(
+                            &registered.name,
+                            service,
+                            &mut seen_services,
+                            &peer_tx,
+                        ).await;
+                    }
+                    Err(err) => {
+                        warn!("Wi-Fi Direct: macOS browse error: {err}");
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn handle_service_event(
+    own_service_name: &str,
+    service: BrowseResult,
+    seen_services: &mut HashSet<String>,
+    peer_tx: &mpsc::Sender<SocketAddr>,
+) {
+    let key = service_key(&service.service_name, &service.domain);
+
+    if !service.flags.contains(BrowsedFlags::ADD) {
+        seen_services.remove(&key);
+        debug!(service = %key, "Wi-Fi Direct: macOS peer removed");
+        return;
+    }
+
+    if service.service_name == own_service_name {
+        debug!(service = %key, "Wi-Fi Direct: ignoring local macOS service advertisement");
+        return;
+    }
+
+    if !seen_services.insert(key.clone()) {
+        return;
+    }
+
+    info!(service = %key, "Wi-Fi Direct: macOS peer discovered");
+    match resolve_peer_addr(service).await {
+        Ok(addr) => {
+            info!(addr = %addr, "Wi-Fi Direct: macOS peer resolved");
+            let _ = peer_tx.send(addr).await;
+        }
+        Err(err) => {
+            warn!("Wi-Fi Direct: failed to resolve macOS peer {key}: {err}");
+            seen_services.remove(&key);
+        }
+    }
+}
+
+async fn resolve_peer_addr(service: BrowseResult) -> Result<SocketAddr, WifiDirectError> {
+    let mut resolve = Box::pin(service.resolve());
+
+    loop {
+        let next = tokio::time::timeout(RESOLVE_TIMEOUT, resolve.next())
+            .await
+            .map_err(|_| {
+                WifiDirectError::Bonjour(format!(
+                    "timed out resolving service {}",
+                    service.service_name
+                ))
+            })?;
+
+        let Some(result) = next else {
+            return Err(WifiDirectError::Bonjour(format!(
+                "service {} resolved without addresses",
+                service.service_name
+            )));
+        };
+
+        let resolved = result.map_err(|err| {
+            WifiDirectError::Bonjour(format!(
+                "resolve failed for {}: {err}",
+                service.service_name
+            ))
+        })?;
+        if let Some(addr) = resolve_socket_addr(resolved).await? {
+            return Ok(addr);
+        }
+    }
+}
+
+async fn resolve_socket_addr(
+    resolved: async_dnssd::ResolveResult,
+) -> Result<Option<SocketAddr>, WifiDirectError> {
+    let mut addresses = Box::pin(resolved.resolve_socket_address());
+    loop {
+        let next = tokio::time::timeout(ADDRESS_TIMEOUT, addresses.next())
+            .await
+            .map_err(|_| {
+                WifiDirectError::Bonjour(format!(
+                    "timed out resolving host {}",
+                    resolved.host_target
+                ))
+            })?;
+
+        let Some(result) = next else {
+            return Ok(None);
+        };
+
+        let resolved_host = result.map_err(|err| {
+            WifiDirectError::Bonjour(format!(
+                "host resolution failed for {}: {err}",
+                resolved.host_target
+            ))
+        })?;
+
+        if let Some(addr) = socket_addr_from_host(resolved_host) {
+            return Ok(Some(addr));
+        }
+    }
+}
+
+fn socket_addr_from_host(result: ResolveHostResult) -> Option<SocketAddr> {
+    if result.flags.contains(async_dnssd::ResolvedHostFlags::ADD) {
+        Some(result.address.into())
+    } else {
+        None
+    }
+}
+
+fn service_key(service_name: &str, domain: &str) -> String {
+    format!("{service_name}@{domain}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_dnssd::{ResolvedHostFlags, ScopedSocketAddr};
+    use std::net::{IpAddr, Ipv4Addr};
+
+    #[test]
+    fn service_key_is_stable() {
+        assert_eq!(service_key("node-a", "local."), "node-a@local.");
+    }
+
+    #[test]
+    fn service_key_distinguishes_domains() {
+        assert_ne!(
+            service_key("node-a", "local."),
+            service_key("node-a", "example.com.")
+        );
+    }
+
+    #[test]
+    fn socket_addr_from_host_ignores_removed_records() {
+        let result = ResolveHostResult {
+            flags: ResolvedHostFlags::empty(),
+            address: ScopedSocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9100, 0),
+        };
+        assert!(socket_addr_from_host(result).is_none());
+    }
+
+    #[test]
+    fn socket_addr_from_host_returns_added_records() {
+        let result = ResolveHostResult {
+            flags: ResolvedHostFlags::ADD,
+            address: ScopedSocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9100, 0),
+        };
+        assert_eq!(
+            socket_addr_from_host(result),
+            Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9100))
+        );
+    }
+}

--- a/crates/pim-wifidirect/src/lib.rs
+++ b/crates/pim-wifidirect/src/lib.rs
@@ -21,19 +21,22 @@
 
 #![warn(missing_docs)]
 
+#[cfg(target_os = "macos")]
+mod bonjour;
 pub mod group;
 pub mod wpa_cli;
 
-use std::{
-    collections::HashSet,
-    net::{IpAddr, SocketAddr},
-    time::Duration,
-};
+use std::net::SocketAddr;
+
+#[cfg(not(target_os = "macos"))]
+use std::{collections::HashSet, net::IpAddr, time::Duration};
 
 use pim_core::WifiDirectConfig;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info, warn};
+#[cfg(not(target_os = "macos"))]
+use tracing::debug;
+use tracing::{info, warn};
 
 pub use group::{GroupRole, WifiDirectGroup, GO_INTERFACE_IP};
 pub use wpa_cli::{P2pPeerInfo, WpaCliController};
@@ -44,6 +47,9 @@ pub enum WifiDirectError {
     /// A `wpa_cli` invocation failed or returned an unexpected response.
     #[error("wpa_cli error: {0}")]
     WpaCli(String),
+    /// A Bonjour / DNS-SD operation failed on macOS.
+    #[error("bonjour error: {0}")]
+    Bonjour(String),
     /// P2P group formation did not complete within the expected time.
     #[error("group formation failed: {0}")]
     GroupFormation(String),
@@ -59,10 +65,21 @@ pub enum WifiDirectError {
 /// P2P group.  The address is `peer_ip:listen_port` — ready to be passed
 /// directly to `initiate_peer_connection`.
 pub struct WifiDirectDiscovery {
+    #[cfg(target_os = "macos")]
+    node_name: String,
+    #[cfg(not(target_os = "macos"))]
     ctrl: WpaCliController,
     config: WifiDirectConfig,
     listen_port: u16,
     peer_tx: mpsc::Sender<SocketAddr>,
+}
+
+#[cfg(target_os = "macos")]
+struct WifiDirectServiceType;
+
+#[cfg(target_os = "macos")]
+impl WifiDirectServiceType {
+    const REG_TYPE: &'static str = "_pimmesh._tcp";
 }
 
 impl WifiDirectDiscovery {
@@ -70,12 +87,21 @@ impl WifiDirectDiscovery {
     ///
     /// Returns `(service, receiver)`.  Call [`WifiDirectDiscovery::run`] to start
     /// background operation; receive discovered peer addresses from the receiver.
-    pub fn new(config: WifiDirectConfig, listen_port: u16) -> (Self, mpsc::Receiver<SocketAddr>) {
+    pub fn new(
+        node_name: impl Into<String>,
+        config: WifiDirectConfig,
+        listen_port: u16,
+    ) -> (Self, mpsc::Receiver<SocketAddr>) {
+        #[cfg(not(target_os = "macos"))]
+        let _ = node_name;
+
         let (peer_tx, peer_rx) = mpsc::channel(16);
-        let ctrl = WpaCliController::new(&config.interface);
         (
             Self {
-                ctrl,
+                #[cfg(target_os = "macos")]
+                node_name: node_name.into(),
+                #[cfg(not(target_os = "macos"))]
+                ctrl: WpaCliController::new(&config.interface),
                 config,
                 listen_port,
                 peer_tx,
@@ -94,34 +120,60 @@ impl WifiDirectDiscovery {
     /// 5. Resolves peer IP via [`WifiDirectGroup::from_iface`].
     /// 6. Sends `SocketAddr` on the peer channel.
     pub async fn run(self, cancel: CancellationToken) {
-        info!(
-            "Wi-Fi Direct discovery starting on interface {}",
-            self.config.interface
-        );
+        #[cfg(target_os = "macos")]
+        {
+            if self.config.interface != WifiDirectConfig::default().interface
+                || self.config.go_intent != WifiDirectConfig::default().go_intent
+                || self.config.listen_channel != WifiDirectConfig::default().listen_channel
+                || self.config.op_channel != WifiDirectConfig::default().op_channel
+                || self.config.connect_method != WifiDirectConfig::default().connect_method
+            {
+                info!(
+                    interface = %self.config.interface,
+                    go_intent = self.config.go_intent,
+                    listen_channel = self.config.listen_channel,
+                    op_channel = self.config.op_channel,
+                    connect_method = %self.config.connect_method,
+                    "Wi-Fi Direct macOS backend uses Bonjour peer-to-peer discovery; Linux-specific P2P tuning fields are ignored"
+                );
+            }
 
-        // Verify wpa_cli is available; log a warning and return early if not.
-        if let Err(e) = self.ctrl.p2p_find().await {
-            warn!("Wi-Fi Direct: p2p_find failed (wpa_supplicant not running?): {e}");
+            bonjour::run(self.node_name, self.listen_port, self.peer_tx, cancel).await;
             return;
         }
 
-        let mut seen_macs: HashSet<String> = HashSet::new();
-        let mut poll_interval = tokio::time::interval(Duration::from_secs(2));
+        #[cfg(not(target_os = "macos"))]
+        {
+            info!(
+                "Wi-Fi Direct discovery starting on interface {}",
+                self.config.interface
+            );
 
-        loop {
-            tokio::select! {
-                _ = cancel.cancelled() => {
-                    debug!("Wi-Fi Direct discovery cancelled");
-                    let _ = self.ctrl.p2p_stop_find().await;
-                    return;
-                }
-                _ = poll_interval.tick() => {
-                    self.poll_and_connect(&mut seen_macs).await;
+            // Verify wpa_cli is available; log a warning and return early if not.
+            if let Err(e) = self.ctrl.p2p_find().await {
+                warn!("Wi-Fi Direct: p2p_find failed (wpa_supplicant not running?): {e}");
+                return;
+            }
+
+            let mut seen_macs: HashSet<String> = HashSet::new();
+            let mut poll_interval = tokio::time::interval(Duration::from_secs(2));
+
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => {
+                        debug!("Wi-Fi Direct discovery cancelled");
+                        let _ = self.ctrl.p2p_stop_find().await;
+                        return;
+                    }
+                    _ = poll_interval.tick() => {
+                        self.poll_and_connect(&mut seen_macs).await;
+                    }
                 }
             }
         }
     }
 
+    #[cfg(not(target_os = "macos"))]
     async fn poll_and_connect(&self, seen_macs: &mut HashSet<String>) {
         let peers = match self.ctrl.p2p_peers().await {
             Ok(p) => p,
@@ -145,6 +197,7 @@ impl WifiDirectDiscovery {
         }
     }
 
+    #[cfg(not(target_os = "macos"))]
     async fn connect_and_emit(&self, mac: &str) -> Result<(), WifiDirectError> {
         // Initiate connection based on configured method.
         if self.config.connect_method == "pbc" {
@@ -214,6 +267,7 @@ impl WifiDirectDiscovery {
         Ok(())
     }
 
+    #[cfg(not(target_os = "macos"))]
     async fn wait_for_group_iface(&self, timeout: Duration) -> Result<String, WifiDirectError> {
         let deadline = tokio::time::Instant::now() + timeout;
 
@@ -242,7 +296,7 @@ mod tests {
     #[test]
     fn discovery_new_returns_receiver() {
         let config = WifiDirectConfig::default();
-        let (_svc, _rx) = WifiDirectDiscovery::new(config, 9100);
+        let (_svc, _rx) = WifiDirectDiscovery::new("node-a", config, 9100);
         // Verifies construction does not panic and returns both parts.
     }
 

--- a/crates/pim-wifidirect/src/lib.rs
+++ b/crates/pim-wifidirect/src/lib.rs
@@ -292,6 +292,7 @@ impl WifiDirectDiscovery {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     #[test]
     fn discovery_new_returns_receiver() {

--- a/docs/architecture/wifi-direct.md
+++ b/docs/architecture/wifi-direct.md
@@ -1,10 +1,14 @@
 # Wi-Fi Direct Transport
 
-Wi-Fi Direct (IEEE 802.11 P2P) allows two Linux devices to form a direct wireless
-link without any access point or LAN infrastructure. PIM uses it as an optional
-**peer-finding** layer — once a P2P group is established and both sides have IP
-addresses, the existing `TcpTransport` handles all framing, handshake, and sessions
-unchanged.
+PIM uses Wi-Fi Direct as an optional **peer-finding** layer. The transport and
+session logic remain the normal TCP path after discovery succeeds.
+
+Platform backends:
+
+- Linux uses `wpa_supplicant` P2P control via `wpa_cli`, forms a P2P group, and
+  resolves the resulting peer IP from the group interface.
+- macOS uses Bonjour DNS-SD on Apple's peer-to-peer Wi-Fi interface to advertise
+  and discover the daemon's TCP listen port directly.
 
 ## Overview
 
@@ -26,7 +30,7 @@ unchanged.
           │◀─── AES-256-GCM session ───────────┤
 ```
 
-After group formation the path is identical to a standard LAN connection.
+After discovery, the path is identical to a standard LAN connection.
 
 ## Linux Prerequisites
 
@@ -43,6 +47,12 @@ wpa_cli -i wlan0 p2p_find   → should print "OK"
 
 If this fails, PIM logs a warning and skips Wi-Fi Direct entirely.
 
+## macOS Prerequisites
+
+- no `wpa_cli` or `wpa_supplicant` setup is required
+- the host must permit Bonjour peer-to-peer Wi-Fi service advertisement and browsing
+- the daemon's TCP `listen_port` must be reachable once a peer is discovered
+
 ## Configuration
 
 ```toml
@@ -58,7 +68,11 @@ connect_method  = "pbc"   # "pbc" (push-button) or "pin:<8-digit>"
 The `listen_port` used for the TCP connection is taken from `[transport] listen_port`
 (default `9100`), not from this section.
 
-## Group Roles and IP Addresses
+On macOS, only `enabled` is acted on directly. The Linux-specific tuning fields
+remain in the shared config schema for compatibility but are ignored by the
+Bonjour backend.
+
+## Linux Group Roles and IP Addresses
 
 wpa_supplicant negotiates which device becomes the **Group Owner (GO)** and which
 becomes the **Group Client (GC)** using the `go_intent` value. The GO acts as a
@@ -71,10 +85,16 @@ soft AP and runs a built-in DHCP server:
 
 PIM detects its role by comparing its own interface IP to `192.168.49.1`.
 
+macOS does not expose that Linux P2P group model. The backend resolves peer
+socket addresses directly from Bonjour service discovery, so there is no GO/GC
+role handling in the daemon on macOS.
+
 ## WifiDirectDiscovery Service
 
 `WifiDirectDiscovery` runs as a background Tokio task started by the daemon when
-`wifi_direct.enabled = true`:
+`wifi_direct.enabled = true`.
+
+Linux flow:
 
 ```
                  WifiDirectDiscovery (background task)
@@ -114,6 +134,25 @@ After issuing `p2p_connect`, `WifiDirectDiscovery` polls `list_interfaces` every
 500 ms for up to 15 s, looking for a new `p2p-*` interface. If none appears, the
 attempt is logged as an error and the MAC is not re-tried in the current run (it
 stays in `seen_macs`).
+
+macOS flow:
+
+```
+                 WifiDirectDiscovery (background task)
+                 ─────────────────────────────────────
+                 ┌─────────────────────────────────┐
+startup      ──▶ │  register _pimmesh._tcp        │
+browse loop  ──▶ │  browse peer-to-peer services  │
+                │  → for each new service:         │
+                │      resolve host + port         │
+                │      → peer_tx.send(SocketAddr)  │
+                └─────────────────────────────────┘
+                          │
+                          ▼
+                 run_wifidirect_consumer
+```
+
+macOS deduplicates by Bonjour service identity (`name@domain`) instead of peer MAC.
 
 ## Coexistence with LAN Discovery
 
@@ -195,6 +234,8 @@ When the daemon exits, P2P group interfaces are not explicitly removed.
 `wpa_supplicant` should clean them up on process restart, but a crashed daemon
 may leave a stale `p2p-*` interface. Run `wpa_cli -i wlan0 p2p_group_remove p2p-wlan0-0`
 to clean up manually.
+
+This Linux-only limitation does not apply to the macOS Bonjour backend.
 
 ### Seen-MAC Expiry Not Implemented
 

--- a/docs/getting-started/client-usage.md
+++ b/docs/getting-started/client-usage.md
@@ -6,8 +6,7 @@ interfaces for different peer connectivity mechanisms.
 Platform scope:
 
 - Linux supports TCP, LAN discovery, Wi-Fi Direct, and Bluetooth PAN client paths.
-- macOS supports the client dataplane and routing via `utunN`, plus TCP, LAN discovery, and Bluetooth PAN.
-- macOS does not currently support Wi-Fi Direct in PIM.
+- macOS supports the client dataplane and routing via `utunN`, plus TCP, LAN discovery, Bluetooth PAN, and Wi-Fi Direct.
 
 The key distinction is:
 
@@ -25,7 +24,7 @@ The client host should have:
 - a writable config file such as `/etc/pim/pim.toml`
 - at least one intended peer-connectivity path, such as LAN discovery, Wi-Fi Direct, Bluetooth PAN, or static peers
 
-On macOS, narrow that last item to LAN discovery, static TCP peers, and Bluetooth PAN. Keep Wi-Fi Direct disabled in the generated config.
+On macOS, Wi-Fi Direct uses Bonjour peer-to-peer discovery rather than Linux `wpa_cli` group formation. Keep that difference in mind when choosing and tuning `[wifi_direct]` settings.
 
 Generate a starter client config:
 
@@ -143,8 +142,6 @@ This can be combined with discovery, Wi-Fi Direct, and Bluetooth PAN.
 
 ## Wi-Fi Direct Client
 
-Linux only. This backend is not currently supported on macOS.
-
 Use Wi-Fi Direct when the client should discover peers through a Wi-Fi P2P
 radio link.
 
@@ -162,7 +159,9 @@ Confirm the interface is up:
 ip link show wlan0
 ```
 
-PIM uses the physical Wi-Fi interface in `[wifi_direct].interface`.
+On Linux, PIM uses the physical Wi-Fi interface in `[wifi_direct].interface`. On
+macOS, the OS owns the peer-to-peer Wi-Fi control path, so `[wifi_direct].interface`
+is accepted for config compatibility but ignored by the runtime backend.
 
 Example client config:
 
@@ -179,7 +178,9 @@ connect_method = "pbc"
 Operational notes:
 
 - the client configures the parent Wi-Fi interface, not a transient `p2p-*` group interface
-- `wpa_supplicant` with P2P support must already be running on that interface
+- Linux requires `wpa_supplicant` with P2P support already running on that interface
+- macOS advertises and discovers peers over Bonjour peer-to-peer Wi-Fi using the TCP `listen_port`
+- macOS ignores `go_intent`, `listen_channel`, `op_channel`, and `connect_method`
 - once a group forms, PIM uses the resulting IP path to open its normal TCP session
 
 Useful checks:
@@ -188,6 +189,9 @@ Useful checks:
 iw dev
 wpa_cli -i wlan0 p2p_find
 ```
+
+On macOS, the closest equivalent check is simply to enable `[wifi_direct]` and
+watch the daemon logs for Bonjour peer-to-peer registration and peer resolution.
 
 ## Bluetooth PAN Client
 

--- a/docs/getting-started/gateway-usage.md
+++ b/docs/getting-started/gateway-usage.md
@@ -24,7 +24,7 @@ Generate a starter gateway config:
 pim config generate gateway --output /etc/pim/pim.toml
 ```
 
-On macOS, use a `utunN` name such as `utun0` for `[interface].name`, choose a real uplink such as `en0` for `[gateway].nat_interface`, leave Wi-Fi Direct disabled, and install `blueutil` if this gateway should use Bluetooth PAN radio discovery.
+On macOS, use a `utunN` name such as `utun0` for `[interface].name`, choose a real uplink such as `en0` for `[gateway].nat_interface`, and install `blueutil` if this gateway should use Bluetooth PAN radio discovery. Wi-Fi Direct can also be enabled there; macOS uses Bonjour peer-to-peer discovery instead of Linux `wpa_supplicant` controls.
 
 ## Discover the Internet-Facing Interface
 
@@ -164,8 +164,6 @@ Notes:
 
 ## Wi-Fi Direct Gateway
 
-Linux only.
-
 Use Wi-Fi Direct when the gateway should form P2P Wi-Fi groups and let peers
 connect through the resulting link.
 
@@ -183,7 +181,9 @@ Confirm the interface is up:
 ip link show wlan0
 ```
 
-PIM uses the physical Wi-Fi interface in `[wifi_direct].interface`.
+On Linux, PIM uses the physical Wi-Fi interface in `[wifi_direct].interface`. On
+macOS, the OS owns the peer-to-peer Wi-Fi control path, so `[wifi_direct].interface`
+is accepted for config compatibility but ignored by the runtime backend.
 
 Example gateway config:
 
@@ -204,9 +204,11 @@ connect_method = "pbc"
 Operational notes:
 
 - `gateway.nat_interface` is still the real internet uplink, often `eth0` or `wlan0`
-- `[wifi_direct].interface` is the radio used for P2P group formation
+- Linux uses `[wifi_direct].interface` as the radio for P2P group formation
+- macOS advertises and discovers the gateway over Bonjour peer-to-peer Wi-Fi using the TCP `listen_port`
+- macOS ignores `go_intent`, `listen_channel`, `op_channel`, and `connect_method`
 - these may be the same physical uplink on some systems, but do not assume that
-- `wpa_supplicant` with P2P support must already be running on that interface
+- Linux requires `wpa_supplicant` with P2P support already running on that interface
 
 Useful checks:
 
@@ -219,6 +221,9 @@ If a P2P group is formed, Linux often creates an additional interface such as
 `p2p-wlan0-0`. PIM discovers and uses that group interface automatically after
 formation; you configure the parent Wi-Fi interface, not the transient `p2p-*`
 name.
+
+On macOS, no transient `p2p-*` interface is managed by PIM. Discovery is driven
+through Bonjour peer-to-peer service advertisement and resolution instead.
 
 ## Bluetooth PAN Gateway
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,11 +9,11 @@ This project supports client, relay, and gateway nodes on Linux and macOS. The g
 | Client node | Supported | Supported |
 | Relay node | Supported | Supported |
 | Gateway node | Supported | Supported |
-| Wi-Fi Direct | Supported | Not supported |
+| Wi-Fi Direct | Supported | Supported |
 | Bluetooth PAN | Supported | Supported |
 | Docker lab flows | Supported | Not supported |
 
-On macOS, plan on a `utunN` interface name for the mesh TUN, use a real uplink such as `en0` for `gateway.nat_interface`, and do not expect Wi-Fi Direct, Bluetooth PAN, or Docker lab workflows to work there.
+On macOS, plan on a `utunN` interface name for the mesh TUN and use a real uplink such as `en0` for `gateway.nat_interface`. Wi-Fi Direct uses Bonjour peer-to-peer discovery on macOS, Bluetooth PAN uses the host stack, and the Docker lab workflows still remain Linux-only.
 
 ## Requirements
 
@@ -112,7 +112,7 @@ If you prefer not to install globally, you can run the binaries directly from `t
 
 ## Prepare A Config File
 
-Create `/etc/pim/pim.toml`. On macOS, use a `utunN` interface name such as `utun0`, set `[gateway].nat_interface` to the real uplink such as `en0`, leave Wi-Fi Direct disabled, and install `blueutil` if you want Bluetooth PAN radio discovery and pairing automation. Start from the examples in [configuration.md](configuration.md).
+Create `/etc/pim/pim.toml`. On macOS, use a `utunN` interface name such as `utun0`, set `[gateway].nat_interface` to the real uplink such as `en0`, and install `blueutil` if you want Bluetooth PAN radio discovery and pairing automation. Wi-Fi Direct can also be enabled there; the backend uses Bonjour peer-to-peer discovery rather than Linux `wpa_cli` controls. Start from the examples in [configuration.md](configuration.md).
 
 ## Verify The CLI
 

--- a/docs/project/implementation-plan.md
+++ b/docs/project/implementation-plan.md
@@ -495,7 +495,7 @@ Add Wi-Fi Direct (IEEE 802.11 P2P) as an optional peer-finding layer. After a P2
     - `GO_INTERFACE_IP` constant (`192.168.49.1`)
     - `WifiDirectGroup::from_iface`: polls interface IP, resolves peer IP
 - [x] `src/lib.rs` — `WifiDirectDiscovery`: orchestrates find → connect → group formation
-    - `WifiDirectDiscovery::new(config, listen_port) -> (Self, Receiver<SocketAddr>)`
+    - `WifiDirectDiscovery::new(node_name, config, listen_port) -> (Self, Receiver<SocketAddr>)`
     - `WifiDirectDiscovery::run(cancel)` — polling loop, emits `SocketAddr` per formed group
 - [x] **Tests** (all pure unit tests, no subprocess invoked):
     - [x] `wpa_cli_p2p_peers_parses_empty_output`


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** `pim-cli` configuration generation command (`pim config generate`) used a vulnerable pattern of checking `path.exists()` and then falling back to blindly creating/truncating a file if it did not exist (`.create(true).truncate(true)`). This opens a window for a TOCTOU (Time-of-Check to Time-of-Use) symlink attack. An attacker could create a symlink with the target name between the check and the actual file creation, tricking the CLI into truncating and overwriting the symlink's target file (e.g., another sensitive config file).
🎯 **Impact:** Local privilege escalation or data destruction by tricking the application into overwriting an arbitrary file that the user executing the CLI has permissions to write.
🔧 **Fix:** Changed the file opening logic. If `--force` is false, it uses `std::fs::OpenOptions::new().create_new(true)`, which safely maps to `O_CREAT | O_EXCL` under the hood. This acts atomically and will safely fail if the file (or a symlink) is created before the file open call.
✅ **Verification:** Verified by running `cargo test --workspace` and ensuring the CLI logic is sound.

---
*PR created automatically by Jules for task [10942786872907390099](https://jules.google.com/task/10942786872907390099) started by @Rfluid*