### PR TITLE
⚡ Bolt: [performance improvement] Zero-copy encryption for discovery advertisements

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -22,3 +22,8 @@
 
 **Learning:** Transport write queues were creating unnecessary memory allocations in the hot path. Serializing frames via `BytesMut` then converting them using `.to_vec()` caused extra allocations on every outgoing packet. Using `freeze()` transforms `BytesMut` into `Bytes` with zero copying.
 **Action:** Use `Bytes::freeze()` rather than `.to_vec()` to pass buffers between async tasks without unnecessary memory allocations.
+
+## 2024-05-17 - Discovery advertisement encryption zero-copy allocation optimization
+
+**Learning:** Discovery advertisement serialization/deserialization for encrypted format used standard `.encrypt` and `.decrypt` from the AEAD cipher, resulting in repeated allocation of `Vec<u8>`. For a system that handles heavy network I/O, these continuous runtime allocations can introduce bottlenecks.
+**Action:** Use `AeadInPlace::encrypt_in_place_detached` and `decrypt_in_place_detached` operating directly on stack buffers, preserving zero-copy operations across the codebase.

--- a/crates/pim-discovery/src/advertisement.rs
+++ b/crates/pim-discovery/src/advertisement.rs
@@ -163,7 +163,9 @@ impl DiscoveryAdvertisement {
         plaintext.copy_from_slice(&buf[17..17 + PACKET_SIZE]);
         let tag = Tag::<Aes256Gcm>::from_slice(&buf[17 + PACKET_SIZE..17 + PACKET_SIZE + 16]);
 
-        cipher.decrypt_in_place_detached(nonce, b"", &mut plaintext, tag).ok()?;
+        cipher
+            .decrypt_in_place_detached(nonce, b"", &mut plaintext, tag)
+            .ok()?;
 
         Self::deserialize_plaintext_payload(&plaintext)
     }

--- a/crates/pim-discovery/src/advertisement.rs
+++ b/crates/pim-discovery/src/advertisement.rs
@@ -1,6 +1,6 @@
 //! Discovery advertisement: wire format and capabilities.
 
-use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::aead::KeyInit;
 use aes_gcm::{Aes256Gcm, Nonce};
 use pim_core::NodeId;
 use rand::rngs::OsRng;
@@ -92,19 +92,24 @@ impl DiscoveryAdvertisement {
 
     /// Serialize to the encrypted wire format.
     pub fn serialize_encrypted(&self, key: &[u8; 32]) -> [u8; ENCRYPTED_PACKET_SIZE] {
+        use aes_gcm::aead::AeadInPlace;
+
         let cipher = Aes256Gcm::new_from_slice(key).expect("32-byte key is valid for AES-256");
         let mut nonce_bytes = [0u8; 12];
         OsRng.fill_bytes(&mut nonce_bytes);
         let nonce = Nonce::from_slice(&nonce_bytes);
-        let ciphertext = cipher
-            .encrypt(nonce, self.plaintext_bytes().as_ref())
-            .expect("discovery advertisement encryption should succeed");
 
         let mut buf = [0u8; ENCRYPTED_PACKET_SIZE];
         buf[0..4].copy_from_slice(&MAGIC);
         buf[4] = ENCRYPTED_VERSION;
         buf[5..17].copy_from_slice(&nonce_bytes);
-        buf[17..].copy_from_slice(&ciphertext);
+        buf[17..17 + PACKET_SIZE].copy_from_slice(&self.plaintext_bytes());
+
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, b"", &mut buf[17..17 + PACKET_SIZE])
+            .expect("discovery advertisement encryption should succeed");
+
+        buf[17 + PACKET_SIZE..].copy_from_slice(&tag);
         buf
     }
 
@@ -137,6 +142,8 @@ impl DiscoveryAdvertisement {
 
     /// Decrypt and deserialize from a byte slice using the shared discovery key.
     pub fn deserialize_encrypted(buf: &[u8], key: &[u8; 32]) -> Option<Self> {
+        use aes_gcm::aead::{AeadInPlace, Tag};
+
         if buf.len() < ENCRYPTED_PACKET_SIZE {
             return None;
         }
@@ -151,7 +158,13 @@ impl DiscoveryAdvertisement {
         nonce_bytes.copy_from_slice(&buf[5..17]);
         let nonce = Nonce::from_slice(&nonce_bytes);
         let cipher = Aes256Gcm::new_from_slice(key).ok()?;
-        let plaintext = cipher.decrypt(nonce, &buf[17..]).ok()?;
+
+        let mut plaintext = [0u8; PACKET_SIZE];
+        plaintext.copy_from_slice(&buf[17..17 + PACKET_SIZE]);
+        let tag = Tag::<Aes256Gcm>::from_slice(&buf[17 + PACKET_SIZE..17 + PACKET_SIZE + 16]);
+
+        cipher.decrypt_in_place_detached(nonce, b"", &mut plaintext, tag).ok()?;
+
         Self::deserialize_plaintext_payload(&plaintext)
     }
 


### PR DESCRIPTION
**💡 What:** The discovery advertisement serialization and deserialization for encrypted formats have been refactored to use `AeadInPlace::encrypt_in_place_detached` and `decrypt_in_place_detached`. This replaces the previous `.encrypt` and `.decrypt` calls on `Aes256Gcm`.

**🎯 Why:** The previous implementation caused the cipher to allocate a new `Vec<u8>` on the heap for every encrypted packet processed. For a daemon handling heavy network I/O, allocating these objects on the hot path causes bottlenecks and garbage collection / allocator pressure. 

**📊 Impact:** Eliminates memory allocation overhead for discovery packet encryption/decryption, replacing it with zero-copy operations running directly on pre-allocated stack buffers. This improves memory efficiency and processing latency.

**🔬 Measurement:** The correctness was verified by running `cargo test --workspace` which ensures that all unit tests, specifically `encrypted_round_trip` and `encrypted_wrong_key_rejected` in `advertisement.rs`, pass successfully. The expected behavior matches the test requirements while avoiding the extra allocations under load.

---
*PR created automatically by Jules for task [8297650531492031215](https://jules.google.com/task/8297650531492031215) started by @Rfluid*