### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in config generation

### DIFF
--- a/crates/pim-cli/src/main.rs
+++ b/crates/pim-cli/src/main.rs
@@ -683,14 +683,20 @@ fn cmd_config_generate(
     let rendered = render_config_template(&roles, name.as_deref());
 
     if let Some(path) = output {
-        if path.exists() && !force {
-            bail!(
-                "refusing to overwrite existing file: {} (use --force to overwrite)",
-                path.display()
-            );
-        }
         let mut options = std::fs::OpenOptions::new();
-        options.write(true).create(true).truncate(true);
+        options.write(true);
+
+        if force {
+            options.create(true).truncate(true);
+        } else {
+            if path.exists() {
+                bail!(
+                    "refusing to overwrite existing file: {} (use --force to overwrite)",
+                    path.display()
+                );
+            }
+            options.create_new(true);
+        }
 
         #[cfg(unix)]
         {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A Time-of-Check to Time-of-Use (TOCTOU) race condition existed in `pim config generate` (`crates/pim-cli/src/main.rs`). The code checked if the target file existed using `path.exists()` and then created it using `.create(true).truncate(true)`. An attacker could theoretically create a symlink in the split-second window between the check and the use, causing the application to inadvertently overwrite a file it shouldn't.
🎯 Impact: Local privilege escalation or data loss if an attacker places a symlink pointing to a sensitive file at the expected config output path.
🔧 Fix: Updated the file creation logic to use `OpenOptions::create_new(true)` when `--force` is not provided. This leverages the OS-level `O_CREAT | O_EXCL` flags to guarantee atomic file creation and explicitly fail if the file already exists, eliminating the race condition.
✅ Verification: Ran `cargo clippy --workspace -- -D warnings` and `cargo test --workspace`. All tests passed. The fix retains the existing `path.exists()` check solely for a friendly `bail!` error message under normal conditions, but enforces the hard security boundary at the kernel level.

---
*PR created automatically by Jules for task [11120073716859864399](https://jules.google.com/task/11120073716859864399) started by @Rfluid*