### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in config generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The daemon's PID file (`pid_file`) was written using `std::fs::write`, which falls back to the system's default `umask`. Under a permissive umask (e.g., `0000`), this could leave the PID file world-writable, allowing unprivileged users to spoof the PID.
 **Learning:** Relying on default file permissions when writing non-sensitive system files (like PID files) can still create security risks, such as local DoS or privilege escalation, if the files are used by other system services.
 **Prevention:** Explicitly use `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o644)` on Unix systems to ensure strict file access permissions (owner writable, group/others readable) when writing system files.
+
+## 2024-06-26 - [Secure File Creation for Config Generation]
+**Vulnerability:** The CLI's config generation (`cmd_config_generate`) checked `path.exists()` before calling `std::fs::OpenOptions::create(true).truncate(true)`. This Time-of-Check to Time-of-Use (TOCTOU) vulnerability allowed a symlink attack where an attacker could create a symlink at the target path after the check but before the open, causing the CLI to overwrite an arbitrary file.
+**Learning:** Checking file existence separately from opening the file creates a race condition for file creation, especially when running with elevated privileges.
+**Prevention:** Explicitly use `create_new(true)` on `std::fs::OpenOptions` (or `tokio::fs::OpenOptions`) to enforce `O_CREAT | O_EXCL` at the OS level, making the check and creation atomic. Catch the `AlreadyExists` error to handle the case where the file is already present.

--- a/crates/pim-cli/src/main.rs
+++ b/crates/pim-cli/src/main.rs
@@ -683,14 +683,13 @@ fn cmd_config_generate(
     let rendered = render_config_template(&roles, name.as_deref());
 
     if let Some(path) = output {
-        if path.exists() && !force {
-            bail!(
-                "refusing to overwrite existing file: {} (use --force to overwrite)",
-                path.display()
-            );
-        }
         let mut options = std::fs::OpenOptions::new();
-        options.write(true).create(true).truncate(true);
+        options.write(true);
+        if force {
+            options.create(true).truncate(true);
+        } else {
+            options.create_new(true);
+        }
 
         #[cfg(unix)]
         {
@@ -699,9 +698,19 @@ fn cmd_config_generate(
         }
 
         use std::io::Write;
-        let mut file = options
-            .open(&path)
-            .with_context(|| format!("failed to open config file {}", path.display()))?;
+        let mut file = match options.open(&path) {
+            Ok(file) => file,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                bail!(
+                    "refusing to overwrite existing file: {} (use --force to overwrite)",
+                    path.display()
+                );
+            }
+            Err(e) => {
+                return Err(e).with_context(|| format!("failed to open config file {}", path.display()));
+            }
+        };
+
         file.write_all(rendered.as_bytes())
             .with_context(|| format!("failed to write config template to {}", path.display()))?;
 

--- a/crates/pim-cli/src/main.rs
+++ b/crates/pim-cli/src/main.rs
@@ -707,7 +707,8 @@ fn cmd_config_generate(
                 );
             }
             Err(e) => {
-                return Err(e).with_context(|| format!("failed to open config file {}", path.display()));
+                return Err(e)
+                    .with_context(|| format!("failed to open config file {}", path.display()));
             }
         };
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The CLI's config generation (`cmd_config_generate`) used a non-atomic `path.exists()` check before opening the file to enforce the non-overwrite constraint (when `--force` is missing). This Time-of-Check to Time-of-Use (TOCTOU) race condition allowed a symlink attack where an attacker could link the target path to an arbitrary file between the check and the open.
🎯 **Impact:** An attacker could cause the CLI to overwrite arbitrary system files with generated configuration templates, potentially leading to privilege escalation or denial of service if the CLI is run with elevated permissions.
🔧 **Fix:** Replaced the separate `path.exists()` check with an atomic file creation approach. The code now explicitly configures `std::fs::OpenOptions` with `create_new(true)` to enforce `O_CREAT | O_EXCL` flags at the OS level when `--force` is absent. If the file exists, it securely catches the `AlreadyExists` error. The journal at `.jules/sentinel.md` has been updated with this learning.
✅ **Verification:** Verified by running `cargo test -p pim-cli`, `cargo test --workspace`, and `cargo clippy --workspace -- -D warnings`, ensuring no functionality or formatting regressions were introduced.

---
*PR created automatically by Jules for task [6927646643829213061](https://jules.google.com/task/6927646643829213061) started by @Rfluid*