### PR TITLE
🛡️ Sentinel: [HIGH] Fix TOCTOU vulnerability in config generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The daemon's PID file (`pid_file`) was written using `std::fs::write`, which falls back to the system's default `umask`. Under a permissive umask (e.g., `0000`), this could leave the PID file world-writable, allowing unprivileged users to spoof the PID.
 **Learning:** Relying on default file permissions when writing non-sensitive system files (like PID files) can still create security risks, such as local DoS or privilege escalation, if the files are used by other system services.
 **Prevention:** Explicitly use `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o644)` on Unix systems to ensure strict file access permissions (owner writable, group/others readable) when writing system files.
+
+## 2026-04-22 - [Fix TOCTOU Vulnerability in File Creation]
+**Vulnerability:** The configuration generator used `path.exists()` to check if a file existed before conditionally creating it with `std::fs::OpenOptions` and `create(true).truncate(true)`.
+**Learning:** Checking for file existence before creating a file creates a Time-of-Check to Time-of-Use (TOCTOU) race condition. An attacker could replace the intended path with a symlink between the check and the creation, causing the application to unknowingly overwrite an arbitrary file.
+**Prevention:** Avoid checking for file existence prior to creating new sensitive files (e.g., configurations). Use `std::fs::OpenOptions::new().create_new(true)` to rely on atomic OS-level protections (`O_CREAT | O_EXCL`) that fail if the file already exists, thus closing the TOCTOU gap. Avoid applying this blindly to files that legitimately need to overwrite existing content (like PID files or rotating logs).

--- a/crates/pim-cli/src/main.rs
+++ b/crates/pim-cli/src/main.rs
@@ -707,7 +707,10 @@ fn cmd_config_generate(
                     path.display()
                 );
             }
-            Err(e) => return Err(e).with_context(|| format!("failed to open config file {}", path.display())),
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("failed to open config file {}", path.display()))
+            }
         };
 
         file.write_all(rendered.as_bytes())

--- a/crates/pim-cli/src/main.rs
+++ b/crates/pim-cli/src/main.rs
@@ -683,14 +683,14 @@ fn cmd_config_generate(
     let rendered = render_config_template(&roles, name.as_deref());
 
     if let Some(path) = output {
-        if path.exists() && !force {
-            bail!(
-                "refusing to overwrite existing file: {} (use --force to overwrite)",
-                path.display()
-            );
-        }
         let mut options = std::fs::OpenOptions::new();
-        options.write(true).create(true).truncate(true);
+        options.write(true);
+
+        if force {
+            options.create(true).truncate(true);
+        } else {
+            options.create_new(true);
+        }
 
         #[cfg(unix)]
         {
@@ -699,9 +699,17 @@ fn cmd_config_generate(
         }
 
         use std::io::Write;
-        let mut file = options
-            .open(&path)
-            .with_context(|| format!("failed to open config file {}", path.display()))?;
+        let mut file = match options.open(&path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists && !force => {
+                bail!(
+                    "refusing to overwrite existing file: {} (use --force to overwrite)",
+                    path.display()
+                );
+            }
+            Err(e) => return Err(e).with_context(|| format!("failed to open config file {}", path.display())),
+        };
+
         file.write_all(rendered.as_bytes())
             .with_context(|| format!("failed to write config template to {}", path.display()))?;
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `cmd_config_generate` function in `crates/pim-cli/src/main.rs` contained a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where `path.exists()` was used to check if a configuration file existed before opening it with `create(true).truncate(true)`.
🎯 Impact: An attacker could exploit the time window between the check and the opening by swapping the path out with a symlink, tricking the CLI into overwriting an arbitrary file that the CLI has permissions to write to.
🔧 Fix: Replaced the separate `exists` check and standard open with an atomic `OpenOptions::new().create_new(true)` approach when `--force` is not provided. This correctly maps to `O_CREAT | O_EXCL` avoiding the TOCTOU race window.
✅ Verification: Ran `cargo test --workspace` to ensure that standard behavior remains intact and the correct error format is triggered when the file exists, as well as added an entry to `.jules/sentinel.md` documenting this atomic file creation learning.

---
*PR created automatically by Jules for task [8376940099457435905](https://jules.google.com/task/8376940099457435905) started by @Rfluid*