### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in CLI config generation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -12,3 +12,8 @@
 **Vulnerability:** The daemon's PID file (`pid_file`) was written using `std::fs::write`, which falls back to the system's default `umask`. Under a permissive umask (e.g., `0000`), this could leave the PID file world-writable, allowing unprivileged users to spoof the PID.
 **Learning:** Relying on default file permissions when writing non-sensitive system files (like PID files) can still create security risks, such as local DoS or privilege escalation, if the files are used by other system services.
 **Prevention:** Explicitly use `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o644)` on Unix systems to ensure strict file access permissions (owner writable, group/others readable) when writing system files.
+
+## 2024-08-16 - [Secure File Creation for Configs]
+**Vulnerability:** The CLI's configuration initialization logic used a non-atomic `path.exists()` check before creating the `config.toml` file with `create(true).truncate(true)`. This creates a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an attacker could place a symlink at the target path between the check and the file creation.
+**Learning:** Checking for file existence before creation using separate operations is prone to race conditions and symlink attacks.
+**Prevention:** Use atomic operations like `OpenOptions::new().create_new(true)` when creating sensitive files that shouldn't be overwritten, and handle the resulting `ErrorKind::AlreadyExists` to provide safe, race-free user warnings.

--- a/crates/pim-cli/src/main.rs
+++ b/crates/pim-cli/src/main.rs
@@ -683,14 +683,13 @@ fn cmd_config_generate(
     let rendered = render_config_template(&roles, name.as_deref());
 
     if let Some(path) = output {
-        if path.exists() && !force {
-            bail!(
-                "refusing to overwrite existing file: {} (use --force to overwrite)",
-                path.display()
-            );
-        }
         let mut options = std::fs::OpenOptions::new();
-        options.write(true).create(true).truncate(true);
+        options.write(true);
+        if force {
+            options.create(true).truncate(true);
+        } else {
+            options.create_new(true);
+        }
 
         #[cfg(unix)]
         {
@@ -699,9 +698,16 @@ fn cmd_config_generate(
         }
 
         use std::io::Write;
-        let mut file = options
-            .open(&path)
-            .with_context(|| format!("failed to open config file {}", path.display()))?;
+        let mut file = match options.open(&path) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists && !force => {
+                bail!(
+                    "refusing to overwrite existing file: {} (use --force to overwrite)",
+                    path.display()
+                );
+            }
+            Err(e) => return Err(anyhow::Error::new(e).context(format!("failed to open config file {}", path.display()))),
+        };
         file.write_all(rendered.as_bytes())
             .with_context(|| format!("failed to write config template to {}", path.display()))?;
 

--- a/crates/pim-cli/src/main.rs
+++ b/crates/pim-cli/src/main.rs
@@ -706,7 +706,10 @@ fn cmd_config_generate(
                     path.display()
                 );
             }
-            Err(e) => return Err(anyhow::Error::new(e).context(format!("failed to open config file {}", path.display()))),
+            Err(e) => {
+                return Err(anyhow::Error::new(e)
+                    .context(format!("failed to open config file {}", path.display())))
+            }
         };
         file.write_all(rendered.as_bytes())
             .with_context(|| format!("failed to write config template to {}", path.display()))?;


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Time-of-Check to Time-of-Use (TOCTOU) race condition during CLI configuration file generation. The code used a non-atomic `path.exists()` check followed by `create(true).truncate(true)`.
🎯 **Impact:** An attacker could replace the target path with a symlink between the existence check and the file creation, leading to arbitrary file overwriting or potential privilege escalation.
🔧 **Fix:** Replaced the non-atomic check with `OpenOptions::new().create_new(true)` to leverage the operating system's atomic file creation guarantees (`O_CREAT | O_EXCL`).
✅ **Verification:** Verified by running `cargo test --workspace` and `cargo clippy --workspace -- -D warnings`. Ensure the CLI still correctly refuses to overwrite an existing config without the `--force` flag.

---
*PR created automatically by Jules for task [2463640054340437482](https://jules.google.com/task/2463640054340437482) started by @Rfluid*