### PR TITLE
feat(ios): cross-compile foundation + pim-ios-ffi (#70 milestone 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 
 # Personal
 /debug
+
+# macOS metadata
+.DS_Store
+**/.DS_Store

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -840,6 +840,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pim-ios-ffi"
+version = "0.1.0"
+dependencies = [
+ "pim-core",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "pim-protocol"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/pim-wifidirect",
     "crates/pim-daemon",
     "crates/pim-cli",
+    "crates/pim-ios-ffi",
 ]
 
 [workspace.dependencies]
@@ -67,3 +68,4 @@ pim-gateway = { path = "crates/pim-gateway" }
 pim-discovery = { path = "crates/pim-discovery" }
 pim-routing = { path = "crates/pim-routing" }
 pim-wifidirect = { path = "crates/pim-wifidirect" }
+pim-ios-ffi = { path = "crates/pim-ios-ffi" }

--- a/Makefile
+++ b/Makefile
@@ -225,6 +225,24 @@ clean-all: docker-clean
 test-unit:
 	cargo test --workspace
 
+# ── iOS cross-compile (milestone 1 of issue #70) ─────────────────────────────
+
+IOS_TARGETS := aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+IOS_LIB_CRATES := pim-core pim-crypto pim-protocol pim-routing pim-transport \
+                  pim-discovery pim-gateway pim-tun pim-bluetooth \
+                  pim-wifidirect pim-ios-ffi
+
+.PHONY: ios-check ios-xcframework
+
+ios-check:
+	@for t in $(IOS_TARGETS); do \
+	  echo "==> cargo check --target $$t"; \
+	  cargo check --target $$t $(addprefix -p ,$(IOS_LIB_CRATES)) || exit 1; \
+	done
+
+ios-xcframework:
+	bash scripts/build-ios.sh
+
 .PHONY: help
 help:
 	@echo "PIM Docker test targets:"
@@ -245,6 +263,9 @@ help:
 	@echo "  make test-bluetooth-enx Bluetooth dynamic enx PAN fallback seam test in Docker"
 	@echo "  make test-all           All phases (slow tests skipped)"
 	@echo "  make test-unit          Rust unit tests (no Docker)"
+	@echo ""
+	@echo "  make ios-check          cargo check all library crates for each iOS triple"
+	@echo "  make ios-xcframework    Build target/ios/PimCore.xcframework (requires Xcode)"
 	@echo ""
 	@echo "  make up-p1              Start phase 1 stack (no tests)"
 	@echo "  make up-ipv6            Start IPv6 single-hop stack"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ The codebase is currently centered on a Linux daemon, a small CLI, and Docker-ba
 
 On macOS, use a `utunN` interface such as `utun0` for the mesh TUN and set `gateway.nat_interface` to the internet-facing host interface such as `en0`. The Wi-Fi Direct backend uses Bonjour peer-to-peer discovery on macOS rather than Linux `wpa_cli` group formation, so Linux-specific tuning fields in `[wifi_direct]` are ignored there.
 
+## iOS Support (in progress)
+
+iOS support is tracked in [issue #70](https://github.com/Astervia/proximity-internet-mesh/issues/70).
+
+Milestone 1 — **iOS target architecture and cross-compile scaffolding** — is resolved on this branch. See [docs/architecture/ios.md](docs/architecture/ios.md) for the decision record. Build locally with:
+
+```bash
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+make ios-check          # cross-compile sanity check (works with CLT)
+make ios-xcframework    # produces target/ios/PimCore.xcframework (needs full Xcode)
+```
+
+The Xcode app and `NEPacketTunnelProvider` extension that consume `PimCore.xcframework`, the packet IO bridging, and relay-mode support all land in follow-up plans — milestones 2–6 of the issue remain open.
+
 ## Repository Layout
 
 ```text

--- a/crates/pim-bluetooth/src/lib.rs
+++ b/crates/pim-bluetooth/src/lib.rs
@@ -14,9 +14,9 @@
 #[cfg(target_os = "linux")]
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::net::SocketAddr;
 #[cfg(any(test, target_os = "linux", target_os = "macos"))]
 use std::net::IpAddr;
+use std::net::SocketAddr;
 #[cfg(any(test, target_os = "linux"))]
 use std::net::SocketAddrV6;
 #[cfg(any(test, target_os = "linux"))]

--- a/crates/pim-bluetooth/src/lib.rs
+++ b/crates/pim-bluetooth/src/lib.rs
@@ -14,7 +14,11 @@
 #[cfg(target_os = "linux")]
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::net::{IpAddr, SocketAddr, SocketAddrV6};
+use std::net::SocketAddr;
+#[cfg(any(test, target_os = "linux", target_os = "macos"))]
+use std::net::IpAddr;
+#[cfg(any(test, target_os = "linux"))]
+use std::net::SocketAddrV6;
 #[cfg(any(test, target_os = "linux"))]
 use std::path::Path;
 use std::path::PathBuf;
@@ -103,10 +107,16 @@ struct ResolvedPanInterface {
 #[derive(Debug)]
 pub struct BluetoothDiscovery {
     config: BluetoothConfig,
+    // On iOS the stubs in the impl block return Unavailable without reading
+    // any of these fields. Silence the resulting dead_code warnings rather
+    // than adding cfg gates on each field — Plan 2 may revisit this when
+    // the daemon is refactored into pim-runtime.
+    #[cfg_attr(target_os = "ios", allow(dead_code))]
     listen_port: u16,
     static_targets: Vec<SocketAddr>,
     #[cfg(target_os = "linux")]
     sysfs_root: PathBuf,
+    #[cfg_attr(target_os = "ios", allow(dead_code))]
     ip_command: PathBuf,
     bluetoothctl_command: PathBuf,
     #[cfg(target_os = "linux")]

--- a/crates/pim-bluetooth/src/lib.rs
+++ b/crates/pim-bluetooth/src/lib.rs
@@ -42,12 +42,18 @@ pub const DEFAULT_IP_COMMAND: &str = "ip";
 /// Default command used to inspect Bluetooth PAN neighbors.
 #[cfg(target_os = "macos")]
 pub const DEFAULT_IP_COMMAND: &str = "arp";
+/// Placeholder on platforms without Bluetooth PAN support (e.g. iOS).
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub const DEFAULT_IP_COMMAND: &str = "";
 /// Default command used for radio discovery and pairing.
 #[cfg(target_os = "linux")]
 pub const DEFAULT_BLUETOOTHCTL_COMMAND: &str = "bluetoothctl";
 /// Default command used for radio discovery and pairing.
 #[cfg(target_os = "macos")]
 pub const DEFAULT_BLUETOOTHCTL_COMMAND: &str = "blueutil";
+/// Placeholder on platforms without Bluetooth PAN support (e.g. iOS).
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+pub const DEFAULT_BLUETOOTHCTL_COMMAND: &str = "";
 /// Default `bt-network` command used to request a PAN/NAP connection.
 pub const DEFAULT_BT_NETWORK_COMMAND: &str = "bt-network";
 /// Default `iptables` command used to install NAT rules for the Bluetooth subnet.
@@ -73,6 +79,9 @@ pub enum BluetoothError {
         /// Human-readable error text from stderr.
         message: String,
     },
+    /// Bluetooth is not available on this platform (e.g. iOS).
+    #[error("Bluetooth is not available on this platform")]
+    Unavailable,
 }
 
 /// A discovered Bluetooth device candidate.
@@ -1213,6 +1222,44 @@ impl BluetoothDiscovery {
             interface,
             self.listen_port,
         ))
+    }
+
+    // iOS cannot reach Bluetooth PAN from a third-party app sandbox, and a
+    // Packet Tunnel extension has no access to bluetoothctl/blueutil/arp/ip.
+    // These stubs keep the crate compilable on iOS — the dispatch trampoline
+    // above is cfg-neutral, so the _impl surface has to exist on every
+    // supported target.
+    #[cfg(target_os = "ios")]
+    async fn prepare_controller_impl(&self) -> Result<(), BluetoothError> {
+        Err(BluetoothError::Unavailable)
+    }
+
+    #[cfg(target_os = "ios")]
+    async fn discover_devices_impl(&self) -> Result<Vec<DiscoveredDevice>, BluetoothError> {
+        Err(BluetoothError::Unavailable)
+    }
+
+    #[cfg(target_os = "ios")]
+    async fn pair_and_request_pan_impl(
+        &self,
+        _device: &DiscoveredDevice,
+    ) -> Result<(), BluetoothError> {
+        Err(BluetoothError::Unavailable)
+    }
+
+    #[cfg(target_os = "ios")]
+    async fn resolve_pan_interface_impl(
+        &self,
+    ) -> Result<Option<ResolvedPanInterface>, BluetoothError> {
+        Err(BluetoothError::Unavailable)
+    }
+
+    #[cfg(target_os = "ios")]
+    async fn discover_neighbor_targets_impl(
+        &self,
+        _interface: &str,
+    ) -> Result<Vec<SocketAddr>, BluetoothError> {
+        Err(BluetoothError::Unavailable)
     }
 }
 

--- a/crates/pim-ios-ffi/Cargo.toml
+++ b/crates/pim-ios-ffi/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "pim-ios-ffi"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "pim_ios_ffi"
+# `staticlib` is what Xcode links against inside the XCFramework.
+# `rlib` lets the crate be depended on by other Rust code (tests,
+# future runtime wrapper).
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+pim-core = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }

--- a/crates/pim-ios-ffi/include/pim_ios_ffi.h
+++ b/crates/pim-ios-ffi/include/pim_ios_ffi.h
@@ -1,0 +1,66 @@
+/*
+ * pim_ios_ffi.h — C ABI for the Proximity Internet Mesh iOS bridge.
+ *
+ * Resolves milestone 1 of issue #70. The surface is intentionally
+ * minimal in Plan 1:
+ *
+ *   - pim_ffi_version()      returns a library-owned version string.
+ *   - pim_ffi_start()        allocates an opaque handle and validates
+ *                            the config JSON shape.
+ *   - pim_ffi_stop()         releases a handle.
+ *   - pim_ffi_free_string()  frees an error string from pim_ffi_start.
+ *
+ * Plan 2 extends the surface with read/write packet callbacks that the
+ * NEPacketTunnelProvider extension registers so the Rust core can drive
+ * NEPacketTunnelFlow.
+ */
+#ifndef PIM_IOS_FFI_H
+#define PIM_IOS_FFI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque handle; contents are private to the Rust side. */
+typedef struct PimHandle PimHandle;
+
+/*
+ * Return a pointer to a library-owned NUL-terminated UTF-8 string.
+ * The caller must not free the returned pointer. The lifetime is the
+ * lifetime of the library.
+ */
+const char *pim_ffi_version(void);
+
+/*
+ * Start the PIM runtime with the given JSON config.
+ *
+ * Success:   returns a non-NULL PimHandle*. The caller owns it and must
+ *            release it by calling pim_ffi_stop() exactly once.
+ * Failure:   returns NULL. If `err_out` is non-NULL, *err_out is set to
+ *            a library-owned NUL-terminated UTF-8 string describing the
+ *            error. The caller must release that string by calling
+ *            pim_ffi_free_string().
+ *
+ * Plan 1 validates the JSON shape only — it does not yet start the
+ * daemon.
+ */
+PimHandle *pim_ffi_start(const char *config_json, char **err_out);
+
+/*
+ * Stop and free a handle previously returned by pim_ffi_start.
+ *   - Passing NULL is a no-op.
+ *   - Passing the same non-NULL handle twice is undefined behavior.
+ */
+void pim_ffi_stop(PimHandle *handle);
+
+/*
+ * Release an error string previously produced by pim_ffi_start.
+ * Passing NULL is a no-op.
+ */
+void pim_ffi_free_string(char *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PIM_IOS_FFI_H */

--- a/crates/pim-ios-ffi/src/lib.rs
+++ b/crates/pim-ios-ffi/src/lib.rs
@@ -30,7 +30,7 @@ pub struct PimHandle {
 
 /// Returns a NUL-terminated UTF-8 string owned by the library describing
 /// the crate version. The caller must not free the returned pointer.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub extern "C" fn pim_ffi_version() -> *const c_char {
     // The byte string lives for the lifetime of the library, so the pointer
     // is always valid.
@@ -55,7 +55,7 @@ pub extern "C" fn pim_ffi_version() -> *const c_char {
 ///   valid, readable buffer.
 /// - `err_out` may be null. If non-null, it must point at a writable
 ///   `*mut c_char` slot.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn pim_ffi_start(
     config_json: *const c_char,
     err_out: *mut *mut c_char,
@@ -90,7 +90,7 @@ pub unsafe extern "C" fn pim_ffi_start(
 ///
 /// `handle` must be either null or a pointer returned by
 /// [`pim_ffi_start`] that has not yet been passed to `pim_ffi_stop`.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn pim_ffi_stop(handle: *mut PimHandle) {
     if handle.is_null() {
         return;
@@ -105,7 +105,7 @@ pub unsafe extern "C" fn pim_ffi_stop(handle: *mut PimHandle) {
 ///
 /// `s` must be either null or a pointer previously written to
 /// `*err_out` by [`pim_ffi_start`].
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn pim_ffi_free_string(s: *mut c_char) {
     if s.is_null() {
         return;
@@ -119,10 +119,13 @@ unsafe fn set_error(err_out: *mut *mut c_char, msg: &str) {
     }
     let c = match CString::new(msg) {
         Ok(c) => c,
-        // The only way CString::new fails is an interior NUL in `msg`.
-        // We never pass one, but if we ever did we silently drop the
-        // message rather than writing a half-formed pointer.
-        Err(_) => return,
+        // CString::new only fails on an interior NUL. We never construct
+        // such a message, but if we ever did we write null to *err_out so
+        // callers cannot observe a stale or uninitialized pointer.
+        Err(_) => {
+            *err_out = ptr::null_mut();
+            return;
+        }
     };
     *err_out = c.into_raw();
 }

--- a/crates/pim-ios-ffi/src/lib.rs
+++ b/crates/pim-ios-ffi/src/lib.rs
@@ -1,0 +1,183 @@
+//! C ABI used by the iOS Packet Tunnel Provider extension to drive the PIM
+//! core. The public surface is:
+//!
+//! ```text
+//! const char *pim_ffi_version(void);
+//! PimHandle *pim_ffi_start(const char *config_json, char **err_out);
+//! void       pim_ffi_stop(PimHandle *handle);
+//! void       pim_ffi_free_string(char *s);
+//! ```
+//!
+//! Plan 1 (issue #70, milestone 1) ships only the lifecycle scaffolding —
+//! `pim_ffi_start` allocates an opaque handle and validates the config JSON
+//! shape, and `pim_ffi_stop` releases it. Driving the daemon runtime,
+//! bridging `NEPacketTunnelFlow.readPackets`/`writePackets`, and wiring
+//! routing/discovery on iOS all land in follow-up plans. See
+//! `docs/architecture/ios.md` for the full picture.
+
+#![warn(missing_docs)]
+
+use std::ffi::{c_char, CStr, CString};
+use std::ptr;
+
+/// Opaque handle returned by [`pim_ffi_start`]. Callers must treat the
+/// pointer as a black box and pass it back to [`pim_ffi_stop`] exactly once.
+pub struct PimHandle {
+    // Placeholder — Plan 2 replaces this with a tokio runtime and a
+    // DaemonState. Kept non-empty so every handle has distinct identity.
+    _private: (),
+}
+
+/// Returns a NUL-terminated UTF-8 string owned by the library describing
+/// the crate version. The caller must not free the returned pointer.
+#[no_mangle]
+pub extern "C" fn pim_ffi_version() -> *const c_char {
+    // The byte string lives for the lifetime of the library, so the pointer
+    // is always valid.
+    const VERSION: &[u8] = concat!(env!("CARGO_PKG_VERSION"), "\0").as_bytes();
+    VERSION.as_ptr() as *const c_char
+}
+
+/// Start the PIM runtime with the given JSON config.
+///
+/// On success returns a non-null `*mut PimHandle` that the caller must
+/// release with [`pim_ffi_stop`]. On failure returns null and, if `err_out`
+/// is non-null, writes a library-owned NUL-terminated UTF-8 error string
+/// to `*err_out` that the caller must release with [`pim_ffi_free_string`].
+///
+/// Plan 1 only validates that `config_json` parses as a JSON value — it does
+/// not yet start the daemon. Plan 2 will feed the parsed config into
+/// `pim_core::Config`.
+///
+/// # Safety
+///
+/// - `config_json` must be a NUL-terminated UTF-8 C string pointing at a
+///   valid, readable buffer.
+/// - `err_out` may be null. If non-null, it must point at a writable
+///   `*mut c_char` slot.
+#[no_mangle]
+pub unsafe extern "C" fn pim_ffi_start(
+    config_json: *const c_char,
+    err_out: *mut *mut c_char,
+) -> *mut PimHandle {
+    if config_json.is_null() {
+        set_error(err_out, "config_json is null");
+        return ptr::null_mut();
+    }
+
+    let config_cstr = CStr::from_ptr(config_json);
+    let config_str = match config_cstr.to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            set_error(err_out, "config_json is not valid UTF-8");
+            return ptr::null_mut();
+        }
+    };
+
+    // Shape-check the config JSON. Plan 2 will validate against pim_core::Config.
+    if let Err(e) = serde_json::from_str::<serde_json::Value>(config_str) {
+        set_error(err_out, &format!("invalid config JSON: {e}"));
+        return ptr::null_mut();
+    }
+
+    Box::into_raw(Box::new(PimHandle { _private: () }))
+}
+
+/// Release a handle returned by [`pim_ffi_start`]. Passing null is a no-op;
+/// passing the same non-null handle twice is undefined.
+///
+/// # Safety
+///
+/// `handle` must be either null or a pointer returned by
+/// [`pim_ffi_start`] that has not yet been passed to `pim_ffi_stop`.
+#[no_mangle]
+pub unsafe extern "C" fn pim_ffi_stop(handle: *mut PimHandle) {
+    if handle.is_null() {
+        return;
+    }
+    drop(Box::from_raw(handle));
+}
+
+/// Free an error string previously written by [`pim_ffi_start`]. Null is a
+/// no-op.
+///
+/// # Safety
+///
+/// `s` must be either null or a pointer previously written to
+/// `*err_out` by [`pim_ffi_start`].
+#[no_mangle]
+pub unsafe extern "C" fn pim_ffi_free_string(s: *mut c_char) {
+    if s.is_null() {
+        return;
+    }
+    drop(CString::from_raw(s));
+}
+
+unsafe fn set_error(err_out: *mut *mut c_char, msg: &str) {
+    if err_out.is_null() {
+        return;
+    }
+    let c = match CString::new(msg) {
+        Ok(c) => c,
+        // The only way CString::new fails is an interior NUL in `msg`.
+        // We never pass one, but if we ever did we silently drop the
+        // message rather than writing a half-formed pointer.
+        Err(_) => return,
+    };
+    *err_out = c.into_raw();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn version_is_non_empty() {
+        let p = pim_ffi_version();
+        assert!(!p.is_null());
+        let s = unsafe { CStr::from_ptr(p) }.to_str().unwrap();
+        assert!(!s.is_empty(), "version string should be non-empty");
+    }
+
+    #[test]
+    fn start_and_stop_round_trip() {
+        let cfg = CString::new(r#"{"node":{"name":"test"}}"#).unwrap();
+        let mut err: *mut c_char = ptr::null_mut();
+        let handle = unsafe { pim_ffi_start(cfg.as_ptr(), &mut err as *mut _) };
+        assert!(!handle.is_null(), "expected non-null handle, got err");
+        assert!(err.is_null(), "did not expect an error string");
+        unsafe { pim_ffi_stop(handle) };
+    }
+
+    #[test]
+    fn start_rejects_invalid_json() {
+        let cfg = CString::new("not valid json {{{").unwrap();
+        let mut err: *mut c_char = ptr::null_mut();
+        let handle = unsafe { pim_ffi_start(cfg.as_ptr(), &mut err as *mut _) };
+        assert!(handle.is_null());
+        assert!(!err.is_null());
+        let msg = unsafe { CStr::from_ptr(err) }.to_str().unwrap().to_string();
+        assert!(msg.contains("invalid config JSON"), "got error {msg:?}");
+        unsafe { pim_ffi_free_string(err) };
+    }
+
+    #[test]
+    fn start_rejects_null_config() {
+        let mut err: *mut c_char = ptr::null_mut();
+        let handle = unsafe { pim_ffi_start(ptr::null(), &mut err as *mut _) };
+        assert!(handle.is_null());
+        assert!(!err.is_null());
+        unsafe { pim_ffi_free_string(err) };
+    }
+
+    #[test]
+    fn stop_on_null_is_safe() {
+        unsafe { pim_ffi_stop(ptr::null_mut()) };
+    }
+
+    #[test]
+    fn free_string_on_null_is_safe() {
+        unsafe { pim_ffi_free_string(ptr::null_mut()) };
+    }
+}

--- a/crates/pim-tun/Cargo.toml
+++ b/crates/pim-tun/Cargo.toml
@@ -10,3 +10,6 @@ nix = { workspace = true }
 libc = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/pim-tun/src/lib.rs
+++ b/crates/pim-tun/src/lib.rs
@@ -853,7 +853,11 @@ mod platform {
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+// iOS (and any other non-Linux / non-macOS target) is served by this
+// stub module. A user-space iOS process cannot open /dev/net/tun or
+// SYSPROTO_CONTROL — packet IO on iOS lives inside a Packet Tunnel
+// extension and is bridged via `pim-ios-ffi`. See docs/architecture/ios.md.
+#[cfg(any(target_os = "ios", not(any(target_os = "linux", target_os = "macos"))))]
 mod platform {
     use super::{Ipv4Addr, Ipv6Addr, TunError};
 
@@ -926,5 +930,17 @@ mod tests {
         assert_eq!(prefix_to_mask(30), Ipv4Addr::new(255, 255, 255, 252));
         assert_eq!(prefix_to_mask(0), Ipv4Addr::new(0, 0, 0, 0));
         assert_eq!(prefix_to_mask(32), Ipv4Addr::new(255, 255, 255, 255));
+    }
+
+    // Packet IO on iOS lives inside a NEPacketTunnelProvider extension,
+    // not in the Rust process — so every TunInterface surface must refuse
+    // to touch the host and let `pim-ios-ffi` bridge the Swift extension.
+    #[cfg(target_os = "ios")]
+    #[tokio::test]
+    async fn ios_stub_reports_unavailable_for_all_operations() {
+        assert!(matches!(
+            TunInterface::create("utun0"),
+            Err(TunError::Unavailable)
+        ));
     }
 }

--- a/docs/architecture/ios.md
+++ b/docs/architecture/ios.md
@@ -15,9 +15,14 @@ Accepted — 2026-04-24. Resolves Milestone 1 of [issue #70][issue-70].
 - A user-space process cannot open `/dev/net/tun` or `SYSPROTO_CONTROL`. Packet
   IO is only available to a **Packet Tunnel Provider** extension, via
   `NEPacketTunnelFlow.readPackets` / `writePackets`.
-- The extension process is sandboxed and memory-limited (≈ 50 MB on iOS 15+,
-  with real-world reports of sub-15 MB caps on some iOS 17.x patch versions —
-  the dataplane must be designed for 15 MB).
+- The extension process is sandboxed and memory-limited. Apple documents
+  ≈ 50 MB on iOS 15+ ([Apple Developer Forums thread 106377][ne-mem]), but
+  community reports describe tighter caps on some iOS 17.x patch versions
+  ([Apple Developer Forums thread 747474][ne-mem-17]). Budget for 15 MB
+  rather than 50 MB when the dataplane can afford it.
+
+[ne-mem]: https://developer.apple.com/forums/thread/106377
+[ne-mem-17]: https://developer.apple.com/forums/thread/747474
 - Routing is declared once via `NEPacketTunnelNetworkSettings.IPv4Settings`
   (`includedRoutes` / `excludedRoutes` / `mtu`); there is no runtime
   `ip route` equivalent.

--- a/docs/architecture/ios.md
+++ b/docs/architecture/ios.md
@@ -1,0 +1,107 @@
+# iOS Target Architecture
+
+## Status
+
+Accepted — 2026-04-24. Resolves Milestone 1 of [issue #70][issue-70].
+
+[issue-70]: https://github.com/Astervia/proximity-internet-mesh/issues/70
+
+## Context
+
+`pim-daemon` integrates with the host through Linux (`/dev/net/tun`, `iptables`,
+`ip route`, `wpa_cli`, `bluetoothctl`) and macOS (`utunN` via `SYSPROTO_CONTROL`,
+`ifconfig`, `route`). None of those surfaces exist on iOS:
+
+- A user-space process cannot open `/dev/net/tun` or `SYSPROTO_CONTROL`. Packet
+  IO is only available to a **Packet Tunnel Provider** extension, via
+  `NEPacketTunnelFlow.readPackets` / `writePackets`.
+- The extension process is sandboxed and memory-limited (≈ 50 MB on iOS 15+,
+  with real-world reports of sub-15 MB caps on some iOS 17.x patch versions —
+  the dataplane must be designed for 15 MB).
+- Routing is declared once via `NEPacketTunnelNetworkSettings.IPv4Settings`
+  (`includedRoutes` / `excludedRoutes` / `mtu`); there is no runtime
+  `ip route` equivalent.
+- Wi-Fi Direct (IEEE 802.11 P2P) is not exposed on iOS. Bluetooth PAN is not
+  exposed to third-party apps either. Proximity transports have to be rebuilt
+  on `MultipeerConnectivity` or Bonjour + `Network.framework`.
+- Gateway/NAT mode is explicitly a non-goal of issue #70 — `iptables` has no
+  iOS analogue and the sandbox forbids raw sockets.
+
+## Decision
+
+PIM on iOS is split into three layers:
+
+1. **Platform-independent core (unchanged crates)** — `pim-core`,
+   `pim-crypto`, `pim-protocol`, `pim-routing`, `pim-transport`,
+   `pim-discovery`, `pim-gateway`. These crates already compile for
+   `aarch64-apple-ios` with no source changes.
+
+2. **Rust platform glue** — `pim-tun`, `pim-bluetooth`, `pim-wifidirect`.
+   Each exposes an iOS branch that either returns
+   `TunError::Unavailable` / `BluetoothError::Unavailable` /
+   `WifiDirectError::Unavailable` or is a compile-time no-op. Host
+   integration code (shell-outs to `ip`, `bluetoothctl`, `wpa_cli`) stays
+   compiled out on iOS so the sandbox never sees it.
+
+3. **Rust ↔ Swift bridge** — new crate `pim-ios-ffi` (`crate-type =
+   ["staticlib", "rlib"]`). It exposes a tiny opaque-handle C ABI:
+   - `pim_ffi_version() -> *const c_char`
+   - `pim_ffi_start(config_json, err_out) -> *mut PimHandle`
+   - `pim_ffi_stop(handle)`
+   - `pim_ffi_free_string(s)`
+
+   The Swift side (lands in a follow-up plan) consumes a hand-written header
+   and links against the XCFramework produced by
+   [`scripts/build-ios.sh`](../../scripts/build-ios.sh).
+
+## Build pipeline
+
+`scripts/build-ios.sh`:
+
+1. Confirms `xcode-select -p` and required `rustup` targets
+   (`aarch64-apple-ios`, `aarch64-apple-ios-sim`, `x86_64-apple-ios`).
+2. Runs `cargo build --release -p pim-ios-ffi --target <triple>` for each
+   of the three iOS targets.
+3. Uses `lipo -create` to fuse the two simulator static libs into one
+   multi-arch simulator lib.
+4. Runs `xcodebuild -create-xcframework` with the device lib + fused
+   simulator lib + the `pim_ios_ffi.h` header, producing
+   `target/ios/PimCore.xcframework`.
+
+The Makefile target `make ios-check` runs `cargo check` against all library
+crates for each iOS triple, and `make ios-xcframework` wraps the build
+script.
+
+## Binary crates
+
+`pim-daemon` and `pim-cli` stay Linux/macOS-only. They are deliberately **not**
+cross-compiled for iOS:
+
+- A Packet Tunnel extension has no `main()` and does not run a daemon process
+  in the traditional sense.
+- Getting the daemon to link cleanly on iOS would require a `pim-runtime`
+  library refactor that belongs in a follow-up plan (see below).
+
+## What this plan does not decide
+
+- `NEPacketTunnelFlow` ↔ `PacketIO` bridging design (deferred to Plan 2).
+- Whether relay mode is viable under the 50 MB memory cap
+  (Plan 3 benchmarks).
+- Whether discovery uses `MultipeerConnectivity`, Bonjour, or stays
+  static-peer-only on iOS (Plan 4).
+
+## Follow-up plans
+
+- **Plan 2 (Milestones 2 + 3 + 4):** client-mode dataplane. Introduce a
+  `PacketIO` trait in `pim-tun`, refactor `pim-daemon` into a `pim-runtime`
+  library + thin binary, extend `pim-ios-ffi` with read/write callbacks that
+  the Swift extension registers, add the Xcode app + `NEPacketTunnelProvider`
+  extension target, configure `NEPacketTunnelNetworkSettings` with
+  `includedRoutes`, and land a one-hop end-to-end integration test routing
+  `curl` through a test relay.
+- **Plan 3 (Milestone 5):** relay-mode dataplane. Add an accept loop inside
+  the extension (documenting iOS backgrounding constraints), benchmark
+  memory against the 50 MB cap, and ship a relay-mode test lab.
+- **Plan 4 (Milestone 6):** discovery + integrations + test coverage.
+  Add a `MultipeerConnectivity` or Bonjour-backed discovery adapter,
+  feature-gated for iOS, plus CI coverage for `make ios-xcframework`.

--- a/docs/superpowers/plans/2026-04-24-ios-foundation.md
+++ b/docs/superpowers/plans/2026-04-24-ios-foundation.md
@@ -1,0 +1,1034 @@
+# iOS Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Rust workspace cross-compile for iOS targets (device + simulator), expose a stable C ABI for a future NEPacketTunnelProvider extension, and document the iOS target architecture — resolving **Milestone 1** of issue #70.
+
+**Architecture:** Audit each existing crate, add `#[cfg(target_os = "ios")]` gates to stub out Linux/macOS-only host integrations (TUN/dev/net/tun, wpa_cli, bluetoothctl, iproute2), and introduce a new leaf crate `pim-ios-ffi` with a minimal opaque-handle C ABI. The extension-side Swift code, the NEPacketTunnelFlow bridge, and client/relay runtime wiring land in follow-up plans — this plan stops at "the workspace compiles for `aarch64-apple-ios` and `aarch64-apple-ios-sim`, produces a `PimCore.xcframework`, and the architecture is documented."
+
+**Tech Stack:** Rust (workspace unchanged), `cargo` with `--target`, `lipo` + `xcodebuild -create-xcframework`, a hand-written C header (no uniffi/cbindgen in Plan 1 — the FFI surface is three functions).
+
+**Scope boundary:**
+- **In:** Per-crate iOS platform gates; new `pim-ios-ffi` staticlib crate exposing `pim_ffi_version()`, `pim_ffi_start()`, `pim_ffi_stop()` (start/stop are stubs in this plan — they return a handle and release it, but do not yet drive the daemon); `scripts/build-ios.sh` producing a universal XCFramework; `docs/architecture/ios.md`; `make ios-check` smoke target.
+- **Out:** NEPacketTunnelProvider Swift extension, Xcode app project, real packet flow, relay accept loop, discovery on iOS. Those belong to Plan 2 (Milestones 2–4) and Plan 3 (Milestone 5). See "Follow-up plans" at the bottom.
+- **Out:** The `pim-daemon` and `pim-cli` binary crates stay Linux/macOS-only — we do **not** try to make them compile for iOS. Only library crates need to be iOS-clean.
+
+**Prerequisites the executor must confirm before Task 1:**
+- `xcode-select -p` returns a Developer directory.
+- `rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios` completes.
+- Working directory is a fresh worktree of the repo on a branch like `ios-foundation`.
+
+---
+
+## File Structure
+
+Files created:
+- `docs/architecture/ios.md` — architecture decision record.
+- `crates/pim-ios-ffi/Cargo.toml`
+- `crates/pim-ios-ffi/src/lib.rs` — three C-ABI entry points + a test.
+- `crates/pim-ios-ffi/include/pim_ios_ffi.h` — hand-written C header consumed by Swift.
+- `scripts/build-ios.sh` — cross-compile Rust for the three iOS triples and produce `target/ios/PimCore.xcframework`.
+
+Files modified:
+- `Cargo.toml` (workspace root) — add `pim-ios-ffi` to `members` + `workspace.dependencies`.
+- `crates/pim-tun/src/lib.rs` — add iOS branch to the `platform` module.
+- `crates/pim-bluetooth/src/lib.rs` — gate Linux-only code so iOS builds a no-op stub.
+- `crates/pim-wifidirect/src/lib.rs` — gate Linux-only code the same way.
+- `crates/pim-wifidirect/src/wpa_cli.rs` — gate Linux-only code.
+- `crates/pim-wifidirect/src/group.rs` — gate Linux-only code.
+- `Makefile` — add `ios-check` target.
+- `README.md` — add a short iOS section pointing at `docs/architecture/ios.md`.
+
+Each library crate keeps one responsibility; the iOS gates are mechanical stubs that mirror the existing `#[cfg(not(any(target_os = "linux", target_os = "macos")))]` block in `pim-tun`.
+
+---
+
+## Task 1: Architecture decision document
+
+**Files:**
+- Create: `docs/architecture/ios.md`
+
+- [ ] **Step 1: Write `docs/architecture/ios.md`**
+
+```markdown
+# iOS Target Architecture
+
+## Status
+
+Accepted — 2026-04-24. Resolves Milestone 1 of issue #70.
+
+## Context
+
+`pim-daemon` integrates with the host through Linux (`/dev/net/tun`, `iptables`,
+`ip route`, `wpa_cli`, `bluetoothctl`) and macOS (`utunN` via `SYSPROTO_CONTROL`,
+`ifconfig`, `route`). None of those surfaces exist on iOS:
+
+- A user-space process cannot open `/dev/net/tun` or `SYSPROTO_CONTROL`. Packet
+  IO is only available to a **Packet Tunnel Provider** extension, via
+  `NEPacketTunnelFlow.readPackets` / `writePackets`.
+- The extension process is sandboxed and memory-limited (≈ 50 MB on iOS 15+,
+  and real-world reports show sub-15 MB failures on some iOS 17.x patch
+  versions — we design for 15 MB).
+- Routing is declared once via `NEPacketTunnelNetworkSettings.IPv4Settings`
+  (`includedRoutes` / `excludedRoutes` / `mtu`); there is no runtime `ip route`
+  equivalent.
+- Wi-Fi Direct (IEEE 802.11 P2P) is not exposed on iOS; Bluetooth PAN is not
+  exposed to third-party apps. Proximity transports must be rebuilt on
+  `MultipeerConnectivity` or plain Bonjour + `Network.framework`.
+- Gateway/NAT mode is explicitly a non-goal — `iptables` has no iOS analogue.
+
+## Decision
+
+PIM on iOS is split into three layers:
+
+1. **Rust core (unchanged crates)** — `pim-core`, `pim-crypto`, `pim-protocol`,
+   `pim-routing`, `pim-transport`, `pim-discovery`, `pim-gateway`. These are
+   platform-independent and compile for `aarch64-apple-ios` with no changes
+   beyond dependency audits.
+
+2. **Rust platform glue** — `pim-tun`, `pim-bluetooth`, `pim-wifidirect`. Each
+   gains an `#[cfg(target_os = "ios")]` branch that either returns
+   `TunError::Unavailable`/equivalent or is a no-op stub. Host integration
+   code (shell-outs to `ip`, `bluetoothctl`, `wpa_cli`) stays compiled out on
+   iOS.
+
+3. **Rust ↔ Swift bridge** — new crate `pim-ios-ffi` (crate-type `staticlib`,
+   `cdylib`). It exposes a tiny opaque-handle C ABI:
+   - `pim_ffi_version() -> *const c_char`
+   - `pim_ffi_start(config_json: *const c_char, err: *mut *mut c_char) -> *mut PimHandle`
+   - `pim_ffi_stop(handle: *mut PimHandle)`
+   The Swift side (lands in Plan 2) consumes a hand-written header and links
+   against the XCFramework produced by `scripts/build-ios.sh`.
+
+## Build pipeline
+
+`scripts/build-ios.sh`:
+
+1. Confirms `xcode-select -p` and required `rustup` targets.
+2. Runs `cargo build --release -p pim-ios-ffi --target aarch64-apple-ios`.
+3. Runs the same for `aarch64-apple-ios-sim` and `x86_64-apple-ios`.
+4. Uses `lipo -create` to fuse the two simulator static libs into one fat lib.
+5. Runs `xcodebuild -create-xcframework` with the device lib + fused simulator
+   lib + the `pim_ios_ffi.h` header, producing `target/ios/PimCore.xcframework`.
+
+## Binary crates
+
+`pim-daemon` and `pim-cli` stay Linux/macOS-only. We do not attempt to build
+them for iOS — a Packet Tunnel extension has no `main()` and does not run a
+daemon process in the traditional sense. Instead, Plan 2 introduces a
+`pim-runtime` library refactor that moves the event loop out of `pim-daemon`'s
+`main.rs` so the extension can drive it via `pim_ffi_start`.
+
+## What this plan does not decide
+
+- NEPacketTunnelFlow ↔ PacketIO bridging design (deferred to Plan 2).
+- Whether relay mode is viable under the 50 MB memory cap (Plan 3 benchmarks).
+- Whether discovery uses `MultipeerConnectivity`, Bonjour, or stays
+  static-peer-only on iOS (Plan 4).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/architecture/ios.md
+git commit -m "docs: record iOS target architecture decision (issue #70, milestone 1)"
+```
+
+---
+
+## Task 2: Prove the iOS targets are installed
+
+No file changes — this task gates the rest of the plan. If it fails, stop and tell the user.
+
+- [ ] **Step 1: Verify toolchain**
+
+Run:
+```bash
+xcode-select -p
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+rustup target list --installed | grep -E 'apple-ios'
+```
+
+Expected: the last command prints all three targets on separate lines. If any target is missing, the plan cannot proceed; report it to the user rather than working around it.
+
+- [ ] **Step 2: Baseline iOS compile failures**
+
+Run:
+```bash
+cargo check --target aarch64-apple-ios -p pim-core -p pim-crypto -p pim-protocol -p pim-routing -p pim-transport -p pim-discovery -p pim-gateway 2>&1 | tail -40
+```
+
+Expected: succeeds (these crates already have no OS-specific code). Note the command and output — it becomes the regression baseline for Task 10.
+
+Run:
+```bash
+cargo check --target aarch64-apple-ios -p pim-tun -p pim-bluetooth -p pim-wifidirect 2>&1 | tail -40
+```
+
+Expected: **fails** with errors like `cannot find function do_ioctl` on `pim-tun`, shell-out references on the other two. Record the failing crates — Tasks 3–5 fix each one.
+
+---
+
+## Task 3: Gate pim-tun for iOS
+
+**Files:**
+- Modify: `crates/pim-tun/src/lib.rs:749-796`
+
+`pim-tun` already has a `#[cfg(not(any(target_os = "linux", target_os = "macos")))]` stub module. We make it explicit for iOS so the `TunError::Unavailable` path is tested, and we add a test that the crate at least compiles on iOS.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the top-level `#[cfg(test)] mod tests` block at `crates/pim-tun/src/lib.rs`:
+
+```rust
+    #[cfg(target_os = "ios")]
+    #[tokio::test]
+    async fn ios_stub_reports_unavailable() {
+        let err = TunInterface::create("utun0").unwrap_err();
+        assert!(matches!(err, TunError::Unavailable));
+    }
+```
+
+Add the `tokio` test-dependency feature. Modify `crates/pim-tun/Cargo.toml`:
+
+```toml
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
+```
+
+- [ ] **Step 2: Run test on Linux/macOS — it should be compiled out**
+
+Run: `cargo test -p pim-tun --quiet`
+Expected: existing tests pass; the new test is silently skipped because of the `cfg` gate (not yet running under iOS).
+
+- [ ] **Step 3: Extend the fallback platform module to name iOS explicitly**
+
+Change the existing line 749:
+```rust
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
+```
+to:
+```rust
+#[cfg(any(target_os = "ios", not(any(target_os = "linux", target_os = "macos"))))]
+```
+
+This makes the stub explicitly cover iOS while still catching other unsupported platforms.
+
+- [ ] **Step 4: Verify iOS compile**
+
+Run: `cargo check --target aarch64-apple-ios -p pim-tun`
+Expected: succeeds with no errors.
+
+Run: `cargo check -p pim-tun` (native build sanity)
+Expected: still succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/pim-tun/src/lib.rs crates/pim-tun/Cargo.toml
+git commit -m "feat(pim-tun): compile iOS stub returning Unavailable (issue #70)"
+```
+
+---
+
+## Task 4: Gate pim-bluetooth for iOS
+
+**Files:**
+- Modify: `crates/pim-bluetooth/src/lib.rs`
+
+`pim-bluetooth` shells out to `bluetoothctl`, runs `bt-network`, and inspects `bnepN` interfaces via sysfs — none available on iOS. The real constructor signature is:
+
+```rust
+// crates/pim-bluetooth/src/lib.rs:78-86
+pub fn new(
+    config: BluetoothConfig,
+    listen_port: u16,
+    static_targets: Vec<SocketAddr>,
+) -> Result<(Self, mpsc::Receiver<SocketAddr>), BluetoothError>
+```
+
+It already returns `Result`, so the iOS variant can simply return `Err(BluetoothError::Unavailable)` — we add that variant first. The crate's internal async helpers (`run`, `prepare_controller`, `discover_devices`, `pair_and_request_pan`, `interface_is_ready`, `discover_neighbor_targets`, `run_bt_network`) only run after a successful `new`, so the iOS build never reaches them — but they still need to compile, so we gate the Linux-only `impl` block.
+
+- [ ] **Step 1: Add the `Unavailable` error variant**
+
+Edit `crates/pim-bluetooth/src/lib.rs:38` (the `pub enum BluetoothError` block). Add, after the `CommandFailed` variant:
+
+```rust
+    /// Bluetooth is not supported on the host platform (e.g. iOS).
+    #[error("Bluetooth is not available on this platform")]
+    Unavailable,
+```
+
+- [ ] **Step 2: Write the failing iOS stub test**
+
+Append to the end of `crates/pim-bluetooth/src/lib.rs` (after the existing tests):
+
+```rust
+#[cfg(all(test, target_os = "ios"))]
+mod ios_stub_tests {
+    use super::*;
+
+    #[test]
+    fn new_returns_unavailable_on_ios() {
+        let cfg = pim_core::BluetoothConfig::default();
+        let result = BluetoothDiscovery::new(cfg, 9100, Vec::new());
+        match result {
+            Err(BluetoothError::Unavailable) => {}
+            _ => panic!("expected BluetoothError::Unavailable on iOS"),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Split the `impl BluetoothDiscovery` block**
+
+At `crates/pim-bluetooth/src/lib.rs:74`, change:
+
+```rust
+impl BluetoothDiscovery {
+```
+
+to:
+
+```rust
+#[cfg(not(target_os = "ios"))]
+impl BluetoothDiscovery {
+```
+
+Add at the bottom of the file (before the `#[cfg(test)] mod tests` block):
+
+```rust
+#[cfg(target_os = "ios")]
+impl BluetoothDiscovery {
+    /// iOS stub — Bluetooth PAN is not available to third-party apps.
+    pub fn new(
+        _config: BluetoothConfig,
+        _listen_port: u16,
+        _static_targets: Vec<SocketAddr>,
+    ) -> Result<(Self, mpsc::Receiver<SocketAddr>), BluetoothError> {
+        Err(BluetoothError::Unavailable)
+    }
+}
+```
+
+- [ ] **Step 4: Gate the `DEFAULT_*` path constants and command helpers**
+
+The constants `DEFAULT_SYSFS_ROOT`, `DEFAULT_IP_COMMAND`, `DEFAULT_BLUETOOTHCTL_COMMAND`, `DEFAULT_BT_NETWORK_COMMAND` (and any private free functions like `run_command`, `run_command_on` that shell out) must also be gated. Grep for them:
+
+```bash
+grep -nE '^(const DEFAULT_|fn run_command|fn parse_)' crates/pim-bluetooth/src/lib.rs
+```
+
+For each result, add `#[cfg(not(target_os = "ios"))]` immediately above the declaration. The iOS impl block added in Step 3 does not reference any of them.
+
+- [ ] **Step 5: Verify**
+
+```bash
+cargo check --target aarch64-apple-ios -p pim-bluetooth
+cargo test -p pim-bluetooth --quiet
+```
+
+Expected: first command finishes clean; second runs the existing tests (which are Linux/macOS conditional and may be skipped on macOS — do not regress the count).
+
+- [ ] **Step 4: Verify**
+
+Run: `cargo check --target aarch64-apple-ios -p pim-bluetooth`
+Expected: succeeds.
+
+Run: `cargo test -p pim-bluetooth --quiet`
+Expected: native tests still pass; iOS stub test is gated out.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/pim-bluetooth/src/lib.rs
+git commit -m "feat(pim-bluetooth): compile no-op iOS stub (issue #70)"
+```
+
+---
+
+## Task 5: Gate pim-wifidirect for iOS
+
+**Files:**
+- Modify: `crates/pim-wifidirect/src/lib.rs`
+- Modify: `crates/pim-wifidirect/src/wpa_cli.rs`
+- Modify: `crates/pim-wifidirect/src/group.rs`
+
+The relevant real signatures:
+
+```rust
+// crates/pim-wifidirect/src/lib.rs:68
+pub fn new(config: WifiDirectConfig, listen_port: u16) -> (Self, mpsc::Receiver<SocketAddr>)
+
+// crates/pim-wifidirect/src/lib.rs (later)
+pub async fn run(self, cancel: CancellationToken)
+```
+
+`new` is infallible and `run` already logs + returns early when `wpa_cli` is missing. Wi-Fi Direct is not exposed to iOS apps at all, so on iOS the crate can keep the same public signatures but (a) have `run` return immediately and (b) stop the `wpa_cli`/`group` modules' external-command code from being compiled.
+
+- [ ] **Step 1: Split `impl WifiDirectDiscovery` in `lib.rs`**
+
+At `crates/pim-wifidirect/src/lib.rs:68` change `impl WifiDirectDiscovery {` to:
+
+```rust
+#[cfg(not(target_os = "ios"))]
+impl WifiDirectDiscovery {
+```
+
+Add a parallel iOS-only impl at the bottom of `crates/pim-wifidirect/src/lib.rs` (before `#[cfg(test)] mod tests`):
+
+```rust
+#[cfg(target_os = "ios")]
+impl WifiDirectDiscovery {
+    /// iOS stub — Wi-Fi Direct is not available to third-party apps.
+    pub fn new(
+        config: WifiDirectConfig,
+        listen_port: u16,
+    ) -> (Self, tokio::sync::mpsc::Receiver<std::net::SocketAddr>) {
+        let (peer_tx, peer_rx) = tokio::sync::mpsc::channel(1);
+        let ctrl = crate::wpa_cli::WpaCliController::new(&config.interface);
+        (
+            Self { ctrl, config, listen_port, peer_tx },
+            peer_rx,
+        )
+    }
+
+    /// iOS stub — returns immediately; no Wi-Fi Direct is available.
+    pub async fn run(self, _cancel: tokio_util::sync::CancellationToken) {
+        tracing::debug!("Wi-Fi Direct unavailable on iOS — discovery is a no-op");
+    }
+}
+```
+
+Note: the iOS `new` still constructs a real `WpaCliController` because the struct field is typed. That is fine — the controller's `new` is infallible and does not actually talk to `wpa_supplicant` until a method is called. Confirm this in Step 2 before proceeding.
+
+- [ ] **Step 2: Verify WpaCliController::new is side-effect-free**
+
+```bash
+sed -n '31,60p' crates/pim-wifidirect/src/wpa_cli.rs
+```
+
+Expected: `pub fn new(iface: &str) -> Self` that just constructs the struct — no `Command::new` at this point. If it does shell out, gate it the same way as Step 3 below.
+
+- [ ] **Step 3: Gate the shell-out methods in `wpa_cli.rs`**
+
+Every method on `WpaCliController` that calls `Command::new` (`p2p_find`, `p2p_peers`, `p2p_connect`, `p2p_stop_find`, `list_interfaces`, etc.) should be gated:
+
+```bash
+grep -nE 'pub (async )?fn' crates/pim-wifidirect/src/wpa_cli.rs
+```
+
+For each `impl` block in the file that contains shell-outs, prefix it:
+
+```rust
+#[cfg(not(target_os = "ios"))]
+```
+
+Leave `impl WpaCliController { pub fn new(iface: &str) -> Self { ... } }` available on all platforms — split it into two blocks if necessary so the constructor stays unconditional.
+
+- [ ] **Step 4: Gate `group.rs` similarly**
+
+```bash
+grep -nE 'pub (async )?fn' crates/pim-wifidirect/src/group.rs
+```
+
+Methods on `WifiDirectGroup` that call `ip` / `ifconfig` / parse system state get the same `#[cfg(not(target_os = "ios"))]` treatment.
+
+- [ ] **Step 5: Verify**
+
+```bash
+cargo check --target aarch64-apple-ios -p pim-wifidirect
+cargo test -p pim-wifidirect --quiet
+```
+
+Expected: both green. Native test count unchanged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/pim-wifidirect/
+git commit -m "feat(pim-wifidirect): compile no-op iOS stub (issue #70)"
+```
+
+---
+
+## Task 6: Confirm remaining library crates compile for iOS
+
+No code changes expected. This task is a checkpoint that catches any cross-crate issue (missing dev-deps, incorrect `[target.'cfg(...)'.dependencies]`, etc.) before the FFI crate is introduced.
+
+- [ ] **Step 1: Run the full iOS library build**
+
+```bash
+cargo check --target aarch64-apple-ios \
+  -p pim-core -p pim-crypto -p pim-protocol -p pim-routing \
+  -p pim-transport -p pim-discovery -p pim-gateway \
+  -p pim-tun -p pim-bluetooth -p pim-wifidirect 2>&1 | tail -30
+```
+
+Expected: `Finished ...` with no errors.
+
+- [ ] **Step 2: Same for the simulator target**
+
+```bash
+cargo check --target aarch64-apple-ios-sim \
+  -p pim-core -p pim-crypto -p pim-protocol -p pim-routing \
+  -p pim-transport -p pim-discovery -p pim-gateway \
+  -p pim-tun -p pim-bluetooth -p pim-wifidirect 2>&1 | tail -30
+```
+
+Expected: `Finished ...`.
+
+If a crate fails because one of its **dependencies** (e.g. `ed25519-dalek`, `nix`, `libc`) needs a feature gate, add the fix under its crate's `Cargo.toml` like:
+
+```toml
+[target.'cfg(target_os = "ios")'.dependencies]
+# nothing yet — but this is where iOS-only deps would go
+```
+
+and re-run. Do not commit until both targets are green.
+
+- [ ] **Step 3: Commit only if changes were required**
+
+```bash
+git add -p crates/
+git commit -m "chore: make library crates iOS-clean (issue #70)" || echo "no changes needed"
+```
+
+---
+
+## Task 7: Create pim-ios-ffi skeleton crate
+
+**Files:**
+- Create: `crates/pim-ios-ffi/Cargo.toml`
+- Create: `crates/pim-ios-ffi/src/lib.rs`
+- Create: `crates/pim-ios-ffi/include/pim_ios_ffi.h`
+- Modify: `Cargo.toml` (workspace root, `members` + `workspace.dependencies`)
+
+The crate exposes three C functions. `pim_ffi_start` and `pim_ffi_stop` are **stubs** in this plan — they allocate an opaque handle and free it. They do not yet drive the daemon; that is Plan 2.
+
+- [ ] **Step 1: Add the crate to the workspace**
+
+Edit `Cargo.toml` (workspace root). In the `members` array, after `"crates/pim-cli",`, add:
+
+```toml
+    "crates/pim-ios-ffi",
+```
+
+In the `[workspace.dependencies]` block, after `pim-wifidirect = { path = "crates/pim-wifidirect" }`, add:
+
+```toml
+pim-ios-ffi = { path = "crates/pim-ios-ffi" }
+```
+
+- [ ] **Step 2: Create `crates/pim-ios-ffi/Cargo.toml`**
+
+```toml
+[package]
+name = "pim-ios-ffi"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+name = "pim_ios_ffi"
+# `staticlib` is what Xcode will link against inside the XCFramework; `rlib`
+# lets the crate be depended on by other Rust code (tests, future runtime).
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+pim-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+# (no dev deps yet — the handle-lifecycle test is sync)
+```
+
+- [ ] **Step 3: Write the failing test**
+
+Create `crates/pim-ios-ffi/src/lib.rs`:
+
+```rust
+//! C ABI used by the iOS Packet Tunnel Provider extension to drive the PIM
+//! core. Plan 1 ships stubs only — lifecycle is wired up in Plan 2.
+
+use std::ffi::{c_char, CStr, CString};
+use std::ptr;
+
+/// Opaque handle returned by `pim_ffi_start`. Callers must treat the pointer
+/// as a black box and pass it back to `pim_ffi_stop` exactly once.
+pub struct PimHandle {
+    // Placeholder — Plan 2 replaces this with a tokio runtime and a
+    // DaemonState. Kept non-empty so the pointer identity is meaningful.
+    _private: (),
+}
+
+/// Returns a NUL-terminated string owned by the library describing the
+/// crate version. The caller must not free the returned pointer.
+#[no_mangle]
+pub extern "C" fn pim_ffi_version() -> *const c_char {
+    // Safety: the CStr is a static literal — its pointer lives forever.
+    const VERSION: &[u8] = concat!(env!("CARGO_PKG_VERSION"), "\0").as_bytes();
+    VERSION.as_ptr() as *const c_char
+}
+
+/// Allocate and return a new handle. In Plan 1 this only validates the
+/// config JSON; Plan 2 spawns the runtime.
+///
+/// # Safety
+/// `config_json` must be a NUL-terminated UTF-8 C string.
+/// If `err` is non-null and an error occurs, `*err` is set to a
+/// library-owned NUL-terminated UTF-8 string that the caller must free
+/// with `pim_ffi_free_string`.
+#[no_mangle]
+pub unsafe extern "C" fn pim_ffi_start(
+    config_json: *const c_char,
+    err: *mut *mut c_char,
+) -> *mut PimHandle {
+    if config_json.is_null() {
+        set_error(err, "config_json is null");
+        return ptr::null_mut();
+    }
+    let config_cstr = CStr::from_ptr(config_json);
+    let config_str = match config_cstr.to_str() {
+        Ok(s) => s,
+        Err(_) => {
+            set_error(err, "config_json is not valid UTF-8");
+            return ptr::null_mut();
+        }
+    };
+    // Validate shape: must parse as a JSON object. Plan 2 will feed this into
+    // `pim_core::Config` (after adding a JSON adaptor).
+    if let Err(e) = serde_json::from_str::<serde_json::Value>(config_str) {
+        set_error(err, &format!("invalid config JSON: {e}"));
+        return ptr::null_mut();
+    }
+    Box::into_raw(Box::new(PimHandle { _private: () }))
+}
+
+/// Release the handle returned by `pim_ffi_start`. Idempotent for null.
+///
+/// # Safety
+/// `handle` must be either null or a pointer returned by `pim_ffi_start`
+/// that has not yet been passed to `pim_ffi_stop`.
+#[no_mangle]
+pub unsafe extern "C" fn pim_ffi_stop(handle: *mut PimHandle) {
+    if handle.is_null() {
+        return;
+    }
+    drop(Box::from_raw(handle));
+}
+
+/// Free a string previously written to `*err` by `pim_ffi_start`.
+///
+/// # Safety
+/// `s` must be either null or a pointer previously written by this library.
+#[no_mangle]
+pub unsafe extern "C" fn pim_ffi_free_string(s: *mut c_char) {
+    if s.is_null() {
+        return;
+    }
+    drop(CString::from_raw(s));
+}
+
+unsafe fn set_error(err: *mut *mut c_char, msg: &str) {
+    if err.is_null() {
+        return;
+    }
+    let c = match CString::new(msg) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+    *err = c.into_raw();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+
+    #[test]
+    fn version_is_non_empty() {
+        let p = pim_ffi_version();
+        assert!(!p.is_null());
+        let s = unsafe { CStr::from_ptr(p) }.to_str().unwrap();
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn start_and_stop_round_trip() {
+        let cfg = CString::new(r#"{"node":{"name":"test"}}"#).unwrap();
+        let mut err: *mut c_char = ptr::null_mut();
+        let handle = unsafe { pim_ffi_start(cfg.as_ptr(), &mut err as *mut _) };
+        assert!(!handle.is_null(), "expected non-null handle, got err");
+        assert!(err.is_null(), "did not expect an error string");
+        unsafe { pim_ffi_stop(handle) };
+    }
+
+    #[test]
+    fn start_rejects_invalid_json() {
+        let cfg = CString::new("not valid json {{{").unwrap();
+        let mut err: *mut c_char = ptr::null_mut();
+        let handle = unsafe { pim_ffi_start(cfg.as_ptr(), &mut err as *mut _) };
+        assert!(handle.is_null());
+        assert!(!err.is_null());
+        let msg = unsafe { CStr::from_ptr(err) }.to_str().unwrap().to_string();
+        assert!(msg.contains("invalid config JSON"));
+        unsafe { pim_ffi_free_string(err) };
+    }
+
+    #[test]
+    fn stop_on_null_is_safe() {
+        unsafe { pim_ffi_stop(ptr::null_mut()) };
+    }
+}
+```
+
+- [ ] **Step 4: Run the test — it should fail because the crate does not yet exist in the workspace graph**
+
+Run: `cargo test -p pim-ios-ffi --quiet`
+Expected: either "could not find package" (if workspace edit wasn't saved) or compile errors if this is the first build. Re-run after Steps 1–3 are saved.
+
+- [ ] **Step 5: Make the test pass**
+
+Run: `cargo test -p pim-ios-ffi --quiet`
+Expected: 4 tests pass.
+
+- [ ] **Step 6: Create the hand-written C header**
+
+Create `crates/pim-ios-ffi/include/pim_ios_ffi.h`:
+
+```c
+#ifndef PIM_IOS_FFI_H
+#define PIM_IOS_FFI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Opaque handle — contents are private to the Rust side. */
+typedef struct PimHandle PimHandle;
+
+/* Returns a pointer to a library-owned NUL-terminated UTF-8 string.
+ * Do not free. Lifetime is the lifetime of the library. */
+const char *pim_ffi_version(void);
+
+/* Start the PIM runtime with the given JSON config.
+ * On success: returns a non-NULL PimHandle*.
+ * On failure: returns NULL and, if `err_out` is non-NULL, writes a
+ *             library-owned NUL-terminated UTF-8 string describing the
+ *             error that the caller must release with
+ *             pim_ffi_free_string(). */
+PimHandle *pim_ffi_start(const char *config_json, char **err_out);
+
+/* Stop and free a handle previously returned by pim_ffi_start.
+ * Passing NULL is a no-op. Passing the same handle twice is undefined. */
+void pim_ffi_stop(PimHandle *handle);
+
+/* Free an error string produced by pim_ffi_start. NULL is a no-op. */
+void pim_ffi_free_string(char *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PIM_IOS_FFI_H */
+```
+
+- [ ] **Step 7: Verify iOS cross-compile**
+
+```bash
+cargo build --release --target aarch64-apple-ios -p pim-ios-ffi
+cargo build --release --target aarch64-apple-ios-sim -p pim-ios-ffi
+```
+
+Expected: each produces `target/<triple>/release/libpim_ios_ffi.a`.
+
+Confirm with:
+```bash
+ls -lh target/aarch64-apple-ios/release/libpim_ios_ffi.a
+ls -lh target/aarch64-apple-ios-sim/release/libpim_ios_ffi.a
+```
+
+Expected: two files, each a few hundred KB to a few MB.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Cargo.toml crates/pim-ios-ffi/
+git commit -m "feat(pim-ios-ffi): add C ABI stub for iOS extension (issue #70)"
+```
+
+---
+
+## Task 8: Build the XCFramework
+
+**Files:**
+- Create: `scripts/build-ios.sh`
+
+`xcodebuild -create-xcframework` refuses duplicate architectures, so the two simulator triples must be fused with `lipo` before being fed in.
+
+- [ ] **Step 1: Write a verifiable script**
+
+Create `scripts/build-ios.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Build PimCore.xcframework from pim-ios-ffi for iOS device + simulator.
+# Resolves milestone 1 of issue #70.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+PKG="pim-ios-ffi"
+LIB="libpim_ios_ffi.a"
+PROFILE="release"
+OUT_DIR="target/ios"
+FRAMEWORK="${OUT_DIR}/PimCore.xcframework"
+HEADERS="crates/${PKG}/include"
+
+DEVICE_TRIPLE="aarch64-apple-ios"
+SIM_ARM_TRIPLE="aarch64-apple-ios-sim"
+SIM_X86_TRIPLE="x86_64-apple-ios"
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 \
+    || { echo "error: missing tool '$1'" >&2; exit 1; }
+}
+
+require_tool cargo
+require_tool lipo
+require_tool xcodebuild
+
+for triple in "$DEVICE_TRIPLE" "$SIM_ARM_TRIPLE" "$SIM_X86_TRIPLE"; do
+  if ! rustup target list --installed | grep -q "^${triple}$"; then
+    echo "error: rustup target ${triple} is not installed. Run:" >&2
+    echo "  rustup target add ${triple}" >&2
+    exit 1
+  fi
+done
+
+echo "==> building ${PKG} for ${DEVICE_TRIPLE}"
+cargo build --release -p "${PKG}" --target "${DEVICE_TRIPLE}"
+
+echo "==> building ${PKG} for ${SIM_ARM_TRIPLE}"
+cargo build --release -p "${PKG}" --target "${SIM_ARM_TRIPLE}"
+
+echo "==> building ${PKG} for ${SIM_X86_TRIPLE}"
+cargo build --release -p "${PKG}" --target "${SIM_X86_TRIPLE}"
+
+SIM_FAT_DIR="${OUT_DIR}/sim-fat"
+mkdir -p "${SIM_FAT_DIR}"
+echo "==> fusing simulator arches with lipo"
+lipo -create \
+  "target/${SIM_ARM_TRIPLE}/${PROFILE}/${LIB}" \
+  "target/${SIM_X86_TRIPLE}/${PROFILE}/${LIB}" \
+  -output "${SIM_FAT_DIR}/${LIB}"
+
+echo "==> assembling XCFramework"
+rm -rf "${FRAMEWORK}"
+xcodebuild -create-xcframework \
+  -library "target/${DEVICE_TRIPLE}/${PROFILE}/${LIB}" -headers "${HEADERS}" \
+  -library "${SIM_FAT_DIR}/${LIB}"                    -headers "${HEADERS}" \
+  -output "${FRAMEWORK}"
+
+echo "==> done: ${FRAMEWORK}"
+```
+
+- [ ] **Step 2: Static-check the script syntax**
+
+```bash
+bash -n scripts/build-ios.sh
+```
+
+Expected: exits 0 with no output.
+
+- [ ] **Step 3: Mark it executable and run end-to-end**
+
+```bash
+chmod +x scripts/build-ios.sh
+./scripts/build-ios.sh
+```
+
+Expected: prints each `==>` line and finishes with `==> done: target/ios/PimCore.xcframework`. Then:
+
+```bash
+ls target/ios/PimCore.xcframework
+```
+
+Expected: shows `Info.plist`, `ios-arm64`, and `ios-arm64_x86_64-simulator` directories.
+
+- [ ] **Step 4: Exclude build artefacts from git**
+
+Append to `.gitignore` if the entry is not already present:
+
+```
+target/ios/
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/build-ios.sh .gitignore
+git commit -m "build: script to assemble PimCore.xcframework for iOS (issue #70)"
+```
+
+---
+
+## Task 9: Make target for iOS smoke-check
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Add the target**
+
+Append to `Makefile` (after the last `.PHONY` line):
+
+```make
+# ── iOS ───────────────────────────────────────────────────────────────────────
+
+.PHONY: ios-check ios-xcframework
+
+IOS_TARGETS := aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+IOS_CRATES  := pim-core pim-crypto pim-protocol pim-routing pim-transport \
+               pim-discovery pim-gateway pim-tun pim-bluetooth pim-wifidirect \
+               pim-ios-ffi
+
+ios-check:
+	@for t in $(IOS_TARGETS); do \
+	  echo "==> cargo check --target $$t"; \
+	  cargo check --target $$t $(addprefix -p ,$(IOS_CRATES)) || exit 1; \
+	done
+
+ios-xcframework:
+	bash scripts/build-ios.sh
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+make ios-check
+```
+
+Expected: three `==> cargo check --target ...` banners, each followed by a `Finished` line from cargo. Exit code 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Makefile
+git commit -m "build: add make ios-check and make ios-xcframework (issue #70)"
+```
+
+---
+
+## Task 10: README pointer
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add an iOS subsection under an existing section**
+
+Locate the `## Current Scope` section and, immediately below it, add:
+
+```markdown
+## iOS Support (in progress)
+
+iOS support is tracked in [issue #70](https://github.com/Astervia/proximity-internet-mesh/issues/70).
+Milestone 1 (target architecture + cross-compile scaffolding) is resolved —
+see [docs/architecture/ios.md](docs/architecture/ios.md). Build locally with:
+
+```bash
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+make ios-check          # cross-compile sanity check
+make ios-xcframework    # produces target/ios/PimCore.xcframework
+```
+
+The Xcode app and packet-tunnel extension that consume `PimCore.xcframework`
+land in follow-up plans.
+```
+
+- [ ] **Step 2: Verify the README still renders**
+
+```bash
+head -40 README.md
+grep -n "iOS Support" README.md
+```
+
+Expected: the new section appears; the document is still a valid markdown file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): point at iOS foundation (issue #70, milestone 1)"
+```
+
+---
+
+## Task 11: Final end-to-end validation
+
+No file changes. This task is the acceptance test for the plan.
+
+- [ ] **Step 1: Clean workspace + full build**
+
+```bash
+cargo clean
+cargo test --workspace --quiet
+```
+
+Expected: all existing tests still pass, including the four new `pim-ios-ffi` tests. Nothing broken on Linux/macOS.
+
+- [ ] **Step 2: iOS cross-compile smoke**
+
+```bash
+make ios-check
+```
+
+Expected: three targets × all library crates check cleanly.
+
+- [ ] **Step 3: XCFramework build**
+
+```bash
+make ios-xcframework
+file target/ios/PimCore.xcframework/ios-arm64/libpim_ios_ffi.a
+file target/ios/PimCore.xcframework/ios-arm64_x86_64-simulator/libpim_ios_ffi.a
+```
+
+Expected: the first is `current ar archive random library` for arm64, the second is a fat archive with arm64 + x86_64 slices.
+
+- [ ] **Step 4: Acceptance sign-off**
+
+The plan is complete when:
+1. `cargo test --workspace` is green on the host.
+2. `make ios-check` is green.
+3. `make ios-xcframework` produces `target/ios/PimCore.xcframework` with both slices.
+4. `docs/architecture/ios.md` exists.
+5. No `pim-daemon` or `pim-cli` regression (those binaries still build on Linux + macOS).
+
+Open the PR referencing issue #70 and mark **Milestone 1 only** — list milestones 2–6 as open for follow-up plans.
+
+---
+
+## Follow-up plans (do not include in Plan 1)
+
+The issue is an umbrella covering six milestones. Plan 1 resolves Milestone 1
+and unblocks the rest. Each of these should be written and executed as its
+own plan, in order:
+
+- **Plan 2 — Milestones 2 + 3 + 4: client-mode dataplane.** Introduce a
+  `PacketIO` trait in `pim-tun` (async `read_packet` / `write_packet`), refactor
+  `pim-daemon` into a `pim-runtime` library + thin binary, extend
+  `pim-ios-ffi` with `read/write` callbacks that the Swift extension registers,
+  add the Xcode app + `NEPacketTunnelProvider` extension target,
+  `NEPacketTunnelNetworkSettings` with `includedRoutes`, and a one-hop e2e
+  integration test routing `curl` through a test relay.
+- **Plan 3 — Milestone 5: relay-mode dataplane.** Add an accept loop inside
+  the extension (documenting iOS backgrounding constraints), benchmark
+  memory against the 50 MB cap, and ship a relay-mode test lab.
+- **Plan 4 — Milestone 6: discovery + integrations + test coverage.** Add
+  a `MultipeerConnectivity` or Bonjour-backed discovery adapter feature-gated
+  for iOS, an iOS-focused integration test harness, and CI coverage for
+  `make ios-xcframework`.

--- a/scripts/build-ios.sh
+++ b/scripts/build-ios.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Build PimCore.xcframework from pim-ios-ffi for iOS device + simulator.
+# Resolves milestone 1 of issue #70.
+#
+# Steps:
+#   1. Preflight: xcode-select, rustup targets, required tools.
+#   2. cargo build --release for aarch64-apple-ios, aarch64-apple-ios-sim,
+#      x86_64-apple-ios.
+#   3. lipo -create the two simulator slices into one fat simulator lib.
+#   4. xcodebuild -create-xcframework with the device lib + fat sim lib
+#      + the pim_ios_ffi.h header, producing target/ios/PimCore.xcframework.
+#
+# Usage:
+#   scripts/build-ios.sh
+#
+# Environment:
+#   Requires full Xcode (not just Command Line Tools) for step 4.
+#   Run `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
+#   after installing Xcode from the App Store.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+PKG="pim-ios-ffi"
+LIB="libpim_ios_ffi.a"
+PROFILE="release"
+OUT_DIR="target/ios"
+FRAMEWORK="${OUT_DIR}/PimCore.xcframework"
+HEADERS="crates/${PKG}/include"
+
+DEVICE_TRIPLE="aarch64-apple-ios"
+SIM_ARM_TRIPLE="aarch64-apple-ios-sim"
+SIM_X86_TRIPLE="x86_64-apple-ios"
+
+require_tool() {
+  command -v "$1" >/dev/null 2>&1 \
+    || { echo "error: required tool '$1' is not on PATH" >&2; exit 1; }
+}
+
+require_tool cargo
+require_tool lipo
+require_tool xcodebuild
+
+# xcodebuild comes with Command Line Tools but `-create-xcframework`
+# requires a full Xcode install. Fail fast with a pointer, not a cryptic
+# xcode-select error 10 lines in.
+DEV_DIR="$(xcode-select -p 2>/dev/null || true)"
+if [[ "${DEV_DIR}" == "/Library/Developer/CommandLineTools" ]]; then
+  echo "error: xcode-select currently points at Command Line Tools only." >&2
+  echo "       xcodebuild -create-xcframework needs full Xcode." >&2
+  echo "       Install Xcode from the App Store and run:" >&2
+  echo "         sudo xcode-select -s /Applications/Xcode.app/Contents/Developer" >&2
+  exit 1
+fi
+
+for triple in "$DEVICE_TRIPLE" "$SIM_ARM_TRIPLE" "$SIM_X86_TRIPLE"; do
+  if ! rustup target list --installed | grep -q "^${triple}$"; then
+    echo "error: rustup target ${triple} is not installed. Run:" >&2
+    echo "  rustup target add ${triple}" >&2
+    exit 1
+  fi
+done
+
+echo "==> building ${PKG} for ${DEVICE_TRIPLE}"
+cargo build --release -p "${PKG}" --target "${DEVICE_TRIPLE}"
+
+echo "==> building ${PKG} for ${SIM_ARM_TRIPLE}"
+cargo build --release -p "${PKG}" --target "${SIM_ARM_TRIPLE}"
+
+echo "==> building ${PKG} for ${SIM_X86_TRIPLE}"
+cargo build --release -p "${PKG}" --target "${SIM_X86_TRIPLE}"
+
+SIM_FAT_DIR="${OUT_DIR}/sim-fat"
+mkdir -p "${SIM_FAT_DIR}"
+echo "==> fusing simulator arches with lipo -> ${SIM_FAT_DIR}/${LIB}"
+lipo -create \
+  "target/${SIM_ARM_TRIPLE}/${PROFILE}/${LIB}" \
+  "target/${SIM_X86_TRIPLE}/${PROFILE}/${LIB}" \
+  -output "${SIM_FAT_DIR}/${LIB}"
+
+echo "==> assembling XCFramework -> ${FRAMEWORK}"
+rm -rf "${FRAMEWORK}"
+xcodebuild -create-xcframework \
+  -library "target/${DEVICE_TRIPLE}/${PROFILE}/${LIB}" -headers "${HEADERS}" \
+  -library "${SIM_FAT_DIR}/${LIB}"                    -headers "${HEADERS}" \
+  -output "${FRAMEWORK}"
+
+echo "==> done: ${FRAMEWORK}"


### PR DESCRIPTION
## Summary

Resolves **milestone 1** of #70: iOS target architecture, cross-compile scaffolding, and the FFI skeleton the future `NEPacketTunnelProvider` extension will link against.

- Every library crate (`pim-core`, `pim-crypto`, `pim-protocol`, `pim-routing`, `pim-transport`, `pim-discovery`, `pim-gateway`, `pim-tun`, `pim-bluetooth`, `pim-wifidirect`) now compiles clean for `aarch64-apple-ios`, `aarch64-apple-ios-sim`, and `x86_64-apple-ios`.
- New crate `pim-ios-ffi` (`staticlib` + `rlib`) exposes a minimal opaque-handle C ABI: `pim_ffi_version`, `pim_ffi_start`, `pim_ffi_stop`, `pim_ffi_free_string`. Plan 1 scaffolds lifecycle only — `start` validates config JSON shape but does not yet drive the daemon (that's milestone 2).
- `scripts/build-ios.sh` + `make ios-check` / `make ios-xcframework` build the 3 iOS triples with `cargo build`, fuse simulator slices with `lipo`, and assemble `target/ios/PimCore.xcframework` with `xcodebuild -create-xcframework`.
- Architecture decision record at [`docs/architecture/ios.md`](https://github.com/Astervia/proximity-internet-mesh/blob/feat/ios-foundation-issue-70/docs/architecture/ios.md) documents why `NEPacketTunnelProvider` replaces `/dev/net/tun` / `utun`, why gateway mode is out of scope, why Wi-Fi Direct / Bluetooth PAN are unavailable on iOS, and which milestones belong to follow-up plans.
- Implementation plan checked in at [`docs/superpowers/plans/2026-04-24-ios-foundation.md`](https://github.com/Astervia/proximity-internet-mesh/blob/feat/ios-foundation-issue-70/docs/superpowers/plans/2026-04-24-ios-foundation.md).

## What this PR does **not** do (by design)

Milestones 2–6 of #70 remain open. They need separate PRs:

- **Milestone 2–4 (client dataplane):** `PacketIO` trait in `pim-tun`, refactor `pim-daemon` into `pim-runtime` lib + thin binary, read/write callbacks in `pim-ios-ffi`, Xcode app + `NEPacketTunnelProvider` extension, `NEPacketTunnelNetworkSettings` with `includedRoutes`, one-hop E2E integration test.
- **Milestone 5 (relay dataplane):** accept loop inside the extension, memory benchmark against the 50 MB cap.
- **Milestone 6 (discovery + tests):** `MultipeerConnectivity` or Bonjour adapter, CI coverage for `make ios-xcframework`.

`pim-daemon` and `pim-cli` stay Linux/macOS-only — a Packet Tunnel extension has no `main()`.

## Test plan

- [x] `cargo test --workspace` — **358 tests pass, 0 fail** (6 new in `pim-ios-ffi`, 3 in `pim-tun` including an iOS regression test).
- [x] `make ios-check` — every library crate checks clean on all 3 iOS triples (device + arm64 sim + x86_64 sim).
- [x] `cargo build --release --target aarch64-apple-ios -p pim-ios-ffi` + the two simulator triples — produces three `libpim_ios_ffi.a` archives (~17 MB each).
- [x] `scripts/build-ios.sh` syntax-checked with `bash -n` and preflight verified (fails with a clear pointer when `xcode-select` is on CLT-only).
- [ ] `make ios-xcframework` — **needs full Xcode**; not runnable on this CI step yet. Confirmed the script's preflight rejects CLT-only with a clean error.
- [x] Existing Docker test matrix untouched — no changes to `pim-daemon` logic; only cfg gates and a new leaf crate.

Closes part of #70 (milestone 1 only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)