### PR TITLE
🛡️ Sentinel: [security improvement] Secure log file permissions

### DIFF
--- a/crates/pim-cli/src/main.rs
+++ b/crates/pim-cli/src/main.rs
@@ -322,9 +322,16 @@ fn cmd_up(config: PathBuf, pid_file: PathBuf, detach: bool, log_file: PathBuf) -
     let daemon_bin = find_daemon_binary()?;
 
     if detach {
-        let log = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
+        let mut options = std::fs::OpenOptions::new();
+        options.create(true).append(true);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o640);
+        }
+
+        let log = options
             .open(&log_file)
             .with_context(|| format!("failed to open log file: {}", log_file.display()))?;
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Log files created by `pim-cli` for the detached daemon were using default `umask` permissions, which could leave them world-readable, potentially exposing sensitive peer identities, IPs, or network state.
🎯 **Impact:** Local Information Disclosure. Any other user on the system could potentially read sensitive runtime logs of the PIM daemon.
🔧 **Fix:** Explicitly configure `std::fs::OpenOptions` to use `0o640` (owner read/write, group read) permissions on Unix systems via `std::os::unix::fs::OpenOptionsExt` when creating the detached log file.
✅ **Verification:** Compiled and verified the workspace tests passed.

Ref: `.jules/sentinel.md` patterns for secure file permissions.

---
*PR created automatically by Jules for task [5747849163283137738](https://jules.google.com/task/5747849163283137738) started by @Rfluid*