### PR TITLE
fix(cli): emit complete schema in `pim config generate`

### DIFF
--- a/crates/pim-cli/src/commands/config.rs
+++ b/crates/pim-cli/src/commands/config.rs
@@ -53,7 +53,26 @@ pub(crate) fn cmd_config_generate(
     Ok(())
 }
 
-// ── `pim route` ──────────────────────────────────────────────────────────────
+// ── Template renderer ────────────────────────────────────────────────────────
+//
+// The output is a complete, parseable `pim.toml` whose layout mirrors
+// `pim-core/src/config/model.rs` 1:1 — every field defined on `Config`
+// (and its sub-structs) appears here, either with its real value or as
+// a commented `# key = …` line with an inline explanation. Tests assert
+// the rendered string round-trips through `Config::from_toml_str`.
+//
+// Conventions:
+//   - Active values are written verbatim.
+//   - Optional fields (`Option<T>` in the model — `mesh_ipv6`,
+//     `shared_key`, `dhcp_range`, `dhcp_dns`) are emitted commented-out
+//     with a one-line explanation of how to enable them.
+//   - Sections that are role-conditional (`[gateway]`) are emitted as
+//     a commented placeholder when the role is absent — preserving the
+//     existing CLI ergonomic where users uncomment-to-enable.
+//   - `[bluetooth]` and `[wifi_direct]` are emitted as full blocks with
+//     `enabled = false` (matching `BluetoothConfig::default()` /
+//     `WifiDirectConfig::default()` in pim-core), so all knobs are
+//     visible and users edit a single toggle to turn them on.
 
 pub(crate) fn render_config_template(roles: &[NodeRole], override_name: Option<&str>) -> String {
     let roles = unique_roles(roles);
@@ -71,216 +90,516 @@ pub(crate) fn render_config_template(roles: &[NodeRole], override_name: Option<&
         .collect::<Vec<_>>()
         .join(", ");
 
-    let mut out = String::new();
-    push_line(&mut out, "# Proximity Internet Mesh configuration template");
-    push_line(&mut out, &format!("# Roles enabled: {roles_label}"));
+    let mut out = String::with_capacity(8 * 1024);
+
+    push_header(&mut out, &roles_label);
+    push_node(&mut out, &node_name);
+    push_interface(&mut out, mesh_ip);
+    push_discovery(&mut out);
+    push_transport(&mut out);
+    push_routing(&mut out);
+    push_gateway(&mut out, is_gateway);
+    push_relay(&mut out, is_relay, is_gateway);
+    push_security(&mut out);
+    push_bluetooth(&mut out, &node_name);
+    push_wifi_direct(&mut out);
+    push_static_peers(&mut out, peer_example, is_client, is_relay, is_gateway);
+
+    out
+}
+
+// ── Section writers ──────────────────────────────────────────────────────────
+
+fn push_header(out: &mut String, roles_label: &str) {
+    push_line(out, "# Proximity Internet Mesh configuration template");
+    push_line(out, &format!("# Roles enabled: {roles_label}"));
     push_line(
-        &mut out,
+        out,
         "# Edit the values below, save the file, then start the daemon with:",
     );
-    push_line(&mut out, "#   sudo pim up --config /etc/pim/pim.toml");
-    push_blank(&mut out);
+    push_line(out, "#   sudo pim up --config /etc/pim/pim.toml");
+    push_blank(out);
+}
 
-    push_line(&mut out, "[node]");
+fn push_node(out: &mut String, node_name: &str) {
+    push_line(out, "[node]");
     push_line(
-        &mut out,
-        "# Human-readable node name used in logs and status output.",
+        out,
+        "# Human-readable node name shown in logs, status output, and to other peers.",
     );
-    push_line(&mut out, &format!("name = {:?}", node_name));
+    push_line(out, &format!("name = {:?}", node_name));
     push_line(
-        &mut out,
-        "# Writable state directory for generated keys and runtime data.",
+        out,
+        "# Writable directory for the Ed25519 node key, the trust store, and runtime state.",
     );
-    push_line(&mut out, "data_dir = \"/var/lib/pim\"");
-    push_blank(&mut out);
+    push_line(out, "data_dir = \"/var/lib/pim\"");
+    push_blank(out);
+}
 
-    push_line(&mut out, "[interface]");
+fn push_interface(out: &mut String, mesh_ip: &str) {
+    push_line(out, "[interface]");
     push_line(
-        &mut out,
+        out,
         "# TUN interface exposed by the daemon. Linux commonly uses pim0; macOS must use a utunN name.",
     );
-    push_line(&mut out, &format!("name = {:?}", default_interface_name()));
+    push_line(out, &format!("name = {:?}", default_interface_name()));
     push_line(
-        &mut out,
+        out,
         "# Use a static CIDR for predictable labs or \"auto\" to request an address from a gateway.",
     );
-    push_line(&mut out, &format!("mesh_ip = {:?}", mesh_ip));
+    push_line(out, &format!("mesh_ip = {:?}", mesh_ip));
     push_line(
-        &mut out,
+        out,
         "# Optional static IPv6 ULA on the mesh TUN. Leave commented to run IPv4-only.",
     );
-    push_line(&mut out, "# mesh_ipv6 = \"fd77::10/64\"");
+    push_line(out, "# mesh_ipv6 = \"fd77::10/64\"");
     push_line(
-        &mut out,
+        out,
         "# Keep this aligned with the mesh MTU expected by other peers.",
     );
-    push_line(&mut out, "mtu = 1400");
-    push_blank(&mut out);
+    push_line(out, "mtu = 1400");
+    push_blank(out);
+}
 
-    push_line(&mut out, "[discovery]");
+fn push_discovery(out: &mut String) {
+    push_line(out, "[discovery]");
     push_line(
-        &mut out,
-        "# Broadcast-based peer discovery. Static peers below are still the simplest way to start.",
-    );
-    push_line(&mut out, "broadcast_interval_ms = 5000");
-    push_line(&mut out, "peer_timeout_ms = 30000");
-    push_line(
-        &mut out,
-        "# Optional 64-hex-character group key. When set, only nodes with the same key can decode discovery broadcasts.",
+        out,
+        "# UDP-broadcast peer discovery (`PIMD` advertisements on `port`). Limited to a single",
     );
     push_line(
-        &mut out,
+        out,
+        "# broadcast domain — cross-subnet topologies need static [[peers]] entries.",
+    );
+    push_line(
+        out,
+        "# Set `enabled = false` to rely entirely on static peers below.",
+    );
+    push_line(out, "enabled = true");
+    push_line(
+        out,
+        "# UDP port used for sending and receiving discovery broadcasts.",
+    );
+    push_line(out, "port = 9101");
+    push_line(
+        out,
+        "# How often this node broadcasts its presence (milliseconds).",
+    );
+    push_line(out, "broadcast_interval_ms = 5000");
+    push_line(
+        out,
+        "# How long a previously-seen peer remains in the table before expiry (milliseconds).",
+    );
+    push_line(out, "peer_timeout_ms = 30000");
+    push_line(
+        out,
+        "# Auto-connect to discovered peers advertising relay capability.",
+    );
+    push_line(out, "connect_relays = true");
+    push_line(
+        out,
+        "# Auto-connect to discovered peers advertising gateway capability.",
+    );
+    push_line(out, "connect_gateways = true");
+    push_line(
+        out,
+        "# Optional 64-hex-character group key. When set, only nodes with the same key can",
+    );
+    push_line(
+        out,
+        "# decode discovery broadcasts (gates discovery, NOT transport security).",
+    );
+    push_line(
+        out,
         "# shared_key = \"00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff\"",
     );
-    push_blank(&mut out);
+    push_blank(out);
+}
 
-    push_line(&mut out, "[transport]");
+fn push_transport(out: &mut String) {
+    push_line(out, "[transport]");
     push_line(
-        &mut out,
-        "# Transport backend implemented in this repository today.",
+        out,
+        "# Wire transport backend. Currently \"tcp\" is the only supported value.",
     );
-    push_line(&mut out, "type = \"tcp\"");
+    push_line(out, "type = \"tcp\"");
     push_line(
-        &mut out,
+        out,
         "# TCP port this node listens on for direct peer sessions.",
     );
-    push_line(&mut out, "listen_port = 9100");
-    push_blank(&mut out);
-
-    push_line(&mut out, "[routing]");
+    push_line(out, "listen_port = 9100");
     push_line(
-        &mut out,
+        out,
+        "# Maximum reconnect attempts per peer before giving up.",
+    );
+    push_line(out, "max_reconnect_attempts = 20");
+    push_line(
+        out,
+        "# Timeout for outbound TCP connect attempts (milliseconds).",
+    );
+    push_line(out, "connect_timeout_ms = 3000");
+    push_blank(out);
+}
+
+fn push_routing(out: &mut String) {
+    push_line(out, "[routing]");
+    push_line(
+        out,
         "# Distance-vector settings used for route propagation and expiry.",
     );
-    push_line(&mut out, "max_hops = 10");
-    push_line(&mut out, "algorithm = \"distance-vector\"");
-    push_line(&mut out, "route_expiry_s = 300");
-    push_blank(&mut out);
+    push_line(
+        out,
+        "# `max_hops` bounds how far a route advertisement can travel.",
+    );
+    push_line(out, "max_hops = 10");
+    push_line(out, "algorithm = \"distance-vector\"");
+    push_line(
+        out,
+        "# How long learned routes survive before being re-advertised (seconds).",
+    );
+    push_line(out, "route_expiry_s = 300");
+    push_blank(out);
+}
 
+fn push_gateway(out: &mut String, is_gateway: bool) {
     if is_gateway {
-        push_line(&mut out, "[gateway]");
+        push_line(out, "[gateway]");
         push_line(
-            &mut out,
+            out,
             "# Enable NAT and internet egress on a node with upstream connectivity.",
         );
-        push_line(&mut out, "enabled = true");
         push_line(
-            &mut out,
+            out,
+            "# A gateway is implicitly also a relay and a client (capability bits 0x07).",
+        );
+        push_line(out, "enabled = true");
+        push_line(
+            out,
             "# Replace this with the real internet-facing interface on the host.",
         );
         push_line(
-            &mut out,
+            out,
             &format!("nat_interface = {:?}", default_gateway_nat_interface()),
         );
         push_line(
-            &mut out,
+            out,
             "# Maximum concurrent gateway connection-tracking entries.",
         );
-        push_line(&mut out, "max_connections = 200");
+        push_line(out, "max_connections = 200");
     } else {
         push_line(
-            &mut out,
+            out,
             "# [gateway]  # Uncomment this section only on a node that should provide internet access.",
         );
-        push_line(&mut out, "# enabled = true");
+        push_line(out, "# enabled = true");
         push_line(
-            &mut out,
+            out,
             &format!("# nat_interface = {:?}", default_gateway_nat_interface()),
         );
-        push_line(&mut out, "# max_connections = 200");
+        push_line(out, "# max_connections = 200");
     }
-    push_blank(&mut out);
+    push_blank(out);
+}
 
-    push_line(&mut out, "[security]");
+fn push_relay(out: &mut String, is_relay: bool, is_gateway: bool) {
+    push_line(out, "[relay]");
     push_line(
-        &mut out,
+        out,
+        "# Relay nodes forward mesh frames for other peers in addition to originating their",
+    );
+    push_line(
+        out,
+        "# own (capability bits 0x03 = relay + client). Set false to run as client-only (0x01)",
+    );
+    push_line(
+        out,
+        "# — other nodes will not initiate connections to a client-only peer.",
+    );
+    if is_gateway {
+        push_line(
+            out,
+            "# Note: a gateway is implicitly also a relay regardless of this setting.",
+        );
+    }
+    push_line(out, &format!("enabled = {}", is_relay));
+    push_blank(out);
+}
+
+fn push_security(out: &mut String) {
+    push_line(out, "[security]");
+    push_line(
+        out,
         "# The daemon creates this Ed25519 private key on first startup if it does not exist.",
     );
-    push_line(&mut out, "key_file = \"/var/lib/pim/node.key\"");
+    push_line(out, "key_file = \"/var/lib/pim/node.key\"");
     push_line(
-        &mut out,
+        out,
         "# Reject direct peer sessions that do not complete the authenticated handshake.",
     );
-    push_line(&mut out, "require_encryption = true");
+    push_line(out, "require_encryption = true");
     push_line(
-        &mut out,
-        "# Authorization policy: allow_all, allow_list, or trust_on_first_use.",
-    );
-    push_line(&mut out, "authorization_policy = \"allow_all\"");
-    push_line(
-        &mut out,
-        "# Used only when authorization_policy = \"allow_list\".",
+        out,
+        "# Authorization policy applied AFTER peer identity is authenticated:",
     );
     push_line(
-        &mut out,
-        "# authorized_peers = [\"0123456789abcdef0123456789abcdef\"]",
+        out,
+        "#   allow_all          — admit any authenticated peer (default)",
     );
     push_line(
-        &mut out,
-        "# Used only when authorization_policy = \"trust_on_first_use\".",
+        out,
+        "#   allow_list         — admit only NodeIds listed in `authorized_peers`",
     );
     push_line(
-        &mut out,
+        out,
+        "#   trust_on_first_use — admit on first contact and persist identity to trust_store_file",
+    );
+    push_line(out, "authorization_policy = \"allow_all\"");
+    push_line(
+        out,
+        "# Used only when authorization_policy = \"allow_list\". 64-hex-char NodeIds.",
+    );
+    push_line(
+        out,
+        "# authorized_peers = [\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\"]",
+    );
+    push_line(
+        out,
+        "# Used by trust_on_first_use to remember peers that handshake successfully.",
+    );
+    push_line(
+        out,
         "trust_store_file = \"/var/lib/pim/trusted-peers.toml\"",
     );
-    push_blank(&mut out);
+    push_blank(out);
+}
 
+fn push_bluetooth(out: &mut String, node_name: &str) {
+    let bt_iface = default_bluetooth_interface();
+    let bt_iface_comment = if cfg!(target_os = "macos") {
+        "macOS — host Bluetooth stack PAN bridge"
+    } else {
+        "Linux — \"auto\" prefers a configured iface, falls back to live bnep* / enx*"
+    };
+
+    push_line(out, "[bluetooth]");
     push_line(
-        &mut out,
+        out,
+        "# Bluetooth PAN peer link-establishment — macOS host stack and Linux BlueZ.",
+    );
+    push_line(
+        out,
+        "# This mechanism finds peers and learns their PAN IPs; the existing TCP transport",
+    );
+    push_line(
+        out,
+        "# then connects to that IP for the encrypted handshake. NOT a separate transport.",
+    );
+    push_line(
+        out,
+        "# Off by default — flip `enabled = true` once BlueZ / blueutil are installed.",
+    );
+    push_line(out, "enabled = false");
+    push_line(out, &format!("# {bt_iface_comment}."));
+    push_line(out, &format!("interface = {:?}", bt_iface));
+    push_line(
+        out,
+        "# Radio-level scanning for new peers via bluetoothctl/blueutil.",
+    );
+    push_line(out, "radio_discovery_enabled = true");
+    push_line(
+        out,
+        "# Filter inquiry results by Bluetooth device-name prefix.",
+    );
+    push_line(out, "device_name_prefix = \"PIM-\"");
+    push_line(
+        out,
+        "# Local Bluetooth controller alias broadcast to nearby devices. Empty derives from node.name.",
+    );
+    push_line(out, &format!("local_alias = \"PIM-{node_name}\""));
+    push_line(
+        out,
+        "# Allow outbound PAN/NAP connection attempts to discovered peers.",
+    );
+    push_line(out, "connect_pan = true");
+    push_line(
+        out,
+        "# Linux NAP server: serve a local NAP on `nap_bridge` and supervise dnsmasq DHCP.",
+    );
+    push_line(
+        out,
+        "# Off by default — flip to true on a Linux gateway acting as the BT access point.",
+    );
+    push_line(out, "serve_nap = false");
+    push_line(out, "nap_bridge = \"br-bt\"");
+    push_line(
+        out,
+        "# IPv4 CIDR assigned to nap_bridge when the daemon manages it (Linux NAP server only).",
+    );
+    push_line(out, "nap_bridge_addr = \"192.168.44.1/24\"");
+    push_line(
+        out,
+        "# Daemon-supervised dnsmasq DHCP on the bridge (Linux NAP server only).",
+    );
+    push_line(out, "dhcp_enabled = true");
+    push_line(
+        out,
+        "# Optional explicit DHCP pool. When unset, derived from `nap_bridge_addr`.",
+    );
+    push_line(out, "# dhcp_range = \"192.168.44.10,192.168.44.200\"");
+    push_line(out, "dhcp_lease_time = \"12h\"");
+    push_line(
+        out,
+        "# Optional DNS list advertised to DHCP clients; otherwise inherits /etc/resolv.conf.",
+    );
+    push_line(out, "# dhcp_dns = \"1.1.1.1,8.8.8.8\"");
+    push_line(
+        out,
+        "# Linux PAN client side: request DHCP on the resolved PAN interface after pairing.",
+    );
+    push_line(out, "request_dhcp = true");
+    push_line(
+        out,
+        "# Read peer IPs from the PAN interface neighbor table (ip neigh / arp).",
+    );
+    push_line(out, "auto_discover_peers = true");
+    push_line(
+        out,
+        "# Polling cadence while waiting for the PAN interface to come up (ms).",
+    );
+    push_line(out, "poll_interval_ms = 2000");
+    push_line(out, "# Radio-level inquiry cadence (ms).");
+    push_line(out, "scan_interval_ms = 5000");
+    push_line(
+        out,
+        "# Polling cadence for neighbor-table peer discovery once the interface is up (ms).",
+    );
+    push_line(out, "peer_discovery_interval_ms = 2000");
+    push_line(out, "# bluetoothctl operation timeout (seconds).");
+    push_line(out, "bluetoothctl_timeout_s = 15");
+    push_line(
+        out,
+        "# How long the controller stays discoverable after startup (seconds).",
+    );
+    push_line(out, "discoverable_timeout_s = 180");
+    push_line(
+        out,
+        "# Maximum time to wait for the PAN interface to appear before giving up (ms).",
+    );
+    push_line(out, "startup_timeout_ms = 15000");
+    push_blank(out);
+}
+
+fn push_wifi_direct(out: &mut String) {
+    push_line(out, "[wifi_direct]");
+    push_line(
+        out,
+        "# Wi-Fi Direct (IEEE 802.11 P2P) peer discovery and group formation.",
+    );
+    push_line(
+        out,
+        "# Linux backend: wpa_supplicant compiled with CONFIG_P2P=y, controlled via wpa_cli.",
+    );
+    push_line(
+        out,
+        "# macOS backend: Bonjour DNS-SD on the host's peer-to-peer Wi-Fi interface.",
+    );
+    push_line(
+        out,
+        "# Off by default — verify `wpa_cli p2p_find` returns OK before enabling on Linux.",
+    );
+    push_line(out, "enabled = false");
+    push_line(
+        out,
+        &format!("interface = {:?}", default_wifi_direct_interface()),
+    );
+    push_line(
+        out,
+        "# Group Owner intent (0–15). Higher = more likely to become Group Owner. 7 = neutral.",
+    );
+    push_line(out, "go_intent = 7");
+    push_line(out, "# P2P listen and operating channels.");
+    push_line(out, "listen_channel = 6");
+    push_line(out, "op_channel = 6");
+    push_line(
+        out,
+        "# Connection method — \"pbc\" (push-button) or \"pin:<8-digit-pin>\".",
+    );
+    push_line(out, "connect_method = \"pbc\"");
+    push_blank(out);
+}
+
+fn push_static_peers(
+    out: &mut String,
+    peer_example: &str,
+    is_client: bool,
+    is_relay: bool,
+    is_gateway: bool,
+) {
+    push_line(
+        out,
         "# Static peers are the easiest way to bootstrap a mesh in development and Docker labs.",
     );
     push_line(
-        &mut out,
+        out,
         "# Each peer declares its connection mechanism. Today `tcp` and `bluetooth` are supported.",
     );
     push_line(
-        &mut out,
+        out,
         "# Uncomment one or more entries and replace the example endpoint with a real peer.",
     );
     if is_gateway && !is_relay && !is_client {
         push_line(
-            &mut out,
+            out,
             "# A standalone gateway can usually start without static peers and wait for inbound connections.",
         );
     }
-    push_line(&mut out, "# [[peers]]");
-    push_line(&mut out, "# mechanism = \"tcp\"");
-    push_line(&mut out, &format!("# address = {:?}", peer_example));
-    push_line(&mut out, "# label = \"replace-with-hostname-or-purpose\"");
+    push_line(out, "# [[peers]]");
+    push_line(out, "# mechanism = \"tcp\"");
+    push_line(out, &format!("# address = {:?}", peer_example));
+    push_line(out, "# label = \"replace-with-hostname-or-purpose\"");
+    push_line(out, "#");
+    push_line(
+        out,
+        "# [[peers]]  # Bluetooth PAN peer — `ip` is the address learned from the PAN neighbor table.",
+    );
+    push_line(out, "# mechanism = \"bluetooth\"");
+    push_line(out, "# ip = \"192.168.44.2\"");
+    push_line(out, "# label = \"bt-relay-a\"");
 
     if is_relay {
+        push_line(out, "#");
         push_line(
-            &mut out,
+            out,
             "# [[peers]]  # Relays commonly connect to a second upstream or downstream neighbor.",
         );
-        push_line(&mut out, "# mechanism = \"tcp\"");
-        push_line(&mut out, "# address = \"another-peer:9100\"");
-        push_line(&mut out, "# label = \"secondary-link\"");
+        push_line(out, "# mechanism = \"tcp\"");
+        push_line(out, "# address = \"another-peer:9100\"");
+        push_line(out, "# label = \"secondary-link\"");
     }
 
     if is_client {
         push_line(
-            &mut out,
+            out,
             "# Clients usually point at a nearby relay or directly at a gateway.",
         );
     }
 
     if is_relay {
         push_line(
-            &mut out,
+            out,
             "# Relays forward traffic for other nodes and typically keep at least one static upstream.",
         );
     }
 
     if is_gateway {
         push_line(
-            &mut out,
+            out,
             "# Gateways may also keep static peers if they should proactively connect into the mesh.",
         );
     }
-
-    out
 }
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
 
 pub(crate) fn unique_roles(roles: &[NodeRole]) -> BTreeSet<NodeRole> {
     roles.iter().copied().collect()
@@ -346,6 +665,30 @@ pub(crate) fn default_gateway_nat_interface() -> &'static str {
     #[cfg(not(target_os = "macos"))]
     {
         "eth0"
+    }
+}
+
+pub(crate) fn default_bluetooth_interface() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "bridge0"
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        "auto"
+    }
+}
+
+pub(crate) fn default_wifi_direct_interface() -> &'static str {
+    #[cfg(target_os = "macos")]
+    {
+        "en0"
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        "wlan0"
     }
 }
 

--- a/crates/pim-cli/src/tests/template.rs
+++ b/crates/pim-cli/src/tests/template.rs
@@ -1,5 +1,7 @@
 use super::super::*;
 
+// ── Existing coverage (pre-expansion) ────────────────────────────────────────
+
 #[test]
 fn client_template_has_commented_gateway_block_and_parses() {
     let rendered = render_config_template(&[NodeRole::Client], None);
@@ -40,4 +42,262 @@ fn multi_role_template_deduplicates_roles() {
 fn config_template_uses_platform_interface_name() {
     let rendered = render_config_template(&[NodeRole::Client], None);
     assert!(rendered.contains(&format!("name = {:?}", default_interface_name())));
+}
+
+// ── Schema-completeness coverage (every field in pim-core/config/model.rs) ──
+
+#[test]
+fn template_node_emits_data_dir() {
+    let rendered = render_config_template(&[NodeRole::Client], None);
+    let cfg = pim_core::Config::from_toml_str(&rendered).unwrap();
+    assert_eq!(cfg.node.data_dir.as_os_str(), "/var/lib/pim");
+}
+
+#[test]
+fn template_interface_emits_mtu_and_optional_ipv6() {
+    let rendered = render_config_template(&[NodeRole::Client], None);
+    assert!(rendered.contains("mtu = 1400"));
+    // Optional Option<String> field — should appear commented out so it
+    // round-trips as `None` after parse.
+    assert!(rendered.contains("# mesh_ipv6 ="));
+    let cfg = pim_core::Config::from_toml_str(&rendered).unwrap();
+    assert_eq!(cfg.interface.mtu, 1400);
+    assert_eq!(cfg.interface.mesh_ipv6, None);
+}
+
+#[test]
+fn template_discovery_emits_all_fields() {
+    let rendered = render_config_template(&[NodeRole::Client], None);
+    // Active values
+    for needle in [
+        "[discovery]",
+        "enabled = true",
+        "port = 9101",
+        "broadcast_interval_ms = 5000",
+        "peer_timeout_ms = 30000",
+        "connect_relays = true",
+        "connect_gateways = true",
+    ] {
+        assert!(
+            rendered.contains(needle),
+            "discovery missing `{needle}`. rendered:\n{rendered}"
+        );
+    }
+    // Optional shared_key — commented out
+    assert!(rendered.contains("# shared_key ="));
+
+    let cfg = pim_core::Config::from_toml_str(&rendered).unwrap();
+    assert!(cfg.discovery.enabled);
+    assert_eq!(cfg.discovery.port, 9101);
+    assert_eq!(cfg.discovery.broadcast_interval_ms, 5000);
+    assert_eq!(cfg.discovery.peer_timeout_ms, 30000);
+    assert!(cfg.discovery.connect_relays);
+    assert!(cfg.discovery.connect_gateways);
+    assert_eq!(cfg.discovery.shared_key, None);
+}
+
+#[test]
+fn template_transport_emits_all_fields() {
+    let rendered = render_config_template(&[NodeRole::Client], None);
+    for needle in [
+        "type = \"tcp\"",
+        "listen_port = 9100",
+        "max_reconnect_attempts = 20",
+        "connect_timeout_ms = 3000",
+    ] {
+        assert!(
+            rendered.contains(needle),
+            "transport missing `{needle}`. rendered:\n{rendered}"
+        );
+    }
+    let cfg = pim_core::Config::from_toml_str(&rendered).unwrap();
+    assert_eq!(cfg.transport.r#type, "tcp");
+    assert_eq!(cfg.transport.listen_port, 9100);
+    assert_eq!(cfg.transport.max_reconnect_attempts, 20);
+    assert_eq!(cfg.transport.connect_timeout_ms, 3000);
+}
+
+#[test]
+fn template_routing_emits_all_fields() {
+    let rendered = render_config_template(&[NodeRole::Client], None);
+    let cfg = pim_core::Config::from_toml_str(&rendered).unwrap();
+    assert_eq!(cfg.routing.max_hops, 10);
+    assert_eq!(cfg.routing.algorithm, "distance-vector");
+    assert_eq!(cfg.routing.route_expiry_s, 300);
+}
+
+#[test]
+fn template_relay_role_enables_relay() {
+    let rendered = render_config_template(&[NodeRole::Relay], None);
+    assert!(rendered.contains("[relay]"));
+    let cfg = pim_core::Config::from_toml_str(&rendered).unwrap();
+    assert!(
+        cfg.relay.enabled,
+        "relay role should set relay.enabled = true"
+    );
+}
+
+#[test]
+fn template_client_role_disables_relay() {
+    let rendered = render_config_template(&[NodeRole::Client], None);
+    let cfg = pim_core::Config::from_toml_str(&rendered).unwrap();
+    assert!(
+        !cfg.relay.enabled,
+        "client role should keep relay.enabled = false (capability bits 0x01)"
+    );
+}
+
+#[test]
+fn template_gateway_role_keeps_relay_default_false() {
+    // Gateway is implicitly also a relay — the daemon resolves capabilities
+    // from gateway.enabled regardless of relay.enabled. Verify the renderer
+    // documents this and emits a sensible explicit value.
+    let rendered = render_config_template(&[NodeRole::Gateway], None);
+    assert!(rendered.contains("# Note: a gateway is implicitly also a relay"));
+}
+
+#[test]
+fn template_security_emits_authorization_policy_and_files() {
+    let rendered = render_config_template(&[NodeRole::Client], None);
+    for needle in [
+        "key_file = \"/var/lib/pim/node.key\"",
+        "require_encryption = true",
+        "authorization_policy = \"allow_all\"",
+        "trust_store_file = \"/var/lib/pim/trusted-peers.toml\"",
+    ] {
+        assert!(
+            rendered.contains(needle),
+            "security missing `{needle}`. rendered:\n{rendered}"
+        );
+    }
+    // authorized_peers is commented because it's only used for allow_list.
+    assert!(rendered.contains("# authorized_peers ="));
+
+    let cfg = pim_core::Config::from_toml_str(&rendered).unwrap();
+    assert_eq!(
+        cfg.security.authorization_policy,
+        pim_core::AuthorizationPolicy::AllowAll
+    );
+    assert!(cfg.security.require_encryption);
+    assert!(cfg.security.authorized_peers.is_empty());
+    assert_eq!(
+        cfg.security.trust_store_file.as_os_str(),
+        "/var/lib/pim/trusted-peers.toml"
+    );
+}
+
+#[test]
+fn template_bluetooth_emits_full_block_disabled_by_default() {
+    let rendered = render_config_template(&[NodeRole::Client], None);
+    assert!(rendered.contains("[bluetooth]"));
+    // Master toggle off by default — matches BluetoothConfig::default()
+    // and avoids surprising behaviour on hosts without BlueZ / blueutil.
+    assert!(rendered.contains("enabled = false"));
+    // Every required (non-Option) field must be present so the template
+    // doubles as a discovery surface for operators.
+    for needle in [
+        "radio_discovery_enabled = true",
+        "device_name_prefix = \"PIM-\"",
+        "local_alias =",
+        "connect_pan = true",
+        "serve_nap = false",
+        "nap_bridge = \"br-bt\"",
+        "nap_bridge_addr = \"192.168.44.1/24\"",
+        "dhcp_enabled = true",
+        "dhcp_lease_time = \"12h\"",
+        "request_dhcp = true",
+        "auto_discover_peers = true",
+        "poll_interval_ms = 2000",
+        "scan_interval_ms = 5000",
+        "peer_discovery_interval_ms = 2000",
+        "bluetoothctl_timeout_s = 15",
+        "discoverable_timeout_s = 180",
+        "startup_timeout_ms = 15000",
+    ] {
+        assert!(
+            rendered.contains(needle),
+            "bluetooth missing `{needle}`. rendered:\n{rendered}"
+        );
+    }
+    // Optional fields commented out.
+    assert!(rendered.contains("# dhcp_range ="));
+    assert!(rendered.contains("# dhcp_dns ="));
+
+    let cfg = pim_core::Config::from_toml_str(&rendered).unwrap();
+    assert!(!cfg.bluetooth.enabled);
+    assert!(cfg.bluetooth.radio_discovery_enabled);
+    assert!(cfg.bluetooth.connect_pan);
+    assert!(cfg.bluetooth.auto_discover_peers);
+    assert_eq!(cfg.bluetooth.dhcp_range, None);
+    assert_eq!(cfg.bluetooth.dhcp_dns, None);
+}
+
+#[test]
+fn template_bluetooth_local_alias_uses_node_name() {
+    let rendered = render_config_template(&[NodeRole::Client], Some("edge-laptop"));
+    assert!(
+        rendered.contains("local_alias = \"PIM-edge-laptop\""),
+        "expected local_alias derived from override name; rendered:\n{rendered}"
+    );
+}
+
+#[test]
+fn template_wifi_direct_emits_full_block_disabled_by_default() {
+    let rendered = render_config_template(&[NodeRole::Client], None);
+    assert!(rendered.contains("[wifi_direct]"));
+    for needle in [
+        "go_intent = 7",
+        "listen_channel = 6",
+        "op_channel = 6",
+        "connect_method = \"pbc\"",
+    ] {
+        assert!(
+            rendered.contains(needle),
+            "wifi_direct missing `{needle}`. rendered:\n{rendered}"
+        );
+    }
+    let cfg = pim_core::Config::from_toml_str(&rendered).unwrap();
+    assert!(!cfg.wifi_direct.enabled);
+    assert_eq!(cfg.wifi_direct.go_intent, 7);
+    assert_eq!(cfg.wifi_direct.listen_channel, 6);
+    assert_eq!(cfg.wifi_direct.op_channel, 6);
+    assert_eq!(cfg.wifi_direct.connect_method, "pbc");
+}
+
+#[test]
+fn template_static_peers_block_documents_both_mechanisms() {
+    let rendered = render_config_template(&[NodeRole::Client], None);
+    // Both transport mechanisms documented as commented examples so
+    // operators see the option without having to read the docs.
+    assert!(rendered.contains("# mechanism = \"tcp\""));
+    assert!(rendered.contains("# mechanism = \"bluetooth\""));
+    assert!(rendered.contains("# ip = \"192.168.44.2\""));
+}
+
+#[test]
+fn template_round_trips_for_every_role_combination() {
+    use NodeRole::{Client, Gateway, Relay};
+    let combos: &[&[NodeRole]] = &[
+        &[Client],
+        &[Relay],
+        &[Gateway],
+        &[Client, Relay],
+        &[Client, Gateway],
+        &[Relay, Gateway],
+        &[Client, Relay, Gateway],
+    ];
+    for roles in combos {
+        let rendered = render_config_template(roles, None);
+        let cfg = pim_core::Config::from_toml_str(&rendered).unwrap_or_else(|e| {
+            panic!("failed to parse template for {roles:?}: {e}\nrendered:\n{rendered}")
+        });
+        // Every parsed config must agree with the role inputs on capability flags.
+        let want_gateway = roles.iter().any(|r| matches!(r, Gateway));
+        let want_relay = roles.iter().any(|r| matches!(r, Relay));
+        assert_eq!(
+            cfg.gateway.enabled, want_gateway,
+            "gateway flag for {roles:?}"
+        );
+        assert_eq!(cfg.relay.enabled, want_relay, "relay flag for {roles:?}");
+    }
 }


### PR DESCRIPTION
## Summary

The template emitted by `pim config generate` was missing fields defined in `pim-core/src/config/model.rs` and rejected by the daemon if used verbatim. This rewrites the generator so every field on `Config` (and its sub-structs) appears in the output — either with its real value or as a commented `# key = …` line with an inline explanation of how to enable it.

### Missing fields, now emitted

- `[discovery]` — `enabled`, `port`, `connect_relays`, `connect_gateways`
- `[transport]` — `max_reconnect_attempts`, `connect_timeout_ms`
- `[relay]` — entire section was missing (capability bitfield 0x03 vs 0x01)
- `[bluetooth]` — entire section was missing (21 fields)
- `[wifi_direct]` — entire section was missing (6 fields)
- `[security]` — `authorization_policy`, `authorized_peers`, `trust_store_file`

### Conventions

- Active values written verbatim
- Optional `Option<T>` fields (`mesh_ipv6`, `shared_key`, `dhcp_range`, `dhcp_dns`, `authorized_peers`) emitted commented-out with an inline explanation
- Role-conditional sections (`[gateway]`) keep the existing commented-placeholder pattern when the role is absent
- `[bluetooth]` and `[wifi_direct]` emitted as full blocks with `enabled = false` (matches `BluetoothConfig::default()` / `WifiDirectConfig::default()` in pim-core), so all knobs are visible without hunting through the source

### Role semantics

- `client` → `relay.enabled = false` (capability bits 0x01 — client only)
- `relay`  → `relay.enabled = true`  (capability bits 0x03 — relay + client)
- `gateway` → `gateway.enabled = true`, with a note that gateway is implicitly also a relay (capability bits 0x07)

## Test plan

- [x] `cargo build -p pim-cli` — clean
- [x] `cargo test -p pim-cli` — 18 template tests pass (4 preserved + 14 new)
- [x] `cargo test --workspace` — every crate green; no regressions outside pim-cli
- [x] `cargo fmt --check -p pim-cli` — clean
- [x] `cargo clippy -p pim-cli --all-targets` — 0 warnings on changed code
- [x] Round-trip verified for **all 7 role combinations** (client, relay, gateway, and every pair / triple) via the new `template_round_trips_for_every_role_combination` test
- [x] Smoke test: `cargo run --bin pim -- config generate client relay` produces a 164-line documented template

🤖 Generated with [Claude Code](https://claude.com/claude-code)