### PR TITLE
fix(village2026): key 0 jumps to first slide (same as Home)

### DIFF
--- a/assets/presentations/village2026/index.html
+++ b/assets/presentations/village2026/index.html
@@ -1230,7 +1230,11 @@
             }
 
             document.addEventListener("keydown", (e) => {
-                if (e.key >= "0" && e.key <= "9") {
+                if (e.key === "0" && digitBuffer === "") {
+                    goTo(0);
+                    return;
+                }
+                if (e.key >= "1" && e.key <= "9") {
                     digitBuffer += e.key;
                     clearTimeout(digitTimer);
                     // Flush immediately once the buffer can only match one valid slide

--- a/assets/presentations/village2026/index.html
+++ b/assets/presentations/village2026/index.html
@@ -1189,10 +1189,12 @@
 
         <div id="progress"><div id="progress-fill" style="width: 7.69%"></div></div>
 
-        <div id="nav">
-            <button class="nav-btn" id="btn-prev" onclick="go(-1)" disabled>← prev</button>
-            <div id="counter"><span class="cur" id="cur">1</span> / <span id="tot">13</span></div>
-            <button class="nav-btn" id="btn-next" onclick="go(1)">next →</button>
+        <div id="nav-wrap">
+            <div id="nav">
+                <button class="nav-btn" id="btn-prev" onclick="go(-1)" disabled>← prev</button>
+                <div id="slide-nums"></div>
+                <button class="nav-btn" id="btn-next" onclick="go(1)">next →</button>
+            </div>
         </div>
 
         <script>
@@ -1200,11 +1202,24 @@
             const total = slides.length;
             let idx = 0;
 
+            // Build clickable slide number pills
+            const numsContainer = document.getElementById("slide-nums");
+            for (let i = 0; i < total; i++) {
+                const btn = document.createElement("button");
+                btn.className = "slide-num" + (i === 0 ? " active" : "");
+                btn.textContent = String(i + 1).padStart(2, "0");
+                btn.title = "Slide " + (i + 1);
+                btn.addEventListener("click", () => goTo(i));
+                numsContainer.appendChild(btn);
+            }
+
             function goTo(n) {
                 slides[idx].classList.remove("active");
+                numsContainer.children[idx].classList.remove("active");
                 idx = Math.max(0, Math.min(n, total - 1));
                 slides[idx].classList.add("active");
-                document.getElementById("cur").textContent = idx + 1;
+                numsContainer.children[idx].classList.add("active");
+                numsContainer.children[idx].scrollIntoView({ inline: "nearest", block: "nearest" });
                 document.getElementById("btn-prev").disabled = idx === 0;
                 document.getElementById("btn-next").disabled = idx === total - 1;
                 document.getElementById("progress-fill").style.width = (((idx + 1) / total) * 100).toFixed(2) + "%";

--- a/assets/presentations/village2026/index.html
+++ b/assets/presentations/village2026/index.html
@@ -1192,7 +1192,7 @@
         <div id="nav-wrap">
             <div id="nav">
                 <button class="nav-btn" id="btn-prev" onclick="go(-1)" disabled>← prev</button>
-                <div id="slide-nums"></div>
+                <div id="counter"><span class="cur" id="cur">1</span> / <span id="tot">13</span></div>
                 <button class="nav-btn" id="btn-next" onclick="go(1)">next →</button>
             </div>
         </div>
@@ -1200,26 +1200,14 @@
         <script>
             const slides = Array.from(document.querySelectorAll(".slide"));
             const total = slides.length;
+            document.getElementById("tot").textContent = total;
             let idx = 0;
-
-            // Build clickable slide number pills
-            const numsContainer = document.getElementById("slide-nums");
-            for (let i = 0; i < total; i++) {
-                const btn = document.createElement("button");
-                btn.className = "slide-num" + (i === 0 ? " active" : "");
-                btn.textContent = String(i + 1).padStart(2, "0");
-                btn.title = "Slide " + (i + 1);
-                btn.addEventListener("click", () => goTo(i));
-                numsContainer.appendChild(btn);
-            }
 
             function goTo(n) {
                 slides[idx].classList.remove("active");
-                numsContainer.children[idx].classList.remove("active");
                 idx = Math.max(0, Math.min(n, total - 1));
                 slides[idx].classList.add("active");
-                numsContainer.children[idx].classList.add("active");
-                numsContainer.children[idx].scrollIntoView({ inline: "nearest", block: "nearest" });
+                document.getElementById("cur").textContent = idx + 1;
                 document.getElementById("btn-prev").disabled = idx === 0;
                 document.getElementById("btn-next").disabled = idx === total - 1;
                 document.getElementById("progress-fill").style.width = (((idx + 1) / total) * 100).toFixed(2) + "%";
@@ -1229,7 +1217,33 @@
                 goTo(idx + dir);
             }
 
+            // Number-key navigation: buffer digits for up to 600 ms so two-digit
+            // slides (10–13) can be typed as "1" then "0", "1" then "1", etc.
+            let digitBuffer = "";
+            let digitTimer = null;
+
+            function flushDigits() {
+                const n = parseInt(digitBuffer, 10);
+                digitBuffer = "";
+                digitTimer = null;
+                if (n >= 1 && n <= total) goTo(n - 1);
+            }
+
             document.addEventListener("keydown", (e) => {
+                if (e.key >= "0" && e.key <= "9") {
+                    digitBuffer += e.key;
+                    clearTimeout(digitTimer);
+                    // Flush immediately once the buffer can only match one valid slide
+                    const n = parseInt(digitBuffer, 10);
+                    const maxPossible = parseInt(digitBuffer + "9".repeat(2 - digitBuffer.length), 10);
+                    if (n >= 1 && maxPossible > total) {
+                        flushDigits();
+                    } else {
+                        digitTimer = setTimeout(flushDigits, 600);
+                    }
+                    return;
+                }
+
                 switch (e.key) {
                     case "ArrowRight":
                     case "ArrowDown":
@@ -1244,9 +1258,11 @@
                         go(-1);
                         break;
                     case "Home":
+                        e.preventDefault();
                         goTo(0);
                         break;
                     case "End":
+                        e.preventDefault();
                         goTo(total - 1);
                         break;
                 }

--- a/assets/presentations/village2026/styles.css
+++ b/assets/presentations/village2026/styles.css
@@ -113,36 +113,8 @@ body::after {
 }
 .nav-btn:disabled { opacity: 0.18; cursor: not-allowed; }
 
-/* ─── Slide number pills ─── */
-#slide-nums {
-  display: flex; align-items: center; gap: 4px;
-  overflow: hidden;
-}
-
-.slide-num {
-  background: transparent;
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  font-family: inherit;
-  font-size: 10px;
-  letter-spacing: 0.05em;
-  width: 28px; height: 24px;
-  cursor: pointer;
-  display: flex; align-items: center; justify-content: center;
-  transition: border-color 0.12s, color 0.12s, box-shadow 0.12s, background 0.12s;
-  flex-shrink: 0;
-}
-.slide-num:hover {
-  border-color: var(--green);
-  color: var(--green);
-  box-shadow: 0 0 6px var(--green-glow);
-}
-.slide-num.active {
-  border-color: var(--green);
-  color: var(--green-b);
-  background: rgba(61, 214, 110, 0.08);
-  box-shadow: 0 0 10px var(--green-glow);
-}
+#counter { font-size: 11px; color: var(--text-dim); letter-spacing: 0.12em; }
+#counter .cur { color: var(--green); }
 
 /* ─── Slide prompt line ─── */
 .prompt {

--- a/assets/presentations/village2026/styles.css
+++ b/assets/presentations/village2026/styles.css
@@ -59,8 +59,8 @@ body::after {
 
 /* ─── Progress bar ─── */
 #progress {
-  position: fixed; bottom: 52px; left: 0; right: 0;
-  height: 2px; background: var(--border); z-index: 100;
+  position: fixed; bottom: 0; left: 0; right: 0;
+  height: 2px; background: var(--border); z-index: 200;
 }
 #progress-fill {
   height: 100%; background: var(--green);
@@ -68,14 +68,29 @@ body::after {
   transition: width 0.25s ease;
 }
 
-/* ─── Navigation bar ─── */
+/* ─── Navigation — auto-hide, reveal on hover ─── */
+#nav-wrap {
+  position: fixed; bottom: 2px; left: 0; right: 0;
+  height: 72px;
+  z-index: 100;
+}
+
 #nav {
-  position: fixed; bottom: 0; left: 0; right: 0; height: 52px;
+  position: absolute; bottom: 0; left: 0; right: 0; height: 52px;
   display: flex; align-items: center; justify-content: space-between;
   padding: 0 80px;
   border-top: 1px solid var(--border);
   background: rgba(8, 13, 8, 0.97);
-  z-index: 100;
+  opacity: 0;
+  transform: translateY(6px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+#nav-wrap:hover #nav {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
 }
 
 .nav-btn {
@@ -89,6 +104,7 @@ body::after {
   cursor: pointer;
   text-transform: uppercase;
   transition: border-color 0.15s, color 0.15s, box-shadow 0.15s;
+  flex-shrink: 0;
 }
 .nav-btn:hover:not(:disabled) {
   border-color: var(--green);
@@ -97,8 +113,36 @@ body::after {
 }
 .nav-btn:disabled { opacity: 0.18; cursor: not-allowed; }
 
-#counter { font-size: 11px; color: var(--text-dim); letter-spacing: 0.12em; }
-#counter .cur { color: var(--green); }
+/* ─── Slide number pills ─── */
+#slide-nums {
+  display: flex; align-items: center; gap: 4px;
+  overflow: hidden;
+}
+
+.slide-num {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  font-family: inherit;
+  font-size: 10px;
+  letter-spacing: 0.05em;
+  width: 28px; height: 24px;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  transition: border-color 0.12s, color 0.12s, box-shadow 0.12s, background 0.12s;
+  flex-shrink: 0;
+}
+.slide-num:hover {
+  border-color: var(--green);
+  color: var(--green);
+  box-shadow: 0 0 6px var(--green-glow);
+}
+.slide-num.active {
+  border-color: var(--green);
+  color: var(--green-b);
+  background: rgba(61, 214, 110, 0.08);
+  box-shadow: 0 0 10px var(--green-glow);
+}
 
 /* ─── Slide prompt line ─── */
 .prompt {


### PR DESCRIPTION
## Summary

- `0` now behaves identically to `Home`: jumps to slide 1.
- Previously `0` was fed into the digit buffer (leading to no action since slide 0 doesn't exist). Now it's intercepted before buffering when the buffer is empty.

## Test plan

- [ ] Press `0` → lands on slide 1
- [ ] Press `Home` → lands on slide 1
- [ ] Number keys 1–9 and two-digit combos (e.g. `1`+`3`) still work correctly
- [ ] `End` still jumps to the last slide

🤖 Generated with [Claude Code](https://claude.com/claude-code)