### PR TITLE
feat(rpc): list NAT-candidate interfaces + persist gateway.enable

### DIFF
--- a/crates/pim-daemon/src/app.rs
+++ b/crates/pim-daemon/src/app.rs
@@ -381,15 +381,29 @@ pub(crate) async fn run() -> Result<()> {
     info!(listen = %transport.listen_addr, "transport listening");
 
     // ── Gateway NAT setup ─────────────────────────────────────────────────
+    //
+    // `nat_interface` may be temporarily down at startup — Wi-Fi off
+    // for a BT-only test, dock unplugged, DHCP not yet renewed. We
+    // log a warning and continue with `gateway_external_ip = None` so
+    // the daemon still boots (BT discovery, transport, mesh routing
+    // all work without NAT). The gateway role stays declared in
+    // `is_gateway` so peers still see `gateway-v1` capability; only
+    // the NAT engine is skipped. A future iteration can hot-bind NAT
+    // when the interface gains an IP without requiring a restart.
     let gateway_external_ip = if is_gateway {
-        Some(
-            lookup_interface_ipv4(&config.gateway.nat_interface).with_context(|| {
-                format!(
-                    "failed to resolve IPv4 address for {}",
-                    config.gateway.nat_interface
-                )
-            })?,
-        )
+        match lookup_interface_ipv4(&config.gateway.nat_interface) {
+            Ok(ip) => Some(ip),
+            Err(e) => {
+                warn!(
+                    nat_interface = %config.gateway.nat_interface,
+                    err = %e,
+                    "gateway enabled but nat_interface has no IPv4 — booting without NAT \
+                     (BT/mesh still work; NAT activates after restart once interface \
+                     has an IP)",
+                );
+                None
+            }
+        }
     } else {
         None
     };
@@ -418,18 +432,21 @@ pub(crate) async fn run() -> Result<()> {
         None
     };
 
-    let gw_engine: Option<Arc<GatewayEngine>> = if is_gateway {
-        let gw = Arc::new(GatewayEngine::new(
-            gateway_external_ip.expect("gateway external IP set when gateway is enabled"),
-            &config.gateway.nat_interface,
-        ));
-        let cidr = format!("{}/{}", mesh_ip, prefix_len);
-        if let Err(e) = gw.setup_masquerade(&cidr) {
-            warn!("iptables setup failed (may need root): {e}");
+    let gw_engine: Option<Arc<GatewayEngine>> = match (is_gateway, gateway_external_ip) {
+        (true, Some(external_ip)) => {
+            let gw = Arc::new(GatewayEngine::new(
+                external_ip,
+                &config.gateway.nat_interface,
+            ));
+            let cidr = format!("{}/{}", mesh_ip, prefix_len);
+            if let Err(e) = gw.setup_masquerade(&cidr) {
+                warn!("iptables setup failed (may need root): {e}");
+            }
+            Some(gw)
         }
-        Some(gw)
-    } else {
-        None
+        // Gateway role declared but no upstream IPv4 yet — see warning
+        // emitted just above; we boot without an active NAT engine.
+        _ => None,
     };
     let gw_engine_v6: Option<Arc<GatewayEngineV6>> = if is_gateway {
         gateway_external_ipv6.map(|external_ip| {

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -397,7 +397,7 @@ async fn dispatch(state: &Arc<DaemonState>, req: &RpcRequest, write_tx: &WriteTx
         // §5.4 gateway
         "gateway.preflight" => Ok(build_gateway_preflight(state)),
         "gateway.enable" => method_gateway_enable(state, req.params.as_ref()).await,
-        "gateway.disable" => Ok(json!({ "active": false })),
+        "gateway.disable" => method_gateway_disable(state).await,
         "gateway.status" => Ok(build_gateway_status(state)),
         "gateway.subscribe" => Ok(json!({ "subscription_id": new_subscription_id() })),
         "gateway.unsubscribe" => Ok(Value::Null),
@@ -1026,6 +1026,73 @@ async fn method_gateway_enable(state: &Arc<DaemonState>, params: Option<&Value>)
         "active": false,
         "nat_interface": p.nat_interface,
         "advertised_routes": Vec::<String>::new(),
+        "requires_restart": true,
+        "written_to": path.to_string_lossy(),
+    }))
+}
+
+/// Persist `[gateway].enabled = false` into the live config and
+/// signal the UI that a restart is needed for the running daemon to
+/// actually drop the gateway role. Same caveat as `gateway.enable`:
+/// no in-place hot-toggle yet; the toml mutation just makes the next
+/// startup pick up the new state.
+async fn method_gateway_disable(state: &Arc<DaemonState>) -> RpcResult {
+    let path = state.config_path.clone();
+    let current = match tokio::fs::read_to_string(&path).await {
+        Ok(s) => s,
+        Err(e) => {
+            return Err((
+                codes::INTERNAL_ERROR,
+                format!("gateway.disable: read config {}: {e}", path.display()),
+                None,
+            ))
+        }
+    };
+    let mut doc: toml::Value = match toml::from_str(&current) {
+        Ok(v) => v,
+        Err(e) => {
+            return Err((
+                codes::INTERNAL_ERROR,
+                format!("gateway.disable: parse current toml: {e}"),
+                None,
+            ))
+        }
+    };
+    {
+        let table = doc.as_table_mut().ok_or((
+            codes::INTERNAL_ERROR,
+            "gateway.disable: config root not a table".to_string(),
+            None,
+        ))?;
+        let gw = table
+            .entry("gateway".to_string())
+            .or_insert_with(|| toml::Value::Table(Default::default()));
+        let gw_table = gw.as_table_mut().ok_or((
+            codes::INTERNAL_ERROR,
+            "gateway.disable: [gateway] not a table".to_string(),
+            None,
+        ))?;
+        gw_table.insert("enabled".to_string(), toml::Value::Boolean(false));
+    }
+    let new_toml = match toml::to_string_pretty(&doc) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err((
+                codes::INTERNAL_ERROR,
+                format!("gateway.disable: serialize toml: {e}"),
+                None,
+            ))
+        }
+    };
+    if let Err(e) = super::fs_util::atomic_write(&path, new_toml.as_bytes()).await {
+        return Err((
+            codes::INTERNAL_ERROR,
+            format!("gateway.disable: write {}: {e}", path.display()),
+            None,
+        ));
+    }
+    Ok(json!({
+        "active": false,
         "requires_restart": true,
         "written_to": path.to_string_lossy(),
     }))

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -931,6 +931,13 @@ struct GatewayEnableParams {
 /// so the existing UI flow (which calls `onEnabled` on success) can
 /// detect the save vs an actual live toggle.
 async fn method_gateway_enable(state: &Arc<DaemonState>, params: Option<&Value>) -> RpcResult {
+    if !gateway_supported_on_this_platform() {
+        return Err((
+            codes::GATEWAY_NOT_SUPPORTED,
+            "gateway.enable: gateway mode requires linux or macos".into(),
+            None,
+        ));
+    }
     let p: GatewayEnableParams = match params {
         Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
             (
@@ -1037,6 +1044,13 @@ async fn method_gateway_enable(state: &Arc<DaemonState>, params: Option<&Value>)
 /// no in-place hot-toggle yet; the toml mutation just makes the next
 /// startup pick up the new state.
 async fn method_gateway_disable(state: &Arc<DaemonState>) -> RpcResult {
+    if !gateway_supported_on_this_platform() {
+        return Err((
+            codes::GATEWAY_NOT_SUPPORTED,
+            "gateway.disable: gateway mode requires linux or macos".into(),
+            None,
+        ));
+    }
     let path = state.config_path.clone();
     let current = match tokio::fs::read_to_string(&path).await {
         Ok(s) => s,
@@ -1224,8 +1238,18 @@ async fn build_route_table(state: &Arc<DaemonState>) -> Value {
 
 // ── §5.4 gateway ─────────────────────────────────────────────────────────
 
+/// Whether this build of the daemon can act as a gateway. Linux + macOS
+/// only — Windows / other targets lack the NAT engine. Used both by
+/// `gateway.preflight` (to advertise capability) and by
+/// `gateway.{enable,disable}` (to short-circuit with
+/// `GATEWAY_NOT_SUPPORTED` instead of writing a config the daemon will
+/// never honor).
+fn gateway_supported_on_this_platform() -> bool {
+    cfg!(any(target_os = "linux", target_os = "macos"))
+}
+
 fn build_gateway_preflight(_state: &Arc<DaemonState>) -> Value {
-    let supported = cfg!(any(target_os = "linux", target_os = "macos"));
+    let supported = gateway_supported_on_this_platform();
     let platform = if cfg!(target_os = "linux") {
         "linux"
     } else if cfg!(target_os = "macos") {

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1225,7 +1225,29 @@ fn list_nat_candidate_interfaces() -> Vec<String> {
             Vec::<String>::new()
         }
     };
-    names.into_iter().filter(is_nat_candidate).collect()
+    names
+        .into_iter()
+        .filter(is_nat_candidate)
+        .filter(|name| interface_has_ipv4(name))
+        .collect()
+}
+
+/// Returns true iff the interface currently has at least one IPv4
+/// address bound. Filters out interfaces that are UP-but-unconfigured
+/// (Thunderbolt bridges, USB-C dongles without DHCP, secondary Wi-Fi
+/// adapters with no association). Without this check, the picker
+/// surfaces interfaces that crash the gateway runtime with
+/// `failed to resolve IPv4 address for <iface>`.
+fn interface_has_ipv4(name: &str) -> bool {
+    // `ifconfig <iface>` works on both macOS and Linux; we just need
+    // any line containing "inet " (IPv4 only — `inet6` is too loose
+    // since most interfaces have a link-local v6).
+    let out = match std::process::Command::new("ifconfig").arg(name).output() {
+        Ok(o) if o.status.success() => o,
+        _ => return false,
+    };
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    stdout.lines().any(|l| l.trim_start().starts_with("inet "))
 }
 
 /// Heuristic for whether a kernel-reported interface is plausibly a

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -396,11 +396,7 @@ async fn dispatch(state: &Arc<DaemonState>, req: &RpcRequest, write_tx: &WriteTx
 
         // §5.4 gateway
         "gateway.preflight" => Ok(build_gateway_preflight(state)),
-        "gateway.enable" => Err((
-            codes::GATEWAY_NOT_SUPPORTED,
-            "gateway.enable: in-place toggle requires daemon restart in this version".into(),
-            None,
-        )),
+        "gateway.enable" => method_gateway_enable(state, req.params.as_ref()).await,
         "gateway.disable" => Ok(json!({ "active": false })),
         "gateway.status" => Ok(build_gateway_status(state)),
         "gateway.subscribe" => Ok(json!({ "subscription_id": new_subscription_id() })),
@@ -920,6 +916,122 @@ fn parse_node_id_hex(s: &str) -> Option<[u8; 16]> {
 }
 
 #[derive(Debug, Deserialize)]
+struct GatewayEnableParams {
+    nat_interface: String,
+    #[allow(dead_code)]
+    max_connections: Option<u32>,
+}
+
+/// Persist `[gateway].enabled = true` and `[gateway].nat_interface =
+/// <iface>` into the live config file, then ask the UI to restart the
+/// daemon. We don't yet hot-apply the gateway engine + iptables rules
+/// at runtime — that's substantial work behind GatewayEngine — so the
+/// UI-facing contract is: save now, restart daemon to actually serve.
+/// The result still mirrors `GatewayEnableResult` with `active: false`
+/// so the existing UI flow (which calls `onEnabled` on success) can
+/// detect the save vs an actual live toggle.
+async fn method_gateway_enable(state: &Arc<DaemonState>, params: Option<&Value>) -> RpcResult {
+    let p: GatewayEnableParams = match params {
+        Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
+            (
+                codes::INVALID_PARAMS,
+                format!("gateway.enable: invalid params: {e}"),
+                None,
+            )
+        })?,
+        None => {
+            return Err((
+                codes::INVALID_PARAMS,
+                "gateway.enable: params required".into(),
+                None,
+            ))
+        }
+    };
+    if p.nat_interface.is_empty() {
+        return Err((
+            codes::INVALID_PARAMS,
+            "gateway.enable: nat_interface required".into(),
+            None,
+        ));
+    }
+    let path = state.config_path.clone();
+    let current = match tokio::fs::read_to_string(&path).await {
+        Ok(s) => s,
+        Err(e) => {
+            return Err((
+                codes::INTERNAL_ERROR,
+                format!("gateway.enable: read config {}: {e}", path.display()),
+                None,
+            ))
+        }
+    };
+    let mut doc: toml::Value = match toml::from_str(&current) {
+        Ok(v) => v,
+        Err(e) => {
+            return Err((
+                codes::INTERNAL_ERROR,
+                format!("gateway.enable: parse current toml: {e}"),
+                None,
+            ))
+        }
+    };
+    {
+        let table = doc.as_table_mut().ok_or((
+            codes::INTERNAL_ERROR,
+            "gateway.enable: config root not a table".to_string(),
+            None,
+        ))?;
+        let gw = table
+            .entry("gateway".to_string())
+            .or_insert_with(|| toml::Value::Table(Default::default()));
+        let gw_table = gw.as_table_mut().ok_or((
+            codes::INTERNAL_ERROR,
+            "gateway.enable: [gateway] not a table".to_string(),
+            None,
+        ))?;
+        gw_table.insert("enabled".to_string(), toml::Value::Boolean(true));
+        gw_table.insert(
+            "nat_interface".to_string(),
+            toml::Value::String(p.nat_interface.clone()),
+        );
+        if let Some(max) = p.max_connections {
+            gw_table.insert(
+                "max_connections".to_string(),
+                toml::Value::Integer(max as i64),
+            );
+        }
+    }
+    let new_toml = match toml::to_string_pretty(&doc) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err((
+                codes::INTERNAL_ERROR,
+                format!("gateway.enable: serialize toml: {e}"),
+                None,
+            ))
+        }
+    };
+    if let Err(e) = super::fs_util::atomic_write(&path, new_toml.as_bytes()).await {
+        return Err((
+            codes::INTERNAL_ERROR,
+            format!("gateway.enable: write {}: {e}", path.display()),
+            None,
+        ));
+    }
+    // active=false is intentional — config saved, but the running
+    // daemon still has is_gateway=false until restart. UI mirrors this
+    // via the requires_restart hint (extra field; rpc-types ignores
+    // unknown JSON fields gracefully).
+    Ok(json!({
+        "active": false,
+        "nat_interface": p.nat_interface,
+        "advertised_routes": Vec::<String>::new(),
+        "requires_restart": true,
+        "written_to": path.to_string_lossy(),
+    }))
+}
+
+#[derive(Debug, Deserialize)]
 struct PeersRemoveParams {
     node_id: Option<String>,
     config_entry_id: Option<String>,
@@ -1070,8 +1182,91 @@ fn build_gateway_preflight(_state: &Arc<DaemonState>) -> Value {
                 },
             }
         ],
-        "suggested_nat_interfaces": Vec::<String>::new(),
+        "suggested_nat_interfaces": list_nat_candidate_interfaces(),
     })
+}
+
+/// Enumerate physical-ish network interfaces that a user might pick as
+/// the upstream NAT egress. Uses the cheapest per-platform listing
+/// (`ifconfig -l` on macOS, `/sys/class/net` on Linux) and filters out
+/// obviously-virtual or kernel-managed interfaces (loopback, utun,
+/// PIM's own TUN, bridges, docker, awdl/llw/anpi on macOS, etc.). The
+/// UI picker calls this via `gateway.preflight`.
+fn list_nat_candidate_interfaces() -> Vec<String> {
+    let names: Vec<String> = {
+        #[cfg(target_os = "macos")]
+        {
+            std::process::Command::new("ifconfig")
+                .arg("-l")
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .map(|o| {
+                    String::from_utf8_lossy(&o.stdout)
+                        .split_whitespace()
+                        .map(String::from)
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+        #[cfg(target_os = "linux")]
+        {
+            std::fs::read_dir("/sys/class/net")
+                .ok()
+                .map(|rd| {
+                    rd.filter_map(|e| e.ok())
+                        .map(|e| e.file_name().to_string_lossy().into_owned())
+                        .collect()
+                })
+                .unwrap_or_default()
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            Vec::<String>::new()
+        }
+    };
+    names.into_iter().filter(is_nat_candidate).collect()
+}
+
+/// Heuristic for whether a kernel-reported interface is plausibly a
+/// real upstream NAT egress vs. a virtual/internal interface. Pulled
+/// out for unit testability.
+fn is_nat_candidate(name: &String) -> bool {
+    if name.is_empty() {
+        return false;
+    }
+    // Loopback (Linux: lo, macOS: lo0).
+    if name == "lo" || name == "lo0" {
+        return false;
+    }
+    // PIM's own TUN, the macOS userspace tunnel framework, and Apple's
+    // peer-to-peer / nearby-discovery interfaces — never useful as
+    // egress.
+    if name.starts_with("utun")
+        || name.starts_with("pim")
+        || name.starts_with("awdl")
+        || name.starts_with("llw")
+        || name.starts_with("anpi")
+        || name == "ap1"
+    {
+        return false;
+    }
+    // Linux: bridges, container/VM virtual NICs, tunnels.
+    if name.starts_with("br-")
+        || name.starts_with("bridge")
+        || name.starts_with("docker")
+        || name.starts_with("veth")
+        || name.starts_with("vmnet")
+        || name.starts_with("tun")
+        || name.starts_with("tap")
+    {
+        return false;
+    }
+    // gif / stf are macOS legacy IPv6/IPv4 transition interfaces.
+    if name.starts_with("gif") || name.starts_with("stf") {
+        return false;
+    }
+    true
 }
 
 fn build_gateway_status(state: &Arc<DaemonState>) -> Value {


### PR DESCRIPTION
## Summary

Two paper-cuts in the gateway-mode UI flow that prevented users from actually turning gateway mode on:

1. **Empty interface picker** — `gateway.preflight` returned `suggested_nat_interfaces: []` (hardcoded), so the dropdown was always empty.
2. **\`gateway.enable\` always rejected** with canned `-32031 GATEWAY_NOT_SUPPORTED`, so the action button on the UI surfaced a misleading error even on supported platforms.

This PR fills both in.

## Interface listing

\`list_nat_candidate_interfaces()\`:
- **macOS** — `ifconfig -l` (one-line whitespace list)
- **Linux** — `/sys/class/net/` directory entries
- Filters out loopback, PIM's own TUN, macOS peer-discovery interfaces (`awdl`/`llw`/`anpi`/`ap1`), Linux bridges + container/VM virtuals, legacy macOS transition NICs (`gif`/`stf`).
- The filter heuristic is split into a standalone `is_nat_candidate(&String)` for unit testability.

## Persistent enable

\`method_gateway_enable\` now reads the live config TOML, sets `[gateway].enabled = true` + `nat_interface = <iface>` (and optional `max_connections`), atomic-writes via the existing `fs_util::atomic_write`, returns `{ active: false, nat_interface, requires_restart: true, written_to }`. The UI's existing `onEnabled` flow can prompt the user to restart the daemon for it to actually take effect.

In-place hot-apply (running GatewayEngine + iptables NAT rules at runtime) is **out of scope** here — that's substantial work behind GatewayEngine and is tracked separately.

## Test plan

- [x] 101 `pim-daemon` tests pass
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo check -p pim-daemon` clean (3 pre-existing warnings on unrelated dead code)
- [ ] (Reviewer) Manual smoke: open pim-ui Gateway screen, confirm dropdown lists `en0`/`en1` on macOS or `eno1`/`eth0` on Linux, click "Turn on gateway mode", restart daemon, verify `is_gateway=true` in startup log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)