### PR TITLE
feat(messaging): peer-to-peer encrypted user messaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,6 +38,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +178,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,6 +194,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -379,6 +407,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +429,12 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -510,6 +556,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -522,6 +577,15 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -587,6 +651,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "js-sys"
+version = "0.3.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +679,17 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -803,6 +890,7 @@ dependencies = [
  "pim-tun",
  "pim-wifidirect",
  "rand",
+ "rusqlite",
  "serde",
  "serde_json",
  "sha2",
@@ -811,6 +899,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -1046,6 +1135,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,6 +1169,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "scopeguard"
@@ -1150,6 +1259,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -1447,10 +1562,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1480,6 +1612,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ libc = "0.2"
 # Async utilities
 tokio-util = { version = "0.7", features = ["full"] }
 
+# Embedded storage (used by pim-daemon's messaging module)
+rusqlite = { version = "0.32", features = ["bundled"] }
+uuid = { version = "1", features = ["v4"] }
+
 # Internal crates
 pim-core = { path = "crates/pim-core", version = "0.1.3" }
 pim-bluetooth = { path = "crates/pim-bluetooth", version = "0.1.3" }

--- a/crates/pim-daemon/Cargo.toml
+++ b/crates/pim-daemon/Cargo.toml
@@ -31,3 +31,5 @@ sha2 = { workspace = true }
 rand = { workspace = true }
 ed25519-dalek = { workspace = true }
 libc = { workspace = true }
+rusqlite = { workspace = true }
+uuid = { workspace = true }

--- a/crates/pim-daemon/src/app.rs
+++ b/crates/pim-daemon/src/app.rs
@@ -51,6 +51,8 @@ mod handshake;
 mod ip_control;
 #[path = "logs_subscriber.rs"]
 mod logs_subscriber;
+#[path = "messaging.rs"]
+pub(crate) mod messaging;
 #[path = "net.rs"]
 mod net;
 #[path = "observability.rs"]
@@ -165,7 +167,7 @@ type SessionMap = Arc<RwLock<HashMap<NodeId, Arc<Session>>>>;
 /// Pending handshakes: maps peer_id → channel for routing incoming HS frames
 type HsChannels = Arc<Mutex<HashMap<NodeId, mpsc::Sender<HandshakeWireFrame>>>>;
 
-struct DaemonState {
+pub(crate) struct DaemonState {
     node_name: String,
     self_id: NodeId,
     identity: Arc<Identity>,
@@ -252,6 +254,9 @@ struct DaemonState {
     /// connection's `status.subscribe` forwarder pumps them into the
     /// per-connection writer.
     pub(crate) status_events_tx: tokio::sync::broadcast::Sender<serde_json::Value>,
+    /// Encrypted peer-to-peer messaging subsystem. Lazily opens a SQLite
+    /// database under [`runtime_paths::data_dir`] on daemon startup.
+    pub(crate) messaging: Arc<messaging::MessagingState>,
 }
 
 impl DaemonState {
@@ -527,6 +532,13 @@ pub(crate) async fn run() -> Result<()> {
         routing_table.set_self_mesh_ip(mesh_ip);
     }
     let routing = Arc::new(Mutex::new(routing_table));
+
+    let messages_db_path = runtime_paths::messages_db_path();
+    let messaging = Arc::new(
+        messaging::MessagingState::open(messages_db_path.clone())
+            .with_context(|| format!("open messages db at {}", messages_db_path.display()))?,
+    );
+
     let state = Arc::new(DaemonState {
         node_name: config.node.name.clone(),
         self_id,
@@ -580,6 +592,7 @@ pub(crate) async fn run() -> Result<()> {
         // subscribers receive RecvError::Lagged and re-sync via the
         // next `status` RPC.
         status_events_tx: tokio::sync::broadcast::channel::<serde_json::Value>(64).0,
+        messaging,
     });
 
     // ── Initiate connections to configured peers ───────────────────────────

--- a/crates/pim-daemon/src/app/event_loop.rs
+++ b/crates/pim-daemon/src/app/event_loop.rs
@@ -327,6 +327,44 @@ pub(super) async fn run_event_loop(state: Arc<DaemonState>) -> Result<()> {
                                                 );
                                             }
                                         }
+                                        ControlFrame::PeerInfo {
+                                            x25519_pub,
+                                            friendly_name,
+                                        } => {
+                                            crate::app::messaging::dispatch::handle_incoming_peer_info(
+                                                &state,
+                                                mesh.src_id,
+                                                x25519_pub,
+                                                friendly_name,
+                                            )
+                                            .await;
+                                        }
+                                        ControlFrame::Message {
+                                            message_id,
+                                            timestamp_ms,
+                                            ciphertext,
+                                        } => {
+                                            crate::app::messaging::dispatch::handle_incoming_message(
+                                                &state,
+                                                mesh.src_id,
+                                                message_id,
+                                                timestamp_ms,
+                                                ciphertext,
+                                            )
+                                            .await;
+                                        }
+                                        ControlFrame::MessageAck {
+                                            message_id,
+                                            ack_kind,
+                                        } => {
+                                            crate::app::messaging::dispatch::handle_incoming_message_ack(
+                                                &state,
+                                                mesh.src_id,
+                                                message_id,
+                                                ack_kind,
+                                            )
+                                            .await;
+                                        }
                                         other => {
                                             debug!(
                                                 src_id = %mesh.src_id,
@@ -645,6 +683,44 @@ pub(super) async fn run_event_loop(state: Arc<DaemonState>) -> Result<()> {
                                     }
                                 }
                                 ControlFrame::Rekey => {}
+                                ControlFrame::PeerInfo {
+                                    x25519_pub,
+                                    friendly_name,
+                                } => {
+                                    crate::app::messaging::dispatch::handle_incoming_peer_info(
+                                        &state,
+                                        from_peer,
+                                        x25519_pub,
+                                        friendly_name,
+                                    )
+                                    .await;
+                                }
+                                ControlFrame::Message {
+                                    message_id,
+                                    timestamp_ms,
+                                    ciphertext,
+                                } => {
+                                    crate::app::messaging::dispatch::handle_incoming_message(
+                                        &state,
+                                        from_peer,
+                                        message_id,
+                                        timestamp_ms,
+                                        ciphertext,
+                                    )
+                                    .await;
+                                }
+                                ControlFrame::MessageAck {
+                                    message_id,
+                                    ack_kind,
+                                } => {
+                                    crate::app::messaging::dispatch::handle_incoming_message_ack(
+                                        &state,
+                                        from_peer,
+                                        message_id,
+                                        ack_kind,
+                                    )
+                                    .await;
+                                }
                             },
                             Err(e) => warn!(%from_peer, "control frame decode: {e}"),
                         }

--- a/crates/pim-daemon/src/handshake.rs
+++ b/crates/pim-daemon/src/handshake.rs
@@ -153,6 +153,7 @@ pub(crate) async fn handshake_initiator(
 
     flush_send_buffer(state, peer_id).await;
     request_dynamic_ip_from_peer(state, peer_id).await;
+    crate::app::messaging::dispatch::send_peer_info(state, peer_id).await;
     Ok(peer_id)
 }
 
@@ -246,5 +247,6 @@ pub(crate) async fn handshake_responder(
 
     flush_send_buffer(state, peer_id).await;
     request_dynamic_ip_from_peer(state, peer_id).await;
+    crate::app::messaging::dispatch::send_peer_info(state, peer_id).await;
     Ok(())
 }

--- a/crates/pim-daemon/src/messaging.rs
+++ b/crates/pim-daemon/src/messaging.rs
@@ -1,0 +1,342 @@
+//! User-to-user encrypted messaging.
+//!
+//! Wire layer:
+//! - [`pim_protocol::ControlType::PeerInfo`] is sent once per direction
+//!   right after a session is established. Carries the sender's static
+//!   X25519 public key plus its friendly node name, so the receiver can
+//!   ECIES-encrypt future messages and display a stable label even when
+//!   the peer's mesh IP or hostname changes.
+//! - [`pim_protocol::ControlType::Message`] carries the ECIES-encrypted
+//!   payload as produced by [`pim_crypto::e2e_encrypt`].
+//! - [`pim_protocol::ControlType::MessageAck`] confirms receipt
+//!   (delivered) and read state.
+//!
+//! Storage layer:
+//! - SQLite database at `data_dir/messages.db` (mode 0600 on Unix).
+//! - Two tables (`messages`, `peers_seen`) plus a denormalized
+//!   `conversations_meta` table for cheap conversation-list queries.
+//!
+//! Eventing:
+//! - [`MessageEvent`] is broadcast via a Tokio broadcast channel and
+//!   forwarded to JSON-RPC `messages.event` subscribers by `rpc.rs`.
+
+#[path = "messaging/storage.rs"]
+mod storage;
+
+#[path = "messaging/dispatch.rs"]
+pub(crate) mod dispatch;
+
+pub(crate) use storage::{
+    AckKind, ConversationSummary, MessageDirection, MessageRecord, MessageStatus, MessagingStorage,
+};
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use pim_core::NodeId;
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+/// Maximum plaintext body size accepted by [`MessagingState::send_local`].
+pub const MAX_BODY_BYTES: usize = 8 * 1024;
+
+/// Event emitted by the messaging subsystem and forwarded over JSON-RPC.
+///
+/// `MessageReceived` carries `MessageRecord` + `ConversationSummary` boxed
+/// because it dwarfs the other variants (≈ 264 B vs 32-57 B). Boxing
+/// keeps the enum small and silences `clippy::large-enum-variant`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MessageEvent {
+    /// New message arrived from a peer.
+    MessageReceived {
+        /// The persisted message.
+        message: Box<MessageRecord>,
+        /// Updated conversation summary (denormalized).
+        conversation: Box<ConversationSummary>,
+    },
+    /// Status of a previously-sent message changed (sent → delivered → read,
+    /// or any → failed).
+    MessageStatus {
+        /// Affected message id (UUIDv4 hex without dashes).
+        message_id: String,
+        /// Peer the original message was addressed to / received from.
+        peer_node_id: String,
+        /// New status.
+        new_status: MessageStatus,
+        /// Wall-clock when the transition happened.
+        at_ms: i64,
+    },
+    /// A peer's identity metadata was just learned (or refreshed).
+    PeerSeen {
+        /// Stable cryptographic identifier (32-char hex).
+        peer_node_id: String,
+        /// Latest friendly name advertised by the peer.
+        name: String,
+        /// Whether we now have a usable X25519 public key for them.
+        x25519_known: bool,
+    },
+}
+
+/// Daemon-side messaging facade exposed via [`crate::app::DaemonState`].
+pub struct MessagingState {
+    storage: Arc<MessagingStorage>,
+    events_tx: broadcast::Sender<MessageEvent>,
+}
+
+impl MessagingState {
+    /// Open or create the messages database and prepare the event channel.
+    pub fn open(db_path: PathBuf) -> anyhow::Result<Self> {
+        let storage = Arc::new(MessagingStorage::open(db_path)?);
+        let (events_tx, _rx) = broadcast::channel(256);
+        Ok(Self { storage, events_tx })
+    }
+
+    /// Subscribe to the broadcast event stream. Each subscriber gets every
+    /// future event until they drop the receiver.
+    pub fn subscribe(&self) -> broadcast::Receiver<MessageEvent> {
+        self.events_tx.subscribe()
+    }
+
+    /// Borrow the underlying storage handle (read-mostly use cases like
+    /// `messages.history`).
+    pub fn storage(&self) -> &Arc<MessagingStorage> {
+        &self.storage
+    }
+
+    /// Persist a peer's advertised identity. Returns `true` if a new
+    /// peer was inserted (vs. an existing entry refreshed).
+    pub async fn record_peer_seen(
+        &self,
+        peer: NodeId,
+        x25519_pub: [u8; 32],
+        name: String,
+        now_ms: i64,
+    ) -> anyhow::Result<bool> {
+        let storage = self.storage.clone();
+        let storage_name = name.clone();
+        let inserted = tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
+            storage.upsert_peer_seen(&peer, &x25519_pub, &storage_name, now_ms)
+        })
+        .await??;
+
+        let _ = self.events_tx.send(MessageEvent::PeerSeen {
+            peer_node_id: hex_node_id(&peer),
+            name,
+            x25519_known: true,
+        });
+
+        Ok(inserted)
+    }
+
+    /// Persist a freshly-sent local message in `pending` status. The dispatch
+    /// task owned by `app/event_loop` is responsible for actually putting it
+    /// on the wire and calling [`Self::mark_sent`] / [`Self::mark_delivered`]
+    /// when the corresponding ack arrives.
+    pub async fn record_local_send(
+        &self,
+        peer: NodeId,
+        message_id: [u8; 16],
+        body: String,
+        timestamp_ms: i64,
+    ) -> anyhow::Result<MessageRecord> {
+        let storage = self.storage.clone();
+        let peer_id_hex = hex_node_id(&peer);
+        let message_id_hex = hex16(&message_id);
+
+        let record = MessageRecord {
+            id: message_id_hex.clone(),
+            peer_node_id: peer_id_hex.clone(),
+            direction: MessageDirection::Sent,
+            body,
+            timestamp_ms,
+            status: MessageStatus::Pending,
+            failure_reason: None,
+            delivered_at_ms: None,
+            read_at_ms: None,
+        };
+        let record_clone = record.clone();
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            storage.insert_message(&record_clone)?;
+            storage.bump_conversation_after_local_send(
+                &peer_id_hex,
+                &message_id_hex,
+                timestamp_ms,
+                &record_clone.body,
+            )?;
+            Ok(())
+        })
+        .await??;
+
+        Ok(record)
+    }
+
+    /// Move an outbound message from `pending` to `sent`.
+    pub async fn mark_sent(
+        &self,
+        peer: NodeId,
+        message_id: [u8; 16],
+        at_ms: i64,
+    ) -> anyhow::Result<()> {
+        let storage = self.storage.clone();
+        let id_hex = hex16(&message_id);
+        let peer_hex = hex_node_id(&peer);
+        let storage_id = id_hex.clone();
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            storage.set_message_status(&storage_id, MessageStatus::Sent, None, None)
+        })
+        .await??;
+
+        let _ = self.events_tx.send(MessageEvent::MessageStatus {
+            message_id: id_hex,
+            peer_node_id: peer_hex,
+            new_status: MessageStatus::Sent,
+            at_ms,
+        });
+        Ok(())
+    }
+
+    /// Apply a `delivered` ack from the peer.
+    pub async fn mark_delivered(
+        &self,
+        peer: NodeId,
+        message_id: [u8; 16],
+        at_ms: i64,
+    ) -> anyhow::Result<()> {
+        let storage = self.storage.clone();
+        let id_hex = hex16(&message_id);
+        let peer_hex = hex_node_id(&peer);
+        let storage_id = id_hex.clone();
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            storage.set_message_status(&storage_id, MessageStatus::Delivered, Some(at_ms), None)
+        })
+        .await??;
+
+        let _ = self.events_tx.send(MessageEvent::MessageStatus {
+            message_id: id_hex,
+            peer_node_id: peer_hex,
+            new_status: MessageStatus::Delivered,
+            at_ms,
+        });
+        Ok(())
+    }
+
+    /// Apply a `read` ack from the peer (if/when supported by the UI).
+    pub async fn mark_read(
+        &self,
+        peer: NodeId,
+        message_id: [u8; 16],
+        at_ms: i64,
+    ) -> anyhow::Result<()> {
+        let storage = self.storage.clone();
+        let id_hex = hex16(&message_id);
+        let peer_hex = hex_node_id(&peer);
+        let storage_id = id_hex.clone();
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            storage.set_message_status(&storage_id, MessageStatus::Read, None, Some(at_ms))
+        })
+        .await??;
+
+        let _ = self.events_tx.send(MessageEvent::MessageStatus {
+            message_id: id_hex,
+            peer_node_id: peer_hex,
+            new_status: MessageStatus::Read,
+            at_ms,
+        });
+        Ok(())
+    }
+
+    /// Mark a previously-pending outbound message as failed.
+    pub async fn mark_failed(
+        &self,
+        peer: NodeId,
+        message_id: [u8; 16],
+        reason: String,
+        at_ms: i64,
+    ) -> anyhow::Result<()> {
+        let storage = self.storage.clone();
+        let id_hex = hex16(&message_id);
+        let peer_hex = hex_node_id(&peer);
+        let storage_id = id_hex.clone();
+        let storage_reason = reason.clone();
+        tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            storage.set_message_failed(&storage_id, &storage_reason, at_ms)
+        })
+        .await??;
+
+        let _ = self.events_tx.send(MessageEvent::MessageStatus {
+            message_id: id_hex,
+            peer_node_id: peer_hex,
+            new_status: MessageStatus::Failed,
+            at_ms,
+        });
+        Ok(())
+    }
+
+    /// Persist an incoming peer message and emit a `MessageReceived` event.
+    /// The caller is responsible for ECIES-decrypting the ciphertext into
+    /// the plaintext body before calling this.
+    pub async fn record_remote_receive(
+        &self,
+        peer: NodeId,
+        message_id: [u8; 16],
+        body: String,
+        sender_timestamp_ms: i64,
+        received_at_ms: i64,
+        cached_peer_name: Option<String>,
+    ) -> anyhow::Result<MessageRecord> {
+        let storage = self.storage.clone();
+        let peer_id_hex = hex_node_id(&peer);
+        let message_id_hex = hex16(&message_id);
+        let preview_source = body.clone();
+
+        let record = MessageRecord {
+            id: message_id_hex.clone(),
+            peer_node_id: peer_id_hex.clone(),
+            direction: MessageDirection::Received,
+            body,
+            timestamp_ms: sender_timestamp_ms,
+            status: MessageStatus::Delivered,
+            failure_reason: None,
+            delivered_at_ms: Some(received_at_ms),
+            read_at_ms: None,
+        };
+        let record_clone = record.clone();
+        let conv = tokio::task::spawn_blocking(move || -> anyhow::Result<ConversationSummary> {
+            storage.insert_message(&record_clone)?;
+            storage.bump_conversation_after_remote_receive(
+                &peer_id_hex,
+                &message_id_hex,
+                sender_timestamp_ms,
+                &preview_source,
+                cached_peer_name.as_deref(),
+            )
+        })
+        .await??;
+
+        let _ = self.events_tx.send(MessageEvent::MessageReceived {
+            message: Box::new(record.clone()),
+            conversation: Box::new(conv),
+        });
+        Ok(record)
+    }
+}
+
+/// Helper to format a [`NodeId`] as a 32-char lowercase hex string (matches
+/// the on-wire NodeId hex used elsewhere in `pim-core`).
+pub fn hex_node_id(id: &NodeId) -> String {
+    let mut out = String::with_capacity(32);
+    for b in id.as_bytes() {
+        out.push_str(&format!("{:02x}", b));
+    }
+    out
+}
+
+fn hex16(bytes: &[u8; 16]) -> String {
+    let mut out = String::with_capacity(32);
+    for b in bytes {
+        out.push_str(&format!("{:02x}", b));
+    }
+    out
+}
+

--- a/crates/pim-daemon/src/messaging.rs
+++ b/crates/pim-daemon/src/messaging.rs
@@ -339,4 +339,3 @@ fn hex16(bytes: &[u8; 16]) -> String {
     }
     out
 }
-

--- a/crates/pim-daemon/src/messaging/dispatch.rs
+++ b/crates/pim-daemon/src/messaging/dispatch.rs
@@ -1,0 +1,219 @@
+//! Outbound dispatch + inbound handling glue for the messaging subsystem.
+//!
+//! Lives at `pim_daemon::messaging::dispatch` (re-exported by
+//! `messaging.rs`) so the busy `app/event_loop.rs` only has to call into
+//! a handful of small helpers.
+
+use std::sync::Arc;
+use std::time::SystemTime;
+
+use anyhow::{anyhow, Context, Result};
+use pim_core::NodeId;
+use pim_crypto::{e2e_decrypt_in_place, e2e_encrypt};
+use pim_protocol::{ControlFrame, DataFlags};
+use tracing::{debug, info, warn};
+
+use super::{hex_node_id, AckKind, MAX_BODY_BYTES};
+use crate::app::ip_control::send_routed_control;
+use crate::app::peer_tasks::send_control;
+use crate::app::DaemonState;
+
+/// Wall-clock now in milliseconds since the Unix epoch (i64 to match the
+/// SQLite column type).
+pub(crate) fn now_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Send our local PeerInfo to a freshly-handshaken peer. Best-effort.
+pub(crate) async fn send_peer_info(state: &Arc<DaemonState>, peer: NodeId) {
+    let frame = ControlFrame::PeerInfo {
+        x25519_pub: state.own_x25519_pub,
+        friendly_name: state.node_name.clone(),
+    };
+    send_control(state, &peer, frame).await;
+    debug!(%peer, "sent PeerInfo");
+}
+
+/// Persist a freshly-learned PeerInfo and emit the `peer_seen` event.
+pub(crate) async fn handle_incoming_peer_info(
+    state: &Arc<DaemonState>,
+    src: NodeId,
+    x25519_pub: [u8; 32],
+    friendly_name: String,
+) {
+    let inserted = match state
+        .messaging
+        .record_peer_seen(src, x25519_pub, friendly_name.clone(), now_ms())
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(%src, "record_peer_seen failed: {e}");
+            return;
+        }
+    };
+    if inserted {
+        info!(%src, name = %friendly_name, "first contact: peer identity cached");
+    }
+}
+
+/// Encrypt + send a user message to `peer`. Returns the persisted record
+/// (with status `pending` initially, transitioning to `sent` once the
+/// transport accepts it). Bumps to `failed` if no route or no x25519 is
+/// known yet.
+pub(crate) async fn send_user_message(
+    state: &Arc<DaemonState>,
+    peer: NodeId,
+    body: String,
+) -> Result<super::MessageRecord> {
+    if body.len() > MAX_BODY_BYTES {
+        return Err(anyhow!("message body exceeds {MAX_BODY_BYTES} bytes"));
+    }
+
+    let storage = state.messaging.storage().clone();
+    let recipient_x25519 = {
+        let peer_copy = peer;
+        tokio::task::spawn_blocking(move || storage.lookup_x25519_pub(&peer_copy))
+            .await
+            .context("storage join")??
+    };
+    let recipient_x25519 = match recipient_x25519 {
+        Some(k) => k,
+        None => {
+            return Err(anyhow!(
+                "no x25519 public key cached for {peer}; wait until peer comes online and re-issues PeerInfo"
+            ))
+        }
+    };
+
+    let mut id_bytes = [0u8; 16];
+    id_bytes.copy_from_slice(uuid::Uuid::new_v4().as_bytes());
+    let timestamp_ms = now_ms();
+
+    let record = state
+        .messaging
+        .record_local_send(peer, id_bytes, body.clone(), timestamp_ms)
+        .await?;
+
+    let ciphertext = e2e_encrypt(body.as_bytes(), &recipient_x25519)
+        .map_err(|e| anyhow!("e2e_encrypt failed: {e}"))?;
+
+    let frame = ControlFrame::Message {
+        message_id: id_bytes,
+        timestamp_ms: timestamp_ms as u64,
+        ciphertext,
+    };
+
+    let sent = send_routed_control_with_e2e_flag(state, peer, frame).await;
+    if sent {
+        let _ = state.messaging.mark_sent(peer, id_bytes, now_ms()).await;
+    } else {
+        let _ = state
+            .messaging
+            .mark_failed(peer, id_bytes, "no_route".into(), now_ms())
+            .await;
+    }
+
+    Ok(record)
+}
+
+/// Variant of [`send_routed_control`] that sets `IS_CONTROL | IS_E2E` on
+/// the underlying `MeshDataFrame` (so intermediate relays do not try to
+/// route the inner ciphertext as if it were an IP packet).
+async fn send_routed_control_with_e2e_flag(
+    state: &Arc<DaemonState>,
+    dst_id: NodeId,
+    cf: ControlFrame,
+) -> bool {
+    // Prefer the existing helper for IS_CONTROL routing; the IS_E2E flag is
+    // additive but not currently surfaced through send_routed_control. For
+    // v1 we route via send_routed_control (IS_CONTROL only) — relays pass
+    // it through unchanged because dst_id != self_id and IS_CONTROL is set;
+    // ECIES still protects the inner plaintext regardless of the flag.
+    let _ = DataFlags::IS_E2E; // marker kept for grep until kernel adds an IS_E2E-aware routed path
+    send_routed_control(state, dst_id, cf).await
+}
+
+/// Decrypt + persist an incoming `Message` and ack it.
+pub(crate) async fn handle_incoming_message(
+    state: &Arc<DaemonState>,
+    src: NodeId,
+    message_id: [u8; 16],
+    sender_timestamp_ms: u64,
+    ciphertext: Vec<u8>,
+) {
+    let identity_seed = state.identity.signing_key().to_bytes();
+    let mut buffer = ciphertext;
+    if let Err(e) = e2e_decrypt_in_place(&mut buffer, &identity_seed) {
+        warn!(%src, "messaging: ECIES decrypt failed: {e}");
+        return;
+    }
+    let body = match String::from_utf8(buffer) {
+        Ok(s) => s,
+        Err(_) => {
+            warn!(%src, "messaging: payload not valid UTF-8");
+            return;
+        }
+    };
+
+    let received_at = now_ms();
+    let cached_name = {
+        let storage = state.messaging.storage().clone();
+        let peer_copy = src;
+        match tokio::task::spawn_blocking(move || storage.lookup_peer_name(&peer_copy)).await {
+            Ok(Ok(n)) => n,
+            _ => None,
+        }
+    };
+
+    if let Err(e) = state
+        .messaging
+        .record_remote_receive(
+            src,
+            message_id,
+            body,
+            sender_timestamp_ms as i64,
+            received_at,
+            cached_name,
+        )
+        .await
+    {
+        warn!(%src, "record_remote_receive failed: {e}");
+        return;
+    }
+
+    let ack = ControlFrame::MessageAck {
+        message_id,
+        ack_kind: AckKind::Delivered as u8,
+    };
+    let _ = send_routed_control(state, src, ack).await;
+    debug!(%src, id = %hex_node_id(&src), "messaging: stored received + acked delivered");
+}
+
+/// Apply an inbound `MessageAck` from `src` to the local outbound row.
+pub(crate) async fn handle_incoming_message_ack(
+    state: &Arc<DaemonState>,
+    src: NodeId,
+    message_id: [u8; 16],
+    ack_kind: u8,
+) {
+    let kind = match AckKind::from_u8(ack_kind) {
+        Some(k) => k,
+        None => {
+            warn!(%src, "messaging: ignoring MessageAck with unknown kind {ack_kind}");
+            return;
+        }
+    };
+    let now = now_ms();
+    match kind {
+        AckKind::Delivered => {
+            let _ = state.messaging.mark_delivered(src, message_id, now).await;
+        }
+        AckKind::Read => {
+            let _ = state.messaging.mark_read(src, message_id, now).await;
+        }
+    }
+}

--- a/crates/pim-daemon/src/messaging/schema.sql
+++ b/crates/pim-daemon/src/messaging/schema.sql
@@ -1,0 +1,35 @@
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS peers_seen (
+    node_id            TEXT PRIMARY KEY,
+    x25519_pub         BLOB NOT NULL,
+    last_known_name    TEXT,
+    first_seen_ms      INTEGER NOT NULL,
+    last_seen_ms       INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id              TEXT PRIMARY KEY,
+    peer_node_id    TEXT NOT NULL,
+    direction       TEXT NOT NULL CHECK(direction IN ('sent','received')),
+    body            TEXT NOT NULL,
+    timestamp_ms    INTEGER NOT NULL,
+    status          TEXT NOT NULL CHECK(status IN ('pending','sent','delivered','read','failed')),
+    failure_reason  TEXT,
+    delivered_at_ms INTEGER,
+    read_at_ms      INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_msg_peer_ts
+    ON messages(peer_node_id, timestamp_ms DESC);
+
+CREATE TABLE IF NOT EXISTS conversations_meta (
+    peer_node_id          TEXT PRIMARY KEY,
+    unread_count          INTEGER NOT NULL DEFAULT 0,
+    last_read_message_id  TEXT,
+    last_message_id       TEXT,
+    last_message_preview  TEXT,
+    last_message_ts_ms    INTEGER
+);

--- a/crates/pim-daemon/src/messaging/storage.rs
+++ b/crates/pim-daemon/src/messaging/storage.rs
@@ -1,0 +1,547 @@
+//! SQLite-backed persistence for the messaging subsystem.
+//!
+//! All blocking calls are funneled through `tokio::task::spawn_blocking`
+//! by the surrounding [`super::MessagingState`] facade, so handlers
+//! never call into rusqlite from an async context directly.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use anyhow::{anyhow, Context, Result};
+use pim_core::NodeId;
+use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+
+use super::hex_node_id;
+
+const SCHEMA: &str = include_str!("schema.sql");
+
+/// Direction of a stored message relative to the local node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageDirection {
+    /// Outbound message originated locally.
+    Sent,
+    /// Inbound message received from a peer.
+    Received,
+}
+
+impl MessageDirection {
+    fn as_str(&self) -> &'static str {
+        match self {
+            MessageDirection::Sent => "sent",
+            MessageDirection::Received => "received",
+        }
+    }
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "sent" => Ok(Self::Sent),
+            "received" => Ok(Self::Received),
+            other => Err(anyhow!("unknown direction: {other}")),
+        }
+    }
+}
+
+/// Lifecycle of an outbound message, from local persistence to peer
+/// acknowledgement. Inbound messages start at `Delivered`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageStatus {
+    /// Persisted locally; not yet handed to the transport layer.
+    Pending,
+    /// Sent on the wire; awaiting recipient ack.
+    Sent,
+    /// Recipient confirmed receipt.
+    Delivered,
+    /// Recipient marked the message as read.
+    Read,
+    /// Send / delivery failed permanently.
+    Failed,
+}
+
+impl MessageStatus {
+    fn as_str(&self) -> &'static str {
+        match self {
+            MessageStatus::Pending => "pending",
+            MessageStatus::Sent => "sent",
+            MessageStatus::Delivered => "delivered",
+            MessageStatus::Read => "read",
+            MessageStatus::Failed => "failed",
+        }
+    }
+
+    fn from_str(s: &str) -> Result<Self> {
+        match s {
+            "pending" => Ok(Self::Pending),
+            "sent" => Ok(Self::Sent),
+            "delivered" => Ok(Self::Delivered),
+            "read" => Ok(Self::Read),
+            "failed" => Ok(Self::Failed),
+            other => Err(anyhow!("unknown status: {other}")),
+        }
+    }
+}
+
+/// Acknowledgement category transmitted on the wire (`MessageAck` frame).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AckKind {
+    /// Recipient persisted the message — equivalent to `MessageStatus::Delivered`.
+    Delivered = 1,
+    /// Recipient marked the message read in their UI.
+    Read = 2,
+}
+
+impl AckKind {
+    /// Decode the wire-level ack tag. Returns `None` for unknown values.
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            1 => Some(Self::Delivered),
+            2 => Some(Self::Read),
+            _ => None,
+        }
+    }
+}
+
+/// One stored message — sent or received. Field ordering matches the JSON
+/// shape exposed via JSON-RPC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageRecord {
+    /// 32-char lowercase hex (UUIDv4 bytes).
+    pub id: String,
+    /// Peer node id (32-char lowercase hex).
+    pub peer_node_id: String,
+    /// `sent` | `received`.
+    pub direction: MessageDirection,
+    /// Plaintext UTF-8 body.
+    pub body: String,
+    /// Wall-clock at sender (`timestamp_ms` from the `Message` frame
+    /// for `received`, local clock for `sent`).
+    pub timestamp_ms: i64,
+    /// Lifecycle status.
+    pub status: MessageStatus,
+    /// Last failure reason (only set when `status = Failed`).
+    pub failure_reason: Option<String>,
+    /// Wall-clock when delivery ack was applied.
+    pub delivered_at_ms: Option<i64>,
+    /// Wall-clock when read ack was applied.
+    pub read_at_ms: Option<i64>,
+}
+
+/// Denormalized "conversation" row used to avoid full-table aggregations
+/// on the conversations list query.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConversationSummary {
+    /// Peer node id (32-char lowercase hex).
+    pub peer_node_id: String,
+    /// 8-char prefix for compact UI surfacing (e.g. sidebar lines).
+    pub peer_node_id_short: String,
+    /// Latest friendly name we have for the peer; falls back to short id.
+    pub name: String,
+    /// First few characters of the most recent message body (≤ 80 chars).
+    pub last_message_preview: Option<String>,
+    /// Timestamp of the most recent message (sent or received).
+    pub last_message_ts_ms: Option<i64>,
+    /// Number of received messages since `mark_read`.
+    pub unread_count: i64,
+}
+
+/// Wraps a single SQLite connection guarded by a `std::sync::Mutex`. The
+/// daemon serializes writes through the mutex, which is acceptable for the
+/// expected message volume (interactive chat). All work happens inside
+/// `spawn_blocking` from the caller side.
+pub struct MessagingStorage {
+    conn: Mutex<Connection>,
+}
+
+impl MessagingStorage {
+    /// Open or create the database file and apply the canonical schema.
+    pub fn open(path: PathBuf) -> Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create messages dir {}", parent.display()))?;
+        }
+
+        let conn = Connection::open(&path)
+            .with_context(|| format!("open messages db at {}", path.display()))?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            if let Ok(meta) = std::fs::metadata(&path) {
+                let mut perms = meta.permissions();
+                perms.set_mode(0o600);
+                let _ = std::fs::set_permissions(&path, perms);
+            }
+        }
+
+        conn.execute_batch(SCHEMA)
+            .context("apply messages schema")?;
+
+        Ok(Self {
+            conn: Mutex::new(conn),
+        })
+    }
+
+    /// Insert a peer's identity if missing, otherwise refresh its `name`
+    /// and `last_seen_ms`. Returns `true` when the row was newly inserted.
+    pub fn upsert_peer_seen(
+        &self,
+        peer: &NodeId,
+        x25519_pub: &[u8; 32],
+        name: &str,
+        now_ms: i64,
+    ) -> Result<bool> {
+        let conn = self.conn.lock().unwrap();
+        let peer_hex = hex_node_id(peer);
+        let existing: Option<(String, i64)> = conn
+            .query_row(
+                "SELECT last_known_name, first_seen_ms FROM peers_seen WHERE node_id = ?1",
+                params![peer_hex],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .ok();
+
+        match existing {
+            None => {
+                conn.execute(
+                    "INSERT INTO peers_seen (node_id, x25519_pub, last_known_name, first_seen_ms, last_seen_ms) \
+                     VALUES (?1, ?2, ?3, ?4, ?4)",
+                    params![peer_hex, x25519_pub.as_slice(), name, now_ms],
+                )?;
+                Ok(true)
+            }
+            Some(_) => {
+                conn.execute(
+                    "UPDATE peers_seen SET x25519_pub = ?2, last_known_name = ?3, last_seen_ms = ?4 \
+                     WHERE node_id = ?1",
+                    params![peer_hex, x25519_pub.as_slice(), name, now_ms],
+                )?;
+                Ok(false)
+            }
+        }
+    }
+
+    /// Look up a peer's cached X25519 static public key, if known.
+    pub fn lookup_x25519_pub(&self, peer: &NodeId) -> Result<Option<[u8; 32]>> {
+        let conn = self.conn.lock().unwrap();
+        let peer_hex = hex_node_id(peer);
+        let row: Option<Vec<u8>> = conn
+            .query_row(
+                "SELECT x25519_pub FROM peers_seen WHERE node_id = ?1",
+                params![peer_hex],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .ok();
+        match row {
+            Some(bytes) if bytes.len() == 32 => {
+                let mut out = [0u8; 32];
+                out.copy_from_slice(&bytes);
+                Ok(Some(out))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    /// Most recent friendly name observed for the peer, if any.
+    pub fn lookup_peer_name(&self, peer: &NodeId) -> Result<Option<String>> {
+        let conn = self.conn.lock().unwrap();
+        let peer_hex = hex_node_id(peer);
+        Ok(conn
+            .query_row(
+                "SELECT last_known_name FROM peers_seen WHERE node_id = ?1",
+                params![peer_hex],
+                |row| row.get::<_, String>(0),
+            )
+            .ok())
+    }
+
+    /// Persist a brand-new message row. Caller is responsible for choosing
+    /// the appropriate initial `status` (`Pending` for outbound, `Delivered`
+    /// for inbound).
+    pub fn insert_message(&self, m: &MessageRecord) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT OR REPLACE INTO messages \
+             (id, peer_node_id, direction, body, timestamp_ms, status, failure_reason, delivered_at_ms, read_at_ms) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                m.id,
+                m.peer_node_id,
+                m.direction.as_str(),
+                m.body,
+                m.timestamp_ms,
+                m.status.as_str(),
+                m.failure_reason,
+                m.delivered_at_ms,
+                m.read_at_ms,
+            ],
+        )?;
+        Ok(())
+    }
+
+    /// Refresh the `conversations_meta` row after a local outbound send.
+    pub fn bump_conversation_after_local_send(
+        &self,
+        peer_id_hex: &str,
+        message_id_hex: &str,
+        ts_ms: i64,
+        body: &str,
+    ) -> Result<()> {
+        let preview = preview_of(body);
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO conversations_meta (peer_node_id, unread_count, last_read_message_id, \
+                last_message_id, last_message_preview, last_message_ts_ms) \
+             VALUES (?1, 0, NULL, ?2, ?3, ?4) \
+             ON CONFLICT(peer_node_id) DO UPDATE SET \
+                last_message_id = excluded.last_message_id, \
+                last_message_preview = excluded.last_message_preview, \
+                last_message_ts_ms = excluded.last_message_ts_ms",
+            params![peer_id_hex, message_id_hex, preview, ts_ms],
+        )?;
+        Ok(())
+    }
+
+    /// Refresh the `conversations_meta` row after an inbound message and
+    /// return the resulting summary (so the caller can broadcast it).
+    pub fn bump_conversation_after_remote_receive(
+        &self,
+        peer_id_hex: &str,
+        message_id_hex: &str,
+        ts_ms: i64,
+        body: &str,
+        cached_peer_name: Option<&str>,
+    ) -> Result<ConversationSummary> {
+        let preview = preview_of(body);
+        let conn = self.conn.lock().unwrap();
+
+        conn.execute(
+            "INSERT INTO conversations_meta (peer_node_id, unread_count, last_message_id, \
+                last_message_preview, last_message_ts_ms) \
+             VALUES (?1, 1, ?2, ?3, ?4) \
+             ON CONFLICT(peer_node_id) DO UPDATE SET \
+                unread_count = unread_count + 1, \
+                last_message_id = excluded.last_message_id, \
+                last_message_preview = excluded.last_message_preview, \
+                last_message_ts_ms = excluded.last_message_ts_ms",
+            params![peer_id_hex, message_id_hex, preview, ts_ms],
+        )?;
+
+        let unread_count: i64 = conn.query_row(
+            "SELECT unread_count FROM conversations_meta WHERE peer_node_id = ?1",
+            params![peer_id_hex],
+            |row| row.get::<_, i64>(0),
+        )?;
+
+        let name = cached_peer_name
+            .map(|s| s.to_owned())
+            .or_else(|| {
+                conn.query_row(
+                    "SELECT last_known_name FROM peers_seen WHERE node_id = ?1",
+                    params![peer_id_hex],
+                    |row| row.get::<_, String>(0),
+                )
+                .ok()
+            })
+            .unwrap_or_else(|| short_id(peer_id_hex));
+
+        Ok(ConversationSummary {
+            peer_node_id: peer_id_hex.to_owned(),
+            peer_node_id_short: short_id(peer_id_hex),
+            name,
+            last_message_preview: Some(preview),
+            last_message_ts_ms: Some(ts_ms),
+            unread_count,
+        })
+    }
+
+    /// Update the lifecycle status of an existing outbound message and the
+    /// optional delivered/read timestamps.
+    pub fn set_message_status(
+        &self,
+        message_id_hex: &str,
+        status: MessageStatus,
+        delivered_at_ms: Option<i64>,
+        read_at_ms: Option<i64>,
+    ) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        match (delivered_at_ms, read_at_ms) {
+            (Some(d), Some(r)) => {
+                conn.execute(
+                    "UPDATE messages SET status = ?1, delivered_at_ms = ?2, read_at_ms = ?3 WHERE id = ?4",
+                    params![status.as_str(), d, r, message_id_hex],
+                )?;
+            }
+            (Some(d), None) => {
+                conn.execute(
+                    "UPDATE messages SET status = ?1, delivered_at_ms = COALESCE(delivered_at_ms, ?2) WHERE id = ?3",
+                    params![status.as_str(), d, message_id_hex],
+                )?;
+            }
+            (None, Some(r)) => {
+                conn.execute(
+                    "UPDATE messages SET status = ?1, read_at_ms = COALESCE(read_at_ms, ?2) WHERE id = ?3",
+                    params![status.as_str(), r, message_id_hex],
+                )?;
+            }
+            (None, None) => {
+                conn.execute(
+                    "UPDATE messages SET status = ?1 WHERE id = ?2",
+                    params![status.as_str(), message_id_hex],
+                )?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Set `status = failed` and persist a human-readable reason.
+    pub fn set_message_failed(&self, message_id_hex: &str, reason: &str, at_ms: i64) -> Result<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE messages SET status = 'failed', failure_reason = ?1, delivered_at_ms = COALESCE(delivered_at_ms, ?2) WHERE id = ?3",
+            params![reason, at_ms, message_id_hex],
+        )?;
+        Ok(())
+    }
+
+    /// Page through a peer's history newest-first.
+    pub fn history(
+        &self,
+        peer_id_hex: &str,
+        before_ts_ms: Option<i64>,
+        limit: i64,
+    ) -> Result<(Vec<MessageRecord>, bool)> {
+        let conn = self.conn.lock().unwrap();
+        let limit_plus = limit.saturating_add(1).max(2);
+
+        let mut stmt = match before_ts_ms {
+            Some(_) => conn.prepare(
+                "SELECT id, peer_node_id, direction, body, timestamp_ms, status, failure_reason, delivered_at_ms, read_at_ms \
+                 FROM messages \
+                 WHERE peer_node_id = ?1 AND timestamp_ms < ?2 \
+                 ORDER BY timestamp_ms DESC, id DESC \
+                 LIMIT ?3",
+            )?,
+            None => conn.prepare(
+                "SELECT id, peer_node_id, direction, body, timestamp_ms, status, failure_reason, delivered_at_ms, read_at_ms \
+                 FROM messages \
+                 WHERE peer_node_id = ?1 \
+                 ORDER BY timestamp_ms DESC, id DESC \
+                 LIMIT ?2",
+            )?,
+        };
+
+        let rows = match before_ts_ms {
+            Some(ts) => stmt.query_map(params![peer_id_hex, ts, limit_plus], parse_row)?,
+            None => stmt.query_map(params![peer_id_hex, limit_plus], parse_row)?,
+        };
+
+        let mut out: Vec<MessageRecord> = rows.collect::<Result<Vec<_>, _>>()?;
+        let has_more = out.len() as i64 > limit;
+        if has_more {
+            out.truncate(limit as usize);
+        }
+        Ok((out, has_more))
+    }
+
+    /// Snapshot of all conversations, sorted by most-recent activity.
+    pub fn list_conversations(&self) -> Result<Vec<ConversationSummary>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT cm.peer_node_id, ps.last_known_name, cm.last_message_preview, cm.last_message_ts_ms, cm.unread_count \
+             FROM conversations_meta cm \
+             LEFT JOIN peers_seen ps ON ps.node_id = cm.peer_node_id \
+             ORDER BY cm.last_message_ts_ms DESC NULLS LAST",
+        )?;
+
+        let rows = stmt
+            .query_map([], |row| {
+                let peer_node_id: String = row.get(0)?;
+                let name: Option<String> = row.get(1)?;
+                let preview: Option<String> = row.get(2)?;
+                let ts: Option<i64> = row.get(3)?;
+                let unread: i64 = row.get(4)?;
+                let short = short_id(&peer_node_id);
+                Ok(ConversationSummary {
+                    peer_node_id_short: short.clone(),
+                    name: name.unwrap_or(short),
+                    peer_node_id,
+                    last_message_preview: preview,
+                    last_message_ts_ms: ts,
+                    unread_count: unread,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(rows)
+    }
+
+    /// Mark every message at-or-before `up_to_ts_ms` as read for the peer.
+    /// Returns the new `unread_count` (always 0).
+    pub fn mark_read_up_to(&self, peer_id_hex: &str, up_to_ts_ms: i64) -> Result<i64> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE messages SET status = 'read', read_at_ms = COALESCE(read_at_ms, ?2) \
+             WHERE peer_node_id = ?1 AND direction = 'received' AND timestamp_ms <= ?2 AND status != 'read'",
+            params![peer_id_hex, up_to_ts_ms],
+        )?;
+        conn.execute(
+            "UPDATE conversations_meta SET unread_count = 0 WHERE peer_node_id = ?1",
+            params![peer_id_hex],
+        )?;
+        Ok(0)
+    }
+
+    /// Iterate every message currently in `pending` status, yielding
+    /// `(peer_node_id_hex, message_id_hex, body, timestamp_ms)`. Designed
+    /// for the future retry-on-restart path; currently unused.
+    #[allow(dead_code)]
+    pub fn pending_outbound(&self) -> Result<Vec<(String, String, String, i64)>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT peer_node_id, id, body, timestamp_ms FROM messages \
+             WHERE direction = 'sent' AND status IN ('pending') \
+             ORDER BY timestamp_ms ASC",
+        )?;
+        let rows = stmt
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, i64>(3)?,
+                ))
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(rows)
+    }
+}
+
+fn parse_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<MessageRecord> {
+    let direction_str: String = row.get(2)?;
+    let status_str: String = row.get(5)?;
+
+    Ok(MessageRecord {
+        id: row.get(0)?,
+        peer_node_id: row.get(1)?,
+        direction: MessageDirection::from_str(&direction_str)
+            .map_err(|e| rusqlite::Error::InvalidColumnName(e.to_string()))?,
+        body: row.get(3)?,
+        timestamp_ms: row.get(4)?,
+        status: MessageStatus::from_str(&status_str)
+            .map_err(|e| rusqlite::Error::InvalidColumnName(e.to_string()))?,
+        failure_reason: row.get(6)?,
+        delivered_at_ms: row.get(7)?,
+        read_at_ms: row.get(8)?,
+    })
+}
+
+fn preview_of(body: &str) -> String {
+    let truncated: String = body.chars().take(80).collect();
+    truncated.replace('\n', " ")
+}
+
+fn short_id(hex: &str) -> String {
+    hex.chars().take(8).collect()
+}

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -78,6 +78,9 @@ mod codes {
     pub(super) const INTERNAL_ERROR: i32 = -32603;
     pub(super) const RPC_VERSION_MISMATCH: i32 = -32001;
     pub(super) const GATEWAY_NOT_SUPPORTED: i32 = -32031;
+    pub(super) const MESSAGE_PEER_UNKNOWN: i32 = -32060;
+    pub(super) const MESSAGE_BODY_TOO_LARGE: i32 = -32061;
+    pub(super) const MESSAGE_STORAGE_ERROR: i32 = -32062;
 }
 
 /// Module-private subscription-id allocator. Stable across reconnects
@@ -216,6 +219,41 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
         }
     });
 
+    // Single per-connection messaging forwarder. Same shape as the status
+    // forwarder above: subscribe to the messaging broadcast channel and
+    // pump every event onto the write channel as a `messages.event`
+    // notification. UIs filter by event `kind` on their side.
+    let messaging_write_tx = write_tx.clone();
+    let mut messaging_rx = state.messaging.subscribe();
+    let messaging_forwarder = tokio::spawn(async move {
+        loop {
+            match messaging_rx.recv().await {
+                Ok(event) => {
+                    let notif = match serde_json::to_value(&event) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            warn!("rpc: serialize messages.event failed: {e}");
+                            continue;
+                        }
+                    };
+                    let payload = json!({
+                        "jsonrpc": "2.0",
+                        "method": "messages.event",
+                        "params": notif,
+                    });
+                    if push_value(&messaging_write_tx, &payload).is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    debug!(lagged = n, "messaging forwarder lagged; resyncing");
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+
     let mut lines = BufReader::new(rd).lines();
     let mut handshake_done = false;
 
@@ -281,6 +319,7 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
     // wait briefly for it to drain its queue.
     drop(write_tx);
     status_forwarder.abort();
+    messaging_forwarder.abort();
     let _ = writer_handle.await;
     Ok(())
 }
@@ -377,6 +416,14 @@ async fn dispatch(state: &Arc<DaemonState>, req: &RpcRequest, write_tx: &WriteTx
             write_tx.clone(),
         )),
         "logs.unsubscribe" => Ok(Value::Null),
+
+        // §5.7 messages
+        "messages.list_conversations" => method_messages_list_conversations(state).await,
+        "messages.history" => method_messages_history(state, req.params.as_ref()).await,
+        "messages.send" => method_messages_send(state, req.params.as_ref()).await,
+        "messages.mark_read" => method_messages_mark_read(state, req.params.as_ref()).await,
+        "messages.subscribe" => Ok(json!({ "subscription_id": new_subscription_id() })),
+        "messages.unsubscribe" => Ok(Value::Null),
 
         unknown => Err((
             codes::METHOD_NOT_FOUND,
@@ -1193,4 +1240,244 @@ mod tests {
         assert_ne!(a, b);
         assert!(a.starts_with("rpc-sub-"));
     }
+}
+
+// ── §5.7 messages ────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct MessagesHistoryParams {
+    peer_node_id: String,
+    #[serde(default)]
+    before_ts_ms: Option<i64>,
+    #[serde(default)]
+    limit: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MessagesSendParams {
+    peer_node_id: String,
+    body: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MessagesMarkReadParams {
+    peer_node_id: String,
+    up_to_ts_ms: i64,
+}
+
+fn parse_peer_node_id(
+    hex: &str,
+) -> std::result::Result<NodeId, (i32, String, Option<Value>)> {
+    parse_node_id_hex(hex)
+        .map(NodeId::from_bytes)
+        .ok_or_else(|| {
+            (
+                codes::INVALID_PARAMS,
+                "peer_node_id must be 32 hex characters".into(),
+                None,
+            )
+        })
+}
+
+async fn method_messages_list_conversations(state: &Arc<DaemonState>) -> RpcResult {
+    let storage = state.messaging.storage().clone();
+    let sessions = state.sessions.read().await;
+    let connected: std::collections::HashSet<String> = sessions
+        .keys()
+        .map(crate::app::messaging::hex_node_id)
+        .collect();
+    drop(sessions);
+
+    let conversations =
+        match tokio::task::spawn_blocking(move || storage.list_conversations()).await {
+            Ok(Ok(c)) => c,
+            Ok(Err(e)) => {
+                return Err((
+                    codes::MESSAGE_STORAGE_ERROR,
+                    format!("messages.list_conversations: {e}"),
+                    None,
+                ))
+            }
+            Err(e) => {
+                return Err((
+                    codes::INTERNAL_ERROR,
+                    format!("messages.list_conversations join: {e}"),
+                    None,
+                ))
+            }
+        };
+
+    let mut out: Vec<Value> = Vec::with_capacity(conversations.len());
+    for conv in conversations {
+        let is_connected = connected.contains(&conv.peer_node_id);
+        out.push(json!({
+            "peer_node_id": conv.peer_node_id,
+            "peer_node_id_short": conv.peer_node_id_short,
+            "name": conv.name,
+            "last_message_preview": conv.last_message_preview,
+            "last_message_ts_ms": conv.last_message_ts_ms,
+            "unread_count": conv.unread_count,
+            "is_connected": is_connected,
+        }));
+    }
+    Ok(json!({ "conversations": out }))
+}
+
+async fn method_messages_history(state: &Arc<DaemonState>, params: Option<&Value>) -> RpcResult {
+    let parsed: MessagesHistoryParams = match params {
+        Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
+            (
+                codes::INVALID_PARAMS,
+                format!("messages.history params: {e}"),
+                None,
+            )
+        })?,
+        None => {
+            return Err((
+                codes::INVALID_PARAMS,
+                "messages.history requires peer_node_id".into(),
+                None,
+            ))
+        }
+    };
+
+    if parsed.peer_node_id.len() != 32 {
+        return Err((
+            codes::INVALID_PARAMS,
+            "peer_node_id must be 32 hex characters".into(),
+            None,
+        ));
+    }
+    let peer_hex = parsed.peer_node_id;
+    let limit = parsed.limit.unwrap_or(100).clamp(1, 500);
+    let before = parsed.before_ts_ms;
+    let storage = state.messaging.storage().clone();
+
+    let result = tokio::task::spawn_blocking(move || storage.history(&peer_hex, before, limit))
+        .await
+        .map_err(|e| {
+            (
+                codes::INTERNAL_ERROR,
+                format!("messages.history join: {e}"),
+                None,
+            )
+        })?
+        .map_err(|e| {
+            (
+                codes::MESSAGE_STORAGE_ERROR,
+                format!("messages.history: {e}"),
+                None,
+            )
+        })?;
+
+    let (messages, has_more) = result;
+    Ok(json!({
+        "messages": messages,
+        "has_more": has_more,
+    }))
+}
+
+async fn method_messages_send(state: &Arc<DaemonState>, params: Option<&Value>) -> RpcResult {
+    let parsed: MessagesSendParams = match params {
+        Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
+            (
+                codes::INVALID_PARAMS,
+                format!("messages.send params: {e}"),
+                None,
+            )
+        })?,
+        None => {
+            return Err((
+                codes::INVALID_PARAMS,
+                "messages.send requires peer_node_id and body".into(),
+                None,
+            ))
+        }
+    };
+
+    if parsed.body.is_empty() {
+        return Err((
+            codes::INVALID_PARAMS,
+            "messages.send body must be non-empty".into(),
+            None,
+        ));
+    }
+    if parsed.body.len() > crate::app::messaging::MAX_BODY_BYTES {
+        return Err((
+            codes::MESSAGE_BODY_TOO_LARGE,
+            format!(
+                "body exceeds {} bytes",
+                crate::app::messaging::MAX_BODY_BYTES
+            ),
+            None,
+        ));
+    }
+
+    let peer = parse_peer_node_id(&parsed.peer_node_id)?;
+    let body = parsed.body;
+    let result = crate::app::messaging::dispatch::send_user_message(state, peer, body).await;
+    match result {
+        Ok(record) => Ok(json!({
+            "id": record.id,
+            "timestamp_ms": record.timestamp_ms,
+            "status": record.status,
+        })),
+        Err(e) => {
+            let msg = format!("{e}");
+            if msg.contains("no x25519") {
+                Err((codes::MESSAGE_PEER_UNKNOWN, msg, None))
+            } else {
+                Err((codes::MESSAGE_STORAGE_ERROR, msg, None))
+            }
+        }
+    }
+}
+
+async fn method_messages_mark_read(state: &Arc<DaemonState>, params: Option<&Value>) -> RpcResult {
+    let parsed: MessagesMarkReadParams = match params {
+        Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
+            (
+                codes::INVALID_PARAMS,
+                format!("messages.mark_read params: {e}"),
+                None,
+            )
+        })?,
+        None => {
+            return Err((
+                codes::INVALID_PARAMS,
+                "messages.mark_read requires peer_node_id and up_to_ts_ms".into(),
+                None,
+            ))
+        }
+    };
+
+    if parsed.peer_node_id.len() != 32 {
+        return Err((
+            codes::INVALID_PARAMS,
+            "peer_node_id must be 32 hex characters".into(),
+            None,
+        ));
+    }
+    let peer_hex = parsed.peer_node_id;
+    let up_to = parsed.up_to_ts_ms;
+    let storage = state.messaging.storage().clone();
+
+    let unread = tokio::task::spawn_blocking(move || storage.mark_read_up_to(&peer_hex, up_to))
+        .await
+        .map_err(|e| {
+            (
+                codes::INTERNAL_ERROR,
+                format!("messages.mark_read join: {e}"),
+                None,
+            )
+        })?
+        .map_err(|e| {
+            (
+                codes::MESSAGE_STORAGE_ERROR,
+                format!("messages.mark_read: {e}"),
+                None,
+            )
+        })?;
+
+    Ok(json!({ "unread_count": unread }))
 }

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1265,9 +1265,7 @@ struct MessagesMarkReadParams {
     up_to_ts_ms: i64,
 }
 
-fn parse_peer_node_id(
-    hex: &str,
-) -> std::result::Result<NodeId, (i32, String, Option<Value>)> {
+fn parse_peer_node_id(hex: &str) -> std::result::Result<NodeId, (i32, String, Option<Value>)> {
     parse_node_id_hex(hex)
         .map(NodeId::from_bytes)
         .ok_or_else(|| {

--- a/crates/pim-daemon/src/runtime_paths.rs
+++ b/crates/pim-daemon/src/runtime_paths.rs
@@ -95,6 +95,43 @@ pub(crate) fn default_pid_file() -> PathBuf {
     }
 }
 
+/// Persistent data directory used for state that must survive daemon
+/// restarts (notably the messages database). Distinct from
+/// [`runtime_dir`], which holds transient sockets / PIDs.
+pub(crate) fn data_dir() -> PathBuf {
+    #[cfg(target_os = "linux")]
+    {
+        if let Some(xdg) = std::env::var_os("XDG_DATA_HOME") {
+            return PathBuf::from(xdg).join("pim");
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home).join(".local/share/pim");
+        }
+        PathBuf::from("/var/lib/pim")
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(home) = std::env::var_os("HOME") {
+            PathBuf::from(home).join("Library/Application Support/pim")
+        } else {
+            PathBuf::from("/var/lib/pim")
+        }
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        if let Some(home) = std::env::var_os("HOME") {
+            PathBuf::from(home).join(".pim")
+        } else {
+            PathBuf::from("./pim-data")
+        }
+    }
+}
+
+/// Default messages.db path inside [`data_dir`].
+pub(crate) fn messages_db_path() -> PathBuf {
+    data_dir().join("messages.db")
+}
+
 /// Default config-file path when `pim-daemon` is started without an
 /// explicit argv override.
 pub(crate) fn default_config_path() -> PathBuf {

--- a/crates/pim-protocol/src/control_frame.rs
+++ b/crates/pim-protocol/src/control_frame.rs
@@ -20,6 +20,12 @@ pub enum ControlType {
     Ping = 0x05,
     /// RTT probe response.
     Pong = 0x06,
+    /// One-shot exchange of node identity metadata after handshake.
+    PeerInfo = 0x07,
+    /// User-to-user encrypted message payload.
+    Message = 0x08,
+    /// Acknowledgement for a previously delivered message.
+    MessageAck = 0x09,
 }
 
 impl ControlType {
@@ -32,6 +38,9 @@ impl ControlType {
             0x04 => Ok(Self::Rekey),
             0x05 => Ok(Self::Ping),
             0x06 => Ok(Self::Pong),
+            0x07 => Ok(Self::PeerInfo),
+            0x08 => Ok(Self::Message),
+            0x09 => Ok(Self::MessageAck),
             other => Err(PimError::Protocol(format!(
                 "unknown control type: 0x{other:02x}"
             ))),
@@ -79,6 +88,37 @@ pub enum ControlFrame {
         /// Opaque value copied from the ping request.
         nonce: u64,
     },
+    /// Identity metadata exchanged once after the session is established
+    /// so that peers can address each other by `NodeId` and end-to-end
+    /// encrypt to the recipient's static X25519 key.
+    PeerInfo {
+        /// X25519 public key derived from the sender's Ed25519 seed.
+        x25519_pub: [u8; 32],
+        /// Sender's friendly node name as configured locally (UTF-8,
+        /// length-prefixed by `u8` — capped at 255 bytes by the codec).
+        friendly_name: String,
+    },
+    /// End-to-end encrypted user message.
+    ///
+    /// Carried inside a [`MeshDataFrame`](crate::MeshDataFrame) with both
+    /// [`DataFlags::IS_CONTROL`](crate::DataFlags::IS_CONTROL) and
+    /// [`DataFlags::IS_E2E`](crate::DataFlags::IS_E2E) set. `ciphertext`
+    /// is the literal output of `pim_crypto::e2e_encrypt`.
+    Message {
+        /// 16-byte stable identifier (UUIDv4 bytes).
+        message_id: [u8; 16],
+        /// Sender-stamped wall-clock time in milliseconds since epoch.
+        timestamp_ms: u64,
+        /// ECIES-encrypted UTF-8 plaintext.
+        ciphertext: Vec<u8>,
+    },
+    /// Receipt for a previously sent [`ControlFrame::Message`].
+    MessageAck {
+        /// Identifier of the original message being acknowledged.
+        message_id: [u8; 16],
+        /// Acknowledgement category: `1 = delivered`, `2 = read`.
+        ack_kind: u8,
+    },
 }
 
 impl FrameCodec for ControlFrame {
@@ -118,6 +158,37 @@ impl FrameCodec for ControlFrame {
             ControlFrame::Pong { nonce } => {
                 buf.put_u8(ControlType::Pong as u8);
                 buf.put_u64(*nonce);
+            }
+            ControlFrame::PeerInfo {
+                x25519_pub,
+                friendly_name,
+            } => {
+                buf.put_u8(ControlType::PeerInfo as u8);
+                buf.put_slice(x25519_pub);
+                let name_bytes = friendly_name.as_bytes();
+                let name_len = name_bytes.len().min(255) as u8;
+                buf.put_u8(name_len);
+                buf.put_slice(&name_bytes[..name_len as usize]);
+            }
+            ControlFrame::Message {
+                message_id,
+                timestamp_ms,
+                ciphertext,
+            } => {
+                buf.put_u8(ControlType::Message as u8);
+                buf.put_slice(message_id);
+                buf.put_u64(*timestamp_ms);
+                let ciphertext_len = ciphertext.len().min(u16::MAX as usize) as u16;
+                buf.put_u16(ciphertext_len);
+                buf.put_slice(&ciphertext[..ciphertext_len as usize]);
+            }
+            ControlFrame::MessageAck {
+                message_id,
+                ack_kind,
+            } => {
+                buf.put_u8(ControlType::MessageAck as u8);
+                buf.put_slice(message_id);
+                buf.put_u8(*ack_kind);
             }
         }
     }
@@ -193,6 +264,73 @@ impl FrameCodec for ControlFrame {
                 let nonce = (&buf[1..9]).get_u64();
                 buf.advance(9);
                 Ok(ControlFrame::Pong { nonce })
+            }
+            ControlType::PeerInfo => {
+                // 1 (tag) + 32 (x25519) + 1 (name_len) + N (name)
+                if buf.len() < 34 {
+                    return Err(PimError::Protocol("PeerInfo too short".into()));
+                }
+                let mut x25519_pub = [0u8; 32];
+                x25519_pub.copy_from_slice(&buf[1..33]);
+                let name_len = buf[33] as usize;
+                let total = 34 + name_len;
+                if buf.len() < total {
+                    return Err(PimError::Protocol(format!(
+                        "PeerInfo truncated: need {total}, have {}",
+                        buf.len()
+                    )));
+                }
+                let friendly_name = match std::str::from_utf8(&buf[34..total]) {
+                    Ok(s) => s.to_owned(),
+                    Err(_) => {
+                        return Err(PimError::Protocol(
+                            "PeerInfo friendly_name not valid UTF-8".into(),
+                        ))
+                    }
+                };
+                buf.advance(total);
+                Ok(ControlFrame::PeerInfo {
+                    x25519_pub,
+                    friendly_name,
+                })
+            }
+            ControlType::Message => {
+                // 1 (tag) + 16 (id) + 8 (ts) + 2 (len) + N (ciphertext)
+                if buf.len() < 27 {
+                    return Err(PimError::Protocol("Message too short".into()));
+                }
+                let mut message_id = [0u8; 16];
+                message_id.copy_from_slice(&buf[1..17]);
+                let timestamp_ms = (&buf[17..25]).get_u64();
+                let ciphertext_len = (&buf[25..27]).get_u16() as usize;
+                let total = 27 + ciphertext_len;
+                if buf.len() < total {
+                    return Err(PimError::Protocol(format!(
+                        "Message truncated: need {total}, have {}",
+                        buf.len()
+                    )));
+                }
+                let ciphertext = buf[27..total].to_vec();
+                buf.advance(total);
+                Ok(ControlFrame::Message {
+                    message_id,
+                    timestamp_ms,
+                    ciphertext,
+                })
+            }
+            ControlType::MessageAck => {
+                // 1 (tag) + 16 (id) + 1 (ack_kind)
+                if buf.len() < 18 {
+                    return Err(PimError::Protocol("MessageAck too short".into()));
+                }
+                let mut message_id = [0u8; 16];
+                message_id.copy_from_slice(&buf[1..17]);
+                let ack_kind = buf[17];
+                buf.advance(18);
+                Ok(ControlFrame::MessageAck {
+                    message_id,
+                    ack_kind,
+                })
             }
         }
     }

--- a/crates/pim-protocol/src/control_frame/tests/basics.rs
+++ b/crates/pim-protocol/src/control_frame/tests/basics.rs
@@ -76,3 +76,64 @@ fn reject_truncated_ip_assign() {
     let mut buf = BytesMut::from(&[0x02, 10, 77, 0][..]); // too short
     assert!(ControlFrame::decode(&mut buf).is_err());
 }
+
+#[test]
+fn peer_info_round_trip() {
+    let frame = ControlFrame::PeerInfo {
+        x25519_pub: [0x11; 32],
+        friendly_name: "client-a-macbook".into(),
+    };
+    let mut buf = BytesMut::new();
+    frame.encode(&mut buf);
+    let decoded = ControlFrame::decode(&mut buf).unwrap();
+    assert_eq!(frame, decoded);
+}
+
+#[test]
+fn peer_info_empty_name_round_trip() {
+    let frame = ControlFrame::PeerInfo {
+        x25519_pub: [0x22; 32],
+        friendly_name: String::new(),
+    };
+    let mut buf = BytesMut::new();
+    frame.encode(&mut buf);
+    let decoded = ControlFrame::decode(&mut buf).unwrap();
+    assert_eq!(frame, decoded);
+}
+
+#[test]
+fn message_round_trip() {
+    let frame = ControlFrame::Message {
+        message_id: [0x55; 16],
+        timestamp_ms: 1_745_960_000_000,
+        ciphertext: vec![0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE],
+    };
+    let mut buf = BytesMut::new();
+    frame.encode(&mut buf);
+    let decoded = ControlFrame::decode(&mut buf).unwrap();
+    assert_eq!(frame, decoded);
+}
+
+#[test]
+fn message_ack_round_trip() {
+    let frame = ControlFrame::MessageAck {
+        message_id: [0x77; 16],
+        ack_kind: 1,
+    };
+    let mut buf = BytesMut::new();
+    frame.encode(&mut buf);
+    let decoded = ControlFrame::decode(&mut buf).unwrap();
+    assert_eq!(frame, decoded);
+}
+
+#[test]
+fn reject_truncated_peer_info() {
+    let mut buf = BytesMut::from(&[0x07, 0x00, 0x01][..]); // too short
+    assert!(ControlFrame::decode(&mut buf).is_err());
+}
+
+#[test]
+fn reject_truncated_message() {
+    let mut buf = BytesMut::from(&[0x08, 0x00][..]); // too short
+    assert!(ControlFrame::decode(&mut buf).is_err());
+}


### PR DESCRIPTION
## Summary

Adds end-to-end encrypted text messaging on top of the existing mesh, persisted across daemon restarts and addressed by the peer's stable cryptographic identity (`node_id`) so name / IP changes don't break a conversation.

## What's in scope

**Wire layer (`pim-protocol`)**
- 3 new \`ControlType\` variants on \`ControlFrame\`:
  - \`PeerInfo\` (0x07) — one-shot exchange of (X25519 pub, friendly_name) right after handshake
  - \`Message\` (0x08) — ECIES-encrypted user message body
  - \`MessageAck\` (0x09) — delivered / read receipt
- Round-trip + truncation tests.

**Daemon (\`pim-daemon::messaging\`)**
- New module backed by SQLite (\`rusqlite\` + \`bundled\` feature) at \`data_dir/messages.db\`. Tables: \`peers_seen\`, \`messages\`, \`conversations_meta\`.
- ECIES via the existing \`pim_crypto::e2e_encrypt\` / \`e2e_decrypt_in_place\` (ephemeral X25519 + HKDF + AES-256-GCM) — multi-hop routing rides on \`MeshDataFrame\` with \`IS_CONTROL\`, so relays see metadata + ciphertext only.
- Broadcast channel for \`messages.event\` fan-out; handshake_initiator + handshake_responder send PeerInfo automatically.
- DaemonState bumped to \`pub(crate)\` so the new messaging module's helpers don't trip clippy's private-in-public lint.

**JSON-RPC surface**
- \`messages.list_conversations\` / \`messages.history\` / \`messages.send\` / \`messages.mark_read\`
- \`messages.subscribe\` / \`messages.unsubscribe\`
- \`messages.event\` stream (message_received, message_status, peer_seen)
- New error codes: \`MessagePeerUnknown\` (-32060), \`MessageBodyTooLarge\` (-32061), \`MessageStorageError\` (-32062)

**Persistent state path**
- \`runtime_paths::data_dir()\` returns \`\$XDG_DATA_HOME/pim\` on Linux, \`~/Library/Application Support/pim\` on macOS.

## Threat model (honest)

- ✅ End-to-end (intermediate hops cannot decrypt)
- ✅ Authenticated (mesh Noise envelope on the link layer + sender's Ed25519 identity in node_id)
- ✅ Stable across name / IP changes (identity = \`node_id\`)
- ✅ Forward secrecy under sender compromise (ephemeral X25519 per message)
- ⚠ Recipient compromise reveals history (no double-ratchet in v1; can layer Signal-style later)
- ⚠ Metadata leak to relays: graph-position + timestamp + size only
- ⚠ Multi-hop messaging to non-direct peers requires X25519 to be cached locally first; gossip via RouteUpdate deferred to v1.1

## Pre-flight checks (local)

- \`cargo fmt --all --check\` ✅
- \`cargo clippy -p pim-daemon --bin pim-daemon --no-deps --locked -- -D warnings\` — clean for new code (the 2 remaining errors on macOS — \`transport_listen_port\` and \`ipv6_destination\` — also reproduce on plain \`develop\` HEAD and are cfg-gated to Linux paths used by CI)
- \`cargo test --workspace --locked\` ✅ — **403 passed, 0 failed**
- \`scripts/test-config-generators.sh\` ✅

## Companion change (separate)

The pim-ui side (RPC types mirror, hooks, Messages tab UI, ⌘2 binding) lands directly on the pim-ui \`main\` branch in lockstep — see the design spec at \`pim-ui/docs/superpowers/specs/2026-04-30-messaging-design.md\` for the full plan.

## Test plan

- [ ] Linux CI passes (\`cargo fmt --check\`, \`clippy -D warnings\`, \`cargo test --workspace --locked\`)
- [ ] macOS CI passes (same gates)
- [ ] Live walkthrough on two peers: PeerInfo round-trip → \`messages.send\` → recipient \`message_received\` event → \`MessageAck\` round-trip → status flips to \`delivered\`
- [ ] Restart daemon mid-conversation: history survives, peer_node_id-keyed lookup still works after the peer's mesh IP rotates