### PR TITLE
feat(daemon): peers.forget + messages.delete_conversation/delete_all

### DIFF
--- a/crates/pim-daemon/src/messaging.rs
+++ b/crates/pim-daemon/src/messaging.rs
@@ -27,8 +27,8 @@ mod storage;
 pub(crate) mod dispatch;
 
 pub(crate) use storage::{
-    AckKind, ConversationSummary, ImportOutcome, MessageDirection, MessageRecord, MessageStatus,
-    MessagingStorage,
+    AckKind, ConversationSummary, ForgetPeerOutcome, ImportOutcome, MessageDirection,
+    MessageRecord, MessageStatus, MessagingStorage,
 };
 
 use std::path::PathBuf;
@@ -95,6 +95,27 @@ pub enum MessageEvent {
         /// vs. broadcast-discovered peers.
         via: PeerInfoSource,
     },
+    /// Message history was wiped — `scope: "peer"` carries
+    /// `peer_node_id`; `scope: "all"` clears everything. Lets live
+    /// UIs flush their per-peer message buffers + conversation rows
+    /// without an extra refetch.
+    HistoryCleared {
+        peer_node_id: Option<String>,
+        scope: HistoryScope,
+        /// Number of message rows the daemon actually deleted.
+        deleted_messages: i64,
+    },
+}
+
+/// Discriminator for `HistoryCleared` — `peer` (one conversation)
+/// vs. `all` (everything).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HistoryScope {
+    /// One conversation cleared; `peer_node_id` is set.
+    Peer,
+    /// All conversations cleared; `peer_node_id` is `None`.
+    All,
 }
 
 /// Daemon-side messaging facade exposed via [`crate::app::DaemonState`].
@@ -175,6 +196,77 @@ impl MessagingState {
             });
         }
 
+        Ok(outcome)
+    }
+
+    /// Atomic per-peer wipe — see [`MessagingStorage::delete_conversation`].
+    /// Emits `HistoryCleared { scope: Peer }` on success so live UIs
+    /// drop the buffer + sidebar row without polling.
+    pub async fn delete_conversation(&self, peer: NodeId) -> anyhow::Result<(usize, bool)> {
+        let storage = self.storage.clone();
+        let peer_hex = hex_node_id(&peer);
+        let peer_hex_for_storage = peer_hex.clone();
+        let outcome = tokio::task::spawn_blocking(move || -> anyhow::Result<(usize, bool)> {
+            storage.delete_conversation(&peer_hex_for_storage)
+        })
+        .await??;
+        let _ = self.events_tx.send(MessageEvent::HistoryCleared {
+            peer_node_id: Some(peer_hex),
+            scope: HistoryScope::Peer,
+            deleted_messages: outcome.0 as i64,
+        });
+        Ok(outcome)
+    }
+
+    /// Atomic global wipe — see [`MessagingStorage::delete_all_messages`].
+    /// Emits `HistoryCleared { scope: All }`.
+    pub async fn delete_all_messages(&self) -> anyhow::Result<(usize, usize)> {
+        let storage = self.storage.clone();
+        let outcome = tokio::task::spawn_blocking(move || -> anyhow::Result<(usize, usize)> {
+            storage.delete_all_messages()
+        })
+        .await??;
+        let _ = self.events_tx.send(MessageEvent::HistoryCleared {
+            peer_node_id: None,
+            scope: HistoryScope::All,
+            deleted_messages: outcome.0 as i64,
+        });
+        Ok(outcome)
+    }
+
+    /// Drop the cached identity for a peer (and optionally its
+    /// message history). Emits `peer_seen { x25519_known: false }`
+    /// so the discovered/known sidebar drops the row immediately,
+    /// plus `HistoryCleared { scope: Peer }` when messages were
+    /// also wiped.
+    pub async fn forget_peer(
+        &self,
+        peer: NodeId,
+        also_delete_messages: bool,
+    ) -> anyhow::Result<ForgetPeerOutcome> {
+        let storage = self.storage.clone();
+        let peer_hex = hex_node_id(&peer);
+        let peer_hex_for_storage = peer_hex.clone();
+        let outcome = tokio::task::spawn_blocking(move || -> anyhow::Result<ForgetPeerOutcome> {
+            storage.forget_peer(&peer_hex_for_storage, also_delete_messages)
+        })
+        .await??;
+
+        if outcome.forgot_identity {
+            let _ = self.events_tx.send(MessageEvent::PeerSeen {
+                peer_node_id: peer_hex.clone(),
+                name: String::new(),
+                x25519_known: false,
+                via: PeerInfoSource::Direct,
+            });
+        }
+        if also_delete_messages && outcome.deleted_messages > 0 {
+            let _ = self.events_tx.send(MessageEvent::HistoryCleared {
+                peer_node_id: Some(peer_hex),
+                scope: HistoryScope::Peer,
+                deleted_messages: outcome.deleted_messages as i64,
+            });
+        }
         Ok(outcome)
     }
 

--- a/crates/pim-daemon/src/messaging/storage.rs
+++ b/crates/pim-daemon/src/messaging/storage.rs
@@ -150,6 +150,19 @@ pub struct ConversationSummary {
     pub x25519_pubkey: Option<String>,
 }
 
+/// Outcome of [`MessagingStorage::forget_peer`]. Reported back through
+/// `peers.forget` so the UI can surface exact counts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForgetPeerOutcome {
+    /// True when a `peers_seen` row existed and was removed.
+    pub forgot_identity: bool,
+    /// Number of `messages` rows deleted (only non-zero when the
+    /// caller asked to also wipe message history).
+    pub deleted_messages: usize,
+    /// True when a `conversations_meta` row existed and was removed.
+    pub deleted_conversation: bool,
+}
+
 /// Outcome of an out-of-band identity import
 /// ([`MessagingStorage::import_peer_identity_if_compatible`]).
 ///
@@ -609,6 +622,76 @@ impl MessagingStorage {
         Ok(rows)
     }
 
+    /// Atomic per-peer wipe of `messages` and `conversations_meta`.
+    /// Returns `(deleted_messages, deleted_conversation)` so the
+    /// caller can report exact counts to the RPC client.
+    /// Does NOT touch `peers_seen` — the cached x25519 stays so the
+    /// peer remains messageable.
+    pub fn delete_conversation(&self, peer_id_hex: &str) -> Result<(usize, bool)> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let deleted_messages = tx.execute(
+            "DELETE FROM messages WHERE peer_node_id = ?1",
+            params![peer_id_hex],
+        )?;
+        let deleted_meta = tx.execute(
+            "DELETE FROM conversations_meta WHERE peer_node_id = ?1",
+            params![peer_id_hex],
+        )?;
+        tx.commit()?;
+        Ok((deleted_messages, deleted_meta > 0))
+    }
+
+    /// Atomic global wipe of every message + conversation row.
+    /// Identities in `peers_seen` are preserved — that's a separate
+    /// "factory reset" we don't expose yet. Returns
+    /// `(deleted_messages, deleted_conversations)`.
+    pub fn delete_all_messages(&self) -> Result<(usize, usize)> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let deleted_messages = tx.execute("DELETE FROM messages", [])?;
+        let deleted_meta = tx.execute("DELETE FROM conversations_meta", [])?;
+        tx.commit()?;
+        Ok((deleted_messages, deleted_meta))
+    }
+
+    /// Drop a peer's identity row from `peers_seen`. Returns whether
+    /// a row was actually removed (false ⇒ peer was already unknown).
+    /// `also_delete_messages` extends the same transaction with a
+    /// per-peer `delete_conversation` so the wipe is atomic across
+    /// all three tables.
+    pub fn forget_peer(
+        &self,
+        peer_id_hex: &str,
+        also_delete_messages: bool,
+    ) -> Result<ForgetPeerOutcome> {
+        let mut conn = self.conn.lock().unwrap();
+        let tx = conn.transaction()?;
+        let (deleted_messages, deleted_conversation) = if also_delete_messages {
+            let m = tx.execute(
+                "DELETE FROM messages WHERE peer_node_id = ?1",
+                params![peer_id_hex],
+            )?;
+            let c = tx.execute(
+                "DELETE FROM conversations_meta WHERE peer_node_id = ?1",
+                params![peer_id_hex],
+            )?;
+            (m, c > 0)
+        } else {
+            (0, false)
+        };
+        let forgot_identity = tx.execute(
+            "DELETE FROM peers_seen WHERE node_id = ?1",
+            params![peer_id_hex],
+        )? > 0;
+        tx.commit()?;
+        Ok(ForgetPeerOutcome {
+            forgot_identity,
+            deleted_messages,
+            deleted_conversation,
+        })
+    }
+
     /// Mark every message at-or-before `up_to_ts_ms` as read for the peer.
     /// Returns the new `unread_count` (always 0).
     pub fn mark_read_up_to(&self, peer_id_hex: &str, up_to_ts_ms: i64) -> Result<i64> {
@@ -831,5 +914,154 @@ mod tests {
             .find(|c| c.peer_node_id == peer_hex)
             .expect("have one");
         assert_eq!(convo.x25519_pubkey.as_deref(), Some(hex32(&key).as_str()));
+    }
+
+    /// Helper: insert one inbound row + bump the conversations_meta
+    /// counter for the given peer so the delete tests have something
+    /// concrete to wipe.
+    fn seed_one_inbound(storage: &MessagingStorage, peer: &NodeId, body: &str, ts: i64, id: &str) {
+        let peer_hex = hex_node_id(peer);
+        let _ = storage
+            .bump_conversation_after_remote_receive(&peer_hex, id, ts, body, None)
+            .unwrap();
+        // bump_conversation_after_remote_receive doesn't insert into the
+        // `messages` table itself; do it explicitly so deletion has a row.
+        let record = MessageRecord {
+            id: id.to_string(),
+            peer_node_id: peer_hex,
+            direction: MessageDirection::Received,
+            body: body.to_string(),
+            timestamp_ms: ts,
+            status: MessageStatus::Delivered,
+            failure_reason: None,
+            delivered_at_ms: Some(ts),
+            read_at_ms: None,
+        };
+        storage.insert_message(&record).expect("insert");
+    }
+
+    #[test]
+    fn delete_conversation_wipes_messages_and_meta_for_peer() {
+        let (_d, storage) = open_temp_storage();
+        let key = [0xaau8; 32];
+        storage
+            .import_peer_identity_if_compatible(&node_a(), &key, Some("alice"), 100)
+            .unwrap();
+        seed_one_inbound(&storage, &node_a(), "hello", 200, "aaaa1111aaaa1111");
+        seed_one_inbound(&storage, &node_a(), "world", 300, "bbbb2222bbbb2222");
+
+        let (deleted_messages, deleted_conversation) = storage
+            .delete_conversation(&hex_node_id(&node_a()))
+            .unwrap();
+        assert_eq!(deleted_messages, 2);
+        assert!(deleted_conversation);
+
+        // Cached x25519 identity must remain so the peer stays messageable.
+        let cached = storage
+            .lookup_x25519_pub(&node_a())
+            .expect("lookup")
+            .expect("present");
+        assert_eq!(cached, key);
+        // Conversation list no longer contains the peer.
+        let convos = storage.list_conversations().expect("list");
+        assert!(convos
+            .iter()
+            .all(|c| c.peer_node_id != hex_node_id(&node_a())));
+        // History page is empty.
+        let (rows, _) = storage.history(&hex_node_id(&node_a()), None, 100).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn delete_conversation_on_unknown_peer_is_noop() {
+        let (_d, storage) = open_temp_storage();
+        let (deleted_messages, deleted_conversation) = storage
+            .delete_conversation(&hex_node_id(&node_a()))
+            .unwrap();
+        assert_eq!(deleted_messages, 0);
+        assert!(!deleted_conversation);
+    }
+
+    #[test]
+    fn delete_all_messages_wipes_every_conversation_but_keeps_identities() {
+        let (_d, storage) = open_temp_storage();
+        let key_a = [0xbbu8; 32];
+        let key_b = [0xccu8; 32];
+        storage
+            .import_peer_identity_if_compatible(&node_a(), &key_a, Some("alice"), 100)
+            .unwrap();
+        storage
+            .import_peer_identity_if_compatible(&node_b(), &key_b, Some("bob"), 100)
+            .unwrap();
+        seed_one_inbound(
+            &storage,
+            &node_a(),
+            "hi from alice",
+            200,
+            "aaaa1111aaaa1111",
+        );
+        seed_one_inbound(&storage, &node_b(), "hi from bob", 200, "bbbb2222bbbb2222");
+        seed_one_inbound(&storage, &node_b(), "again", 250, "cccc3333cccc3333");
+
+        let (deleted_messages, deleted_conversations) = storage.delete_all_messages().unwrap();
+        assert_eq!(deleted_messages, 3);
+        assert_eq!(deleted_conversations, 2);
+
+        // Identities preserved.
+        assert_eq!(storage.lookup_x25519_pub(&node_a()).unwrap(), Some(key_a));
+        assert_eq!(storage.lookup_x25519_pub(&node_b()).unwrap(), Some(key_b));
+        // Conversation list empty.
+        assert!(storage.list_conversations().unwrap().is_empty());
+    }
+
+    #[test]
+    fn forget_peer_default_keeps_messages() {
+        let (_d, storage) = open_temp_storage();
+        let key = [0xddu8; 32];
+        storage
+            .import_peer_identity_if_compatible(&node_a(), &key, Some("alice"), 100)
+            .unwrap();
+        seed_one_inbound(&storage, &node_a(), "hi", 200, "aaaa1111aaaa1111");
+
+        let outcome = storage.forget_peer(&hex_node_id(&node_a()), false).unwrap();
+        assert!(outcome.forgot_identity);
+        assert_eq!(outcome.deleted_messages, 0);
+        assert!(!outcome.deleted_conversation);
+
+        // Identity is gone …
+        assert!(storage.lookup_x25519_pub(&node_a()).unwrap().is_none());
+        // … but messages stay (the conversation row falls back to short_id
+        // for `name` because the peers_seen JOIN now misses).
+        let (rows, _) = storage.history(&hex_node_id(&node_a()), None, 100).unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[test]
+    fn forget_peer_with_messages_flag_wipes_everything() {
+        let (_d, storage) = open_temp_storage();
+        let key = [0xeeu8; 32];
+        storage
+            .import_peer_identity_if_compatible(&node_a(), &key, Some("alice"), 100)
+            .unwrap();
+        seed_one_inbound(&storage, &node_a(), "hi", 200, "aaaa1111aaaa1111");
+        seed_one_inbound(&storage, &node_a(), "again", 300, "bbbb2222bbbb2222");
+
+        let outcome = storage.forget_peer(&hex_node_id(&node_a()), true).unwrap();
+        assert!(outcome.forgot_identity);
+        assert_eq!(outcome.deleted_messages, 2);
+        assert!(outcome.deleted_conversation);
+
+        assert!(storage.lookup_x25519_pub(&node_a()).unwrap().is_none());
+        let (rows, _) = storage.history(&hex_node_id(&node_a()), None, 100).unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn forget_peer_unknown_returns_false_flags() {
+        let (_d, storage) = open_temp_storage();
+        let outcome = storage.forget_peer(&hex_node_id(&node_a()), true).unwrap();
+        assert!(!outcome.forgot_identity);
+        assert_eq!(outcome.deleted_messages, 0);
+        assert!(!outcome.deleted_conversation);
     }
 }

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -407,6 +407,7 @@ async fn dispatch(state: &Arc<DaemonState>, req: &RpcRequest, write_tx: &WriteTx
             None,
         )),
         "peers.import_identity" => method_peers_import_identity(state, req.params.as_ref()).await,
+        "peers.forget" => method_peers_forget(state, req.params.as_ref()).await,
         "peers.broadcast_identity_now" => method_peers_broadcast_identity_now(state).await,
         "peers.set_broadcast_config" => {
             method_peers_set_broadcast_config(state, req.params.as_ref()).await
@@ -443,6 +444,10 @@ async fn dispatch(state: &Arc<DaemonState>, req: &RpcRequest, write_tx: &WriteTx
         "messages.history" => method_messages_history(state, req.params.as_ref()).await,
         "messages.send" => method_messages_send(state, req.params.as_ref()).await,
         "messages.mark_read" => method_messages_mark_read(state, req.params.as_ref()).await,
+        "messages.delete_conversation" => {
+            method_messages_delete_conversation(state, req.params.as_ref()).await
+        }
+        "messages.delete_all" => method_messages_delete_all(state).await,
         "messages.subscribe" => Ok(json!({ "subscription_id": new_subscription_id() })),
         "messages.unsubscribe" => Ok(Value::Null),
 
@@ -1278,6 +1283,124 @@ async fn method_peers_import_identity(
             })),
         )),
     }
+}
+
+// ── Delete utilities ─────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct PeersForgetParams {
+    /// 32-char lowercase hex NodeId.
+    node_id: String,
+    /// When true, also wipes the message history for this peer.
+    /// Defaults to false (less destructive).
+    #[serde(default)]
+    also_delete_messages: bool,
+}
+
+async fn method_peers_forget(state: &Arc<DaemonState>, params: Option<&Value>) -> RpcResult {
+    let parsed: PeersForgetParams = match params {
+        Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
+            (
+                codes::INVALID_PARAMS,
+                format!("peers.forget: invalid params: {e}"),
+                None,
+            )
+        })?,
+        None => {
+            return Err((
+                codes::INVALID_PARAMS,
+                "peers.forget: params required".into(),
+                None,
+            ))
+        }
+    };
+    let node_id: NodeId = parsed.node_id.parse().map_err(|e| {
+        (
+            codes::INVALID_PARAMS,
+            format!("peers.forget: invalid node_id: {e}"),
+            None,
+        )
+    })?;
+    let outcome = state
+        .messaging
+        .forget_peer(node_id, parsed.also_delete_messages)
+        .await
+        .map_err(|e| {
+            (
+                codes::MESSAGE_STORAGE_ERROR,
+                format!("peers.forget: {e}"),
+                None,
+            )
+        })?;
+    Ok(json!({
+        "forgot_identity": outcome.forgot_identity,
+        "deleted_messages": outcome.deleted_messages,
+        "deleted_conversation": outcome.deleted_conversation,
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+struct MessagesDeleteConversationParams {
+    peer_node_id: String,
+}
+
+async fn method_messages_delete_conversation(
+    state: &Arc<DaemonState>,
+    params: Option<&Value>,
+) -> RpcResult {
+    let parsed: MessagesDeleteConversationParams = match params {
+        Some(v) => serde_json::from_value(v.clone()).map_err(|e| {
+            (
+                codes::INVALID_PARAMS,
+                format!("messages.delete_conversation: invalid params: {e}"),
+                None,
+            )
+        })?,
+        None => {
+            return Err((
+                codes::INVALID_PARAMS,
+                "messages.delete_conversation: params required".into(),
+                None,
+            ))
+        }
+    };
+    let node_id: NodeId = parsed.peer_node_id.parse().map_err(|e| {
+        (
+            codes::INVALID_PARAMS,
+            format!("messages.delete_conversation: invalid peer_node_id: {e}"),
+            None,
+        )
+    })?;
+    let (deleted_messages, deleted_conversation) = state
+        .messaging
+        .delete_conversation(node_id)
+        .await
+        .map_err(|e| {
+            (
+                codes::MESSAGE_STORAGE_ERROR,
+                format!("messages.delete_conversation: {e}"),
+                None,
+            )
+        })?;
+    Ok(json!({
+        "deleted_messages": deleted_messages,
+        "deleted_conversation": deleted_conversation,
+    }))
+}
+
+async fn method_messages_delete_all(state: &Arc<DaemonState>) -> RpcResult {
+    let (deleted_messages, deleted_conversations) =
+        state.messaging.delete_all_messages().await.map_err(|e| {
+            (
+                codes::MESSAGE_STORAGE_ERROR,
+                format!("messages.delete_all: {e}"),
+                None,
+            )
+        })?;
+    Ok(json!({
+        "deleted_messages": deleted_messages,
+        "deleted_conversations": deleted_conversations,
+    }))
 }
 
 // ── Broadcast control ────────────────────────────────────────────────────


### PR DESCRIPTION
Surfaces three destructive utilities for the messaging keystore so the
UI can offer "forget peer", "delete history (per conversation)", and
"delete all chats". Each operation is atomic via a single SQLite
transaction.

- `peers.forget { node_id, also_delete_messages?: bool=false }`:
  drops the `peers_seen` row; optionally extends the same transaction
  with a per-peer `messages` + `conversations_meta` wipe. Default
  keeps the messages so users don't lose history when revoking trust.
- `messages.delete_conversation { peer_node_id }`: per-peer wipe of
  `messages` + `conversations_meta`; keeps the cached x25519 so the
  peer remains messageable.
- `messages.delete_all`: nuclear wipe of every `messages` and
  `conversations_meta` row; preserves identities in `peers_seen`.

Eventing:
- New `MessageEvent::HistoryCleared { peer_node_id?, scope,
deleted_messages }`
  with a `HistoryScope` enum (`Peer` | `All`) so live UIs can flush
  per-peer message buffers + sidebar rows without an extra round-trip.
- `peers.forget` additionally emits `peer_seen { x25519_known: false }`
  so the discovered/known sidebar drops the row immediately.

Six new storage tests: per-peer delete (incl. unknown-peer no-op),
delete-all (preserves identities), `forget_peer` default-keeps-msgs,
`forget_peer` with-messages-flag, `forget_peer` unknown.

Pre-push: fmt + clippy --workspace -D warnings + tests all green
(12 storage tests now, was 6).
