### PR TITLE
fix bt discovery

### DIFF
--- a/crates/pim-bluetooth/src/lib.rs
+++ b/crates/pim-bluetooth/src/lib.rs
@@ -18,13 +18,14 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 #[cfg(target_os = "linux")]
 use std::process::Stdio;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use pim_core::BluetoothConfig;
 #[cfg(target_os = "linux")]
 use tokio::process::Child;
 use tokio::process::Command;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, OnceCell};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -122,6 +123,14 @@ pub struct BluetoothDiscovery {
     #[allow(dead_code)]
     nat_interface: Option<String>,
     peer_tx: mpsc::Sender<SocketAddr>,
+    /// Cached BD address of the local Bluetooth controller, populated
+    /// lazily on first discovery cycle. Used as a self-filter when
+    /// scanning so a remote whose BlueZ-cached name happens to equal our
+    /// `local_alias` isn't mistaken for ourselves. Wrapped in `Arc`
+    /// because the discovery loop holds `&self` and the lookup runs
+    /// inside a `OnceCell::get_or_init` future that may move across
+    /// awaits.
+    local_controller_mac: Arc<OnceCell<Option<String>>>,
 }
 
 impl BluetoothDiscovery {
@@ -204,6 +213,7 @@ impl BluetoothDiscovery {
                 resolv_conf_path: resolv_conf_path.into(),
                 nat_interface: nat_interface.map(Into::into),
                 peer_tx,
+                local_controller_mac: Arc::new(OnceCell::new()),
             },
             peer_rx,
         ))

--- a/crates/pim-bluetooth/src/platform_impl.rs
+++ b/crates/pim-bluetooth/src/platform_impl.rs
@@ -36,6 +36,66 @@ impl BluetoothDiscovery {
         self.run_bluetoothctl_capture(args).await.map(|_| ())
     }
 
+    /// Fire `bluetoothctl <args>` without blocking the caller. The child
+    /// runs to completion (or the configured `bluetoothctl_timeout_s`)
+    /// in a detached tokio task; failures are logged at debug level and
+    /// do not propagate. Used by the discovery loop to re-arm
+    /// `scan on` / `discoverable on` periodically: BlueZ stops scan when
+    /// the issuing client disconnects, and the controller's
+    /// `DiscoverableTimeout` (~3 min) resets the discoverable flag back
+    /// to off — both states have to be refreshed continuously for
+    /// linux↔linux discovery to keep working past the first boot window.
+    #[cfg(target_os = "linux")]
+    pub(super) fn run_bluetoothctl_in_background(&self, args: &[&'static str]) {
+        let bluetoothctl = self.bluetoothctl_command.clone();
+        let timeout = self.config.bluetoothctl_timeout_s;
+        let owned: Vec<&'static str> = args.to_vec();
+        tokio::spawn(async move {
+            let mut cmd = Command::new(&bluetoothctl);
+            cmd.arg("--timeout")
+                .arg(timeout.to_string())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .kill_on_drop(true);
+            for a in owned {
+                cmd.arg(a);
+            }
+            match cmd.spawn() {
+                Ok(mut child) => {
+                    if let Err(err) = child.wait().await {
+                        debug!(%err, "background bluetoothctl child wait failed");
+                    }
+                }
+                Err(err) => {
+                    debug!(%err, "background bluetoothctl spawn failed");
+                }
+            }
+        });
+    }
+
+    /// Resolve the local controller's BD address (`Controller XX:..:XX`).
+    /// Cached after the first successful query — `bluetoothctl show` is
+    /// a non-trivial round-trip and the controller MAC is stable across
+    /// the daemon's lifetime.
+    pub(super) async fn local_controller_mac(&self) -> Option<String> {
+        self.local_controller_mac
+            .get_or_init(|| async {
+                #[cfg(target_os = "linux")]
+                let args = ["show"];
+                #[cfg(target_os = "macos")]
+                let args = ["--list"];
+                match self.run_bluetoothctl_capture(args).await {
+                    Ok(out) => parse_controller_mac(&out),
+                    Err(err) => {
+                        debug!(%err, "failed to query local Bluetooth controller MAC");
+                        None
+                    }
+                }
+            })
+            .await
+            .clone()
+    }
+
     pub(super) async fn run_bluetoothctl_capture<const N: usize>(
         &self,
         args: [&str; N],
@@ -113,10 +173,12 @@ impl BluetoothDiscovery {
         &self,
     ) -> Result<Vec<DiscoveredDevice>, BluetoothError> {
         let output = self.run_bluetoothctl_capture(["devices"]).await?;
+        let local_mac = self.local_controller_mac().await;
         Ok(parse_devices_output(
             &output,
             &self.config.device_name_prefix,
             &self.config.local_alias,
+            local_mac.as_deref(),
         ))
     }
 
@@ -130,10 +192,12 @@ impl BluetoothDiscovery {
                 &self.config.bluetoothctl_timeout_s.to_string(),
             ])
             .await?;
+        let local_mac = self.local_controller_mac().await;
         Ok(parse_blueutil_inquiry_output(
             &output,
             &self.config.device_name_prefix,
             &self.config.local_alias,
+            local_mac.as_deref(),
         ))
     }
 

--- a/crates/pim-bluetooth/src/service.rs
+++ b/crates/pim-bluetooth/src/service.rs
@@ -29,6 +29,46 @@ impl BluetoothDiscovery {
         if self.config.radio_discovery_enabled {
             self.prepare_controller().await?;
             self.run_bluetoothctl(["scan", "on"]).await?;
+            // Warm the local controller MAC cache so the very first
+            // scan_interval tick already filters by MAC instead of
+            // alias. Best-effort — failures fall back to alias filter.
+            self.local_controller_mac().await;
+        }
+
+        // Re-arm `discoverable on` well before the controller's
+        // DiscoverableTimeout (default 180 s) expires. Without this, a
+        // peer that comes up minutes after our daemon never finds us
+        // because the controller has stopped responding to inquiry-scan.
+        // Runs as a detached task — the periodic re-arm doesn't need to
+        // coordinate with the main discovery select! loop.
+        #[cfg(target_os = "linux")]
+        if self.config.radio_discovery_enabled {
+            let bluetoothctl = self.bluetoothctl_command.clone();
+            let timeout = self.config.bluetoothctl_timeout_s;
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                let mut ticker = tokio::time::interval(Duration::from_secs(60));
+                ticker.tick().await; // skip the immediate first tick (prepare_controller already armed it)
+                loop {
+                    tokio::select! {
+                        _ = cancel.cancelled() => break,
+                        _ = ticker.tick() => {
+                            let mut cmd = Command::new(&bluetoothctl);
+                            cmd.arg("--timeout")
+                                .arg(timeout.to_string())
+                                .arg("discoverable")
+                                .arg("on")
+                                .stdout(Stdio::null())
+                                .stderr(Stdio::null())
+                                .kill_on_drop(true);
+                            match cmd.spawn() {
+                                Ok(mut child) => { let _ = child.wait().await; }
+                                Err(err) => debug!(%err, "discoverable keepalive spawn failed"),
+                            }
+                        }
+                    }
+                }
+            });
         }
 
         #[cfg(target_os = "linux")]
@@ -170,6 +210,16 @@ impl BluetoothDiscovery {
                     }
                 }
                 _ = scan_interval.tick(), if self.config.radio_discovery_enabled && self.config.connect_pan => {
+                    // Re-arm BlueZ inquiry: `bluetoothctl --timeout N
+                    // scan on` from prepare_controller stops issuing
+                    // StartDiscovery once the bluetoothctl client exits
+                    // (after `bluetoothctl_timeout_s`). Without this
+                    // periodic re-fire, the daemon's "scan started"
+                    // log lines below are misleading — they only read
+                    // the cached device list, no fresh inquiry happens.
+                    #[cfg(target_os = "linux")]
+                    self.run_bluetoothctl_in_background(&["scan", "on"]);
+
                     #[cfg(target_os = "linux")]
                     {
                         pan_clients.retain(|mac, child| match child.try_wait() {

--- a/crates/pim-bluetooth/src/support.rs
+++ b/crates/pim-bluetooth/src/support.rs
@@ -253,6 +253,7 @@ pub(super) fn parse_devices_output(
     output: &str,
     prefix: &str,
     local_alias: &str,
+    local_mac: Option<&str>,
 ) -> Vec<DiscoveredDevice> {
     let mut devices = Vec::new();
     for line in output.lines() {
@@ -264,7 +265,19 @@ pub(super) fn parse_devices_output(
         let _ = parts.next();
         let Some(mac) = parts.next() else { continue };
         let Some(name) = parts.next() else { continue };
-        if !name.starts_with(prefix) || name == local_alias {
+        if !name.starts_with(prefix) {
+            continue;
+        }
+        // MAC-based self-filter is preferred — BD addresses are unique per
+        // controller, while names are stickily cached by BlueZ and can
+        // collide with our local alias when a remote controller previously
+        // broadcast that alias. Alias check stays as a fallback when MAC
+        // discovery hasn't completed yet.
+        if let Some(self_mac) = local_mac {
+            if mac.eq_ignore_ascii_case(self_mac) {
+                continue;
+            }
+        } else if name == local_alias {
             continue;
         }
         devices.push(DiscoveredDevice {
@@ -275,11 +288,31 @@ pub(super) fn parse_devices_output(
     devices
 }
 
+/// Extract a Bluetooth controller BD address from the first line of
+/// `bluetoothctl show`, which looks like
+/// `Controller 00:15:83:3D:0A:57 (public)`. Returns the MAC verbatim
+/// (uppercase, colon-separated) or `None` when the output doesn't match.
+#[cfg(any(test, target_os = "linux", target_os = "macos"))]
+pub(super) fn parse_controller_mac(output: &str) -> Option<String> {
+    for line in output.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("Controller ") else {
+            continue;
+        };
+        let mac = rest.split_whitespace().next()?;
+        if mac.split(':').count() == 6 && mac.len() == 17 {
+            return Some(mac.to_string());
+        }
+    }
+    None
+}
+
 #[cfg(any(test, target_os = "macos"))]
 pub(super) fn parse_blueutil_inquiry_output(
     output: &str,
     prefix: &str,
     local_alias: &str,
+    local_mac: Option<&str>,
 ) -> Vec<DiscoveredDevice> {
     let mut devices = Vec::new();
 
@@ -303,12 +336,20 @@ pub(super) fn parse_blueutil_inquiry_output(
             continue;
         };
         let name = &name_value[..name_end];
-        if !name.starts_with(prefix) || name == local_alias {
+        if !name.starts_with(prefix) {
+            continue;
+        }
+        let normalised_mac = mac.trim().replace('-', ":").to_uppercase();
+        if let Some(self_mac) = local_mac {
+            if normalised_mac.eq_ignore_ascii_case(self_mac) {
+                continue;
+            }
+        } else if name == local_alias {
             continue;
         }
 
         devices.push(DiscoveredDevice {
-            mac: mac.trim().replace('-', ":").to_uppercase(),
+            mac: normalised_mac,
             name: name.to_string(),
         });
     }

--- a/crates/pim-bluetooth/src/tests/parsers.rs
+++ b/crates/pim-bluetooth/src/tests/parsers.rs
@@ -44,10 +44,49 @@ Device AA:BB:CC:DD:EE:01 PIM-gateway
 Device AA:BB:CC:DD:EE:02 Phone
 Device AA:BB:CC:DD:EE:03 PIM-client
 ";
-    let parsed = parse_devices_output(output, "PIM-", "PIM-self");
+    let parsed = parse_devices_output(output, "PIM-", "PIM-self", None);
     assert_eq!(parsed.len(), 2);
     assert_eq!(parsed[0].mac, "AA:BB:CC:DD:EE:01");
     assert_eq!(parsed[1].name, "PIM-client");
+}
+
+#[test]
+fn devices_output_filters_self_by_mac_when_provided() {
+    // Cached name collides with our local alias (the BlueZ-cache bug
+    // we hit linux↔linux). MAC-based self-filter must keep the entry
+    // so we don't drop a real peer.
+    let output = "\
+Device AA:BB:CC:DD:EE:01 PIM-self
+Device AA:BB:CC:DD:EE:02 PIM-other
+";
+    let parsed = parse_devices_output(output, "PIM-", "PIM-self", Some("00:00:00:00:00:01"));
+    assert_eq!(parsed.len(), 2);
+    assert_eq!(parsed[0].mac, "AA:BB:CC:DD:EE:01");
+    assert_eq!(parsed[0].name, "PIM-self");
+}
+
+#[test]
+fn devices_output_drops_self_when_mac_matches() {
+    let output = "\
+Device AA:BB:CC:DD:EE:01 PIM-gateway
+Device AA:BB:CC:DD:EE:02 PIM-other
+";
+    let parsed = parse_devices_output(output, "PIM-", "PIM-self", Some("aa:bb:cc:dd:ee:01"));
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].mac, "AA:BB:CC:DD:EE:02");
+}
+
+#[test]
+fn parse_controller_mac_extracts_first_line_address() {
+    let show_output = "\
+Controller 00:15:83:3D:0A:57 (public)\n\
+\tAlias: PIM-gateway\n\
+\tDiscoverable: yes\n";
+    assert_eq!(
+        parse_controller_mac(show_output),
+        Some("00:15:83:3D:0A:57".to_string())
+    );
+    assert_eq!(parse_controller_mac("nothing useful here"), None);
 }
 
 #[test]
@@ -56,7 +95,7 @@ fn blueutil_inquiry_output_filters_to_matching_prefix() {
 address: aa-bb-cc-dd-ee-01, not connected, not favourite, not paired, name: \"PIM-gateway\", recent access date: -\n\
 address: aa-bb-cc-dd-ee-02, not connected, not favourite, not paired, name: \"Phone\", recent access date: -\n\
 address: aa-bb-cc-dd-ee-03, not connected, not favourite, not paired, name: \"PIM-self\", recent access date: -\n";
-    let parsed = parse_blueutil_inquiry_output(output, "PIM-", "PIM-self");
+    let parsed = parse_blueutil_inquiry_output(output, "PIM-", "PIM-self", None);
     assert_eq!(parsed.len(), 1);
     assert_eq!(parsed[0].mac, "AA:BB:CC:DD:EE:01");
     assert_eq!(parsed[0].name, "PIM-gateway");


### PR DESCRIPTION
- **fix(bluetooth): re-arm scan/discoverable + MAC-based self-filter**
- **chore(docker): rename phase-numbered lab tests to descriptive names**
- **docs(research): plan to disable BlueZ audio profiles when serving NAP**
- **test(docker): RFCOMM seam — graceful degradation when AF_BLUETOOTH unavailable**
