### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure file permissions when persisting broadcast config

### DIFF
--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1570,7 +1570,8 @@ async fn persist_broadcast_config_to_disk(state: &Arc<DaemonState>) -> anyhow::R
 
         {
             use std::io::Write;
-            let mut file = options.open(&tmp)
+            let mut file = options
+                .open(&tmp)
                 .with_context(|| format!("open tmp {}", tmp.display()))?;
             file.write_all(serialized.as_bytes())
                 .with_context(|| format!("write tmp {}", tmp.display()))?;

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1559,8 +1559,23 @@ async fn persist_broadcast_config_to_disk(state: &Arc<DaemonState>) -> anyhow::R
             .parent()
             .ok_or_else(|| anyhow!("config path has no parent"))?;
         let tmp = tempfile_in_same_dir(parent, &path_for_task)?;
-        std::fs::write(&tmp, serialized.as_bytes())
-            .with_context(|| format!("write tmp {}", tmp.display()))?;
+
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        {
+            use std::io::Write;
+            let mut file = options.open(&tmp)
+                .with_context(|| format!("open tmp {}", tmp.display()))?;
+            file.write_all(serialized.as_bytes())
+                .with_context(|| format!("write tmp {}", tmp.display()))?;
+        }
+
         std::fs::rename(&tmp, &path_for_task)
             .with_context(|| format!("rename {} -> {}", tmp.display(), path_for_task.display()))?;
         Ok(())


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The daemon's broadcast configuration persistence logic in `rpc.rs` used `std::fs::write`, which relies on the system's default `umask`. This could potentially result in the daemon's configuration file being readable or writable by other users on the system.
🎯 Impact: If the system `umask` is overly permissive, an unprivileged user could read or modify the node's network configuration, potentially leading to unauthorized manipulation of the node's broadcast state.
🔧 Fix: Replaced `std::fs::write` with `std::fs::OpenOptions` and explicitly set the file mode to `0o600` (read/write for owner only) on Unix systems. Also used `create_new(true)` to safely fail if the temporary file already exists, preventing potential symlink attacks.
✅ Verification: Ran `cargo test --workspace` to ensure no tests were broken. Manually inspected the code to confirm the file permissions are properly set and the file is properly closed before being renamed.

---
*PR created automatically by Jules for task [14144212806773639508](https://jules.google.com/task/14144212806773639508) started by @Rfluid*