### PR TITLE
⚡ Bolt: [performance improvement] Zero-copy transport framing

### DIFF
--- a/crates/pim-daemon/src/data_plane.rs
+++ b/crates/pim-daemon/src/data_plane.rs
@@ -59,7 +59,7 @@ pub(crate) async fn send_single_mesh(
     }
     .encode(&mut mesh_buf);
 
-    match session.encrypt_frame(&mesh_buf) {
+    match session.encrypt_frame(mesh_buf) {
         Ok(frame) => send_frame_buffered(state, &session.peer_id, frame).await,
         Err(e) => warn!(%dst_id, "encrypt failed: {e}"),
     }

--- a/crates/pim-daemon/src/session.rs
+++ b/crates/pim-daemon/src/session.rs
@@ -12,24 +12,30 @@ pub(crate) struct Session {
 }
 
 impl Session {
-    pub(crate) fn encrypt_frame(&self, plaintext: &[u8]) -> Result<TransportFrame> {
-        let mut payload_buf = plaintext.to_vec();
-        let (nonce, tag) = self.send.encrypt_in_place_detached(&mut payload_buf)?;
+    pub(crate) fn encrypt_frame(&self, mut plaintext: bytes::BytesMut) -> Result<TransportFrame> {
+        // PERFORMANCE: Encrypting the payload in-place inside the `BytesMut` buffer avoids
+        // a runtime memory allocation for the ciphertext on hot network paths.
+        let (nonce, tag) = self.send.encrypt_in_place_detached(&mut plaintext)?;
 
         Ok(TransportFrame {
             frame_type: FrameType::Data,
             nonce,
-            payload: bytes::Bytes::from(payload_buf),
+            payload: plaintext.freeze(), // zero-copy
             tag,
         })
     }
 
     pub(crate) fn decrypt_frame(&self, mut frame: TransportFrame) -> Result<TransportFrame> {
-        let mut payload_buf = frame.payload.to_vec();
+        // PERFORMANCE: Decrypt directly over the uniquely owned `BytesMut` buffer whenever possible
+        // to avoid runtime memory allocation for the plaintext slice.
+        let mut payload_buf = match frame.payload.try_into_mut() {
+            Ok(buf) => buf,
+            Err(payload) => bytes::BytesMut::from(payload.as_ref()), // fallback allocation if shared
+        };
         self.recv
             .decrypt_in_place_detached(&frame.nonce, &mut payload_buf, &frame.tag)?;
 
-        frame.payload = bytes::Bytes::from(payload_buf);
+        frame.payload = payload_buf.freeze(); // zero-copy
         Ok(frame)
     }
 }


### PR DESCRIPTION
💡 What: The optimization implements zero-copy encryption and decryption of frames in the session protocol by removing calls to `.to_vec()` and utilizing `bytes::BytesMut` in-place cipher processing instead.
🎯 Why: Creating new allocations `Vec<u8>` per frame under hot path network routines strains the memory allocator which introduces a performance bottleneck.
📊 Impact: It fundamentally eliminates runtime buffer allocation on hot network framing endpoints by decrypting and encrypting within inherently pre-allocated memory slices. Expected less heap fragmentation and lower CPU cycles per frame.
🔬 Measurement: Verify via `cargo test --workspace` or profiling the daemon application memory profile when routing large payloads.

---
*PR created automatically by Jules for task [10153434397977255873](https://jules.google.com/task/10153434397977255873) started by @Rfluid*