### PR TITLE
fix bt discovery

### DIFF
--- a/crates/pim-bluetooth/src/lib.rs
+++ b/crates/pim-bluetooth/src/lib.rs
@@ -18,13 +18,14 @@ use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 #[cfg(target_os = "linux")]
 use std::process::Stdio;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use pim_core::BluetoothConfig;
 #[cfg(target_os = "linux")]
 use tokio::process::Child;
 use tokio::process::Command;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, OnceCell};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -122,6 +123,14 @@ pub struct BluetoothDiscovery {
     #[allow(dead_code)]
     nat_interface: Option<String>,
     peer_tx: mpsc::Sender<SocketAddr>,
+    /// Cached BD address of the local Bluetooth controller, populated
+    /// lazily on first discovery cycle. Used as a self-filter when
+    /// scanning so a remote whose BlueZ-cached name happens to equal our
+    /// `local_alias` isn't mistaken for ourselves. Wrapped in `Arc`
+    /// because the discovery loop holds `&self` and the lookup runs
+    /// inside a `OnceCell::get_or_init` future that may move across
+    /// awaits.
+    local_controller_mac: Arc<OnceCell<Option<String>>>,
 }
 
 impl BluetoothDiscovery {
@@ -204,6 +213,7 @@ impl BluetoothDiscovery {
                 resolv_conf_path: resolv_conf_path.into(),
                 nat_interface: nat_interface.map(Into::into),
                 peer_tx,
+                local_controller_mac: Arc::new(OnceCell::new()),
             },
             peer_rx,
         ))

--- a/crates/pim-bluetooth/src/platform_impl.rs
+++ b/crates/pim-bluetooth/src/platform_impl.rs
@@ -36,6 +36,66 @@ impl BluetoothDiscovery {
         self.run_bluetoothctl_capture(args).await.map(|_| ())
     }
 
+    /// Fire `bluetoothctl <args>` without blocking the caller. The child
+    /// runs to completion (or the configured `bluetoothctl_timeout_s`)
+    /// in a detached tokio task; failures are logged at debug level and
+    /// do not propagate. Used by the discovery loop to re-arm
+    /// `scan on` / `discoverable on` periodically: BlueZ stops scan when
+    /// the issuing client disconnects, and the controller's
+    /// `DiscoverableTimeout` (~3 min) resets the discoverable flag back
+    /// to off — both states have to be refreshed continuously for
+    /// linux↔linux discovery to keep working past the first boot window.
+    #[cfg(target_os = "linux")]
+    pub(super) fn run_bluetoothctl_in_background(&self, args: &[&'static str]) {
+        let bluetoothctl = self.bluetoothctl_command.clone();
+        let timeout = self.config.bluetoothctl_timeout_s;
+        let owned: Vec<&'static str> = args.to_vec();
+        tokio::spawn(async move {
+            let mut cmd = Command::new(&bluetoothctl);
+            cmd.arg("--timeout")
+                .arg(timeout.to_string())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .kill_on_drop(true);
+            for a in owned {
+                cmd.arg(a);
+            }
+            match cmd.spawn() {
+                Ok(mut child) => {
+                    if let Err(err) = child.wait().await {
+                        debug!(%err, "background bluetoothctl child wait failed");
+                    }
+                }
+                Err(err) => {
+                    debug!(%err, "background bluetoothctl spawn failed");
+                }
+            }
+        });
+    }
+
+    /// Resolve the local controller's BD address (`Controller XX:..:XX`).
+    /// Cached after the first successful query — `bluetoothctl show` is
+    /// a non-trivial round-trip and the controller MAC is stable across
+    /// the daemon's lifetime.
+    pub(super) async fn local_controller_mac(&self) -> Option<String> {
+        self.local_controller_mac
+            .get_or_init(|| async {
+                #[cfg(target_os = "linux")]
+                let args = ["show"];
+                #[cfg(target_os = "macos")]
+                let args = ["--list"];
+                match self.run_bluetoothctl_capture(args).await {
+                    Ok(out) => parse_controller_mac(&out),
+                    Err(err) => {
+                        debug!(%err, "failed to query local Bluetooth controller MAC");
+                        None
+                    }
+                }
+            })
+            .await
+            .clone()
+    }
+
     pub(super) async fn run_bluetoothctl_capture<const N: usize>(
         &self,
         args: [&str; N],
@@ -113,10 +173,12 @@ impl BluetoothDiscovery {
         &self,
     ) -> Result<Vec<DiscoveredDevice>, BluetoothError> {
         let output = self.run_bluetoothctl_capture(["devices"]).await?;
+        let local_mac = self.local_controller_mac().await;
         Ok(parse_devices_output(
             &output,
             &self.config.device_name_prefix,
             &self.config.local_alias,
+            local_mac.as_deref(),
         ))
     }
 
@@ -130,10 +192,12 @@ impl BluetoothDiscovery {
                 &self.config.bluetoothctl_timeout_s.to_string(),
             ])
             .await?;
+        let local_mac = self.local_controller_mac().await;
         Ok(parse_blueutil_inquiry_output(
             &output,
             &self.config.device_name_prefix,
             &self.config.local_alias,
+            local_mac.as_deref(),
         ))
     }
 

--- a/crates/pim-bluetooth/src/rfcomm/bridge.rs
+++ b/crates/pim-bluetooth/src/rfcomm/bridge.rs
@@ -8,15 +8,15 @@
 //! `pim-protocol` frames, exactly as if a normal TCP peer had
 //! connected.
 //!
-//! Wire choreography: each side's bridge writes the LOCAL node's
-//! 16-byte NodeId to the RFCOMM stream as soon as the bridge opens.
-//! Those bytes flow over RFCOMM to the *peer's* bridge, which pumps
-//! them to the peer's `127.0.0.1:9100` listener — where they are
-//! consumed as the (us-shaped) peer NodeId by `handle_incoming`. So
-//! both sides' listeners observe the correct peer NodeId, even
-//! though both bridges connect AS the TCP-dialer to their own
-//! loopback. Without this injection both listeners block forever
-//! waiting for that 16-byte prefix.
+//! Wire choreography: each side's bridge dials `127.0.0.1:9100` and
+//! writes the *peer's* 16-byte NodeId (learned from the RFCOMM
+//! Hello/HelloAck) directly into that local TCP socket — never into
+//! the RFCOMM stream. The local listener consumes those 16 bytes as
+//! `peer_id` in `handle_incoming`. Doing it this way (rather than
+//! sending self_node_id over RFCOMM) avoids a race where the peer's
+//! `session::handshake` reader sees post-handshake binary bytes as
+//! a length-prefixed frame and chokes with
+//! `frame size 246322734 exceeds max 65536`.
 //!
 //! This avoids refactoring the entire `pim-transport` layer to
 //! understand RFCOMM as a transport: from the daemon's point of
@@ -39,16 +39,17 @@ use super::socket::RfcommStream;
 /// TCP loopback connection to `local_addr`. Returns when either side
 /// closes or `cancel` fires.
 ///
-/// `self_node_id` is the LOCAL daemon's 16-byte NodeId — written into
-/// the RFCOMM stream as the very first bytes after the bridge opens
-/// so the *peer's* `handle_incoming` can consume it as `peer_id`.
+/// `peer_node_id` is the REMOTE peer's 16-byte NodeId, learned from
+/// the RFCOMM Hello/HelloAck. It is written to the local TCP socket
+/// as the very first 16 bytes so the daemon's `handle_incoming`
+/// identifies the bridged peer correctly.
 /// `peer_label` is used only in log lines so operators can correlate
 /// kernel logs with the discovery `bd_addr` of the originating peer.
 pub async fn run(
     rfcomm: Arc<RfcommStream>,
     local_addr: SocketAddr,
     peer_label: String,
-    self_node_id: [u8; 16],
+    peer_node_id: [u8; 16],
     cancel: CancellationToken,
 ) -> std::io::Result<()> {
     debug!(
@@ -67,24 +68,26 @@ pub async fn run(
     let rfcomm_r = rfcomm.clone();
     let rfcomm_w = rfcomm;
 
-    // Inject our own NodeId as the first 16 bytes of the RFCOMM
-    // stream. The peer's bridge will pump these bytes to its own
-    // loopback TCP, where the daemon's `handle_incoming` consumes
-    // them as the dialing peer's NodeId. Both sides do this
-    // symmetrically.
-    if let Err(e) = rfcomm_w.write_all(&self_node_id).await {
+    // Inject the peer's NodeId as the first 16 bytes of the local
+    // TCP stream so `handle_incoming` consumes it as `peer_id`. We
+    // intentionally do NOT write into the RFCOMM stream here — that
+    // path collides with the peer's `session::handshake` reader if
+    // the peer hasn't yet transitioned to the bridge phase, and
+    // produces the spurious `frame size 246322734 exceeds max 65536`
+    // teardowns we hit on the linux↔linux bench.
+    if let Err(e) = tcp_w.write_all(&peer_node_id).await {
         warn!(
             target: "pim-bluetooth-rfcomm",
             peer = %peer_label,
             err = %e,
-            "bridge: failed to write self NodeId prelude",
+            "bridge: failed to write peer NodeId prelude to loopback TCP",
         );
         return Err(e);
     }
     debug!(
         target: "pim-bluetooth-rfcomm",
         peer = %peer_label,
-        "bridge: wrote self NodeId prelude (16 B)",
+        "bridge: wrote peer NodeId prelude (16 B) to loopback TCP",
     );
 
     // RFCOMM → TCP

--- a/crates/pim-bluetooth/src/rfcomm/bridge.rs
+++ b/crates/pim-bluetooth/src/rfcomm/bridge.rs
@@ -4,10 +4,19 @@
 //! channel is repurposed as a byte-pipe to the daemon's existing
 //! TCP transport listener. Bytes flow verbatim in both directions —
 //! the daemon's `TcpTransport::handle_incoming` reads the first 16 B
-//! as the peer NodeId (sent by the dialing daemon's
-//! `TcpTransport::connect`) and treats the rest as length-delimited
+//! as the peer NodeId and treats the rest as length-delimited
 //! `pim-protocol` frames, exactly as if a normal TCP peer had
 //! connected.
+//!
+//! Wire choreography: each side's bridge writes the LOCAL node's
+//! 16-byte NodeId to the RFCOMM stream as soon as the bridge opens.
+//! Those bytes flow over RFCOMM to the *peer's* bridge, which pumps
+//! them to the peer's `127.0.0.1:9100` listener — where they are
+//! consumed as the (us-shaped) peer NodeId by `handle_incoming`. So
+//! both sides' listeners observe the correct peer NodeId, even
+//! though both bridges connect AS the TCP-dialer to their own
+//! loopback. Without this injection both listeners block forever
+//! waiting for that 16-byte prefix.
 //!
 //! This avoids refactoring the entire `pim-transport` layer to
 //! understand RFCOMM as a transport: from the daemon's point of
@@ -30,12 +39,16 @@ use super::socket::RfcommStream;
 /// TCP loopback connection to `local_addr`. Returns when either side
 /// closes or `cancel` fires.
 ///
+/// `self_node_id` is the LOCAL daemon's 16-byte NodeId — written into
+/// the RFCOMM stream as the very first bytes after the bridge opens
+/// so the *peer's* `handle_incoming` can consume it as `peer_id`.
 /// `peer_label` is used only in log lines so operators can correlate
 /// kernel logs with the discovery `bd_addr` of the originating peer.
 pub async fn run(
     rfcomm: Arc<RfcommStream>,
     local_addr: SocketAddr,
     peer_label: String,
+    self_node_id: [u8; 16],
     cancel: CancellationToken,
 ) -> std::io::Result<()> {
     debug!(
@@ -53,6 +66,26 @@ pub async fn run(
 
     let rfcomm_r = rfcomm.clone();
     let rfcomm_w = rfcomm;
+
+    // Inject our own NodeId as the first 16 bytes of the RFCOMM
+    // stream. The peer's bridge will pump these bytes to its own
+    // loopback TCP, where the daemon's `handle_incoming` consumes
+    // them as the dialing peer's NodeId. Both sides do this
+    // symmetrically.
+    if let Err(e) = rfcomm_w.write_all(&self_node_id).await {
+        warn!(
+            target: "pim-bluetooth-rfcomm",
+            peer = %peer_label,
+            err = %e,
+            "bridge: failed to write self NodeId prelude",
+        );
+        return Err(e);
+    }
+    debug!(
+        target: "pim-bluetooth-rfcomm",
+        peer = %peer_label,
+        "bridge: wrote self NodeId prelude (16 B)",
+    );
 
     // RFCOMM → TCP
     let cancel_rt = cancel.clone();

--- a/crates/pim-bluetooth/src/rfcomm/listener.rs
+++ b/crates/pim-bluetooth/src/rfcomm/listener.rs
@@ -13,20 +13,22 @@ use super::{session, BdAddr, LocalIdentity, RfcommConfig, RfcommError, RfcommEve
 
 /// Spawn the acceptor task. Errors at bind time are propagated; runtime
 /// errors are surfaced as `RfcommEvent::Error` and the task continues.
+///
+/// `active` is shared with `outbound::spawn` so the inbound accept and
+/// the outbound dial cooperate on dedup — first-arriving wins, the
+/// other path skips its session for the same peer.
 pub fn spawn(
     cfg: RfcommConfig,
     identity: LocalIdentity,
     events_tx: mpsc::Sender<RfcommEvent>,
     cancel: CancellationToken,
+    active: Arc<Mutex<std::collections::HashSet<BdAddr>>>,
 ) -> Result<(), RfcommError> {
     let listener = RfcommListener::bind(cfg.channel).map_err(|e| RfcommError::BindFailed {
         channel: cfg.channel,
         source: e,
     })?;
     info!(target: "pim-bluetooth-rfcomm", channel = cfg.channel, "listening");
-
-    let active: Arc<Mutex<std::collections::HashSet<BdAddr>>> =
-        Arc::new(Mutex::new(std::collections::HashSet::new()));
 
     // Notify the daemon we're up so the UI can mark the service alive.
     let tx0 = events_tx.clone();

--- a/crates/pim-bluetooth/src/rfcomm/mod.rs
+++ b/crates/pim-bluetooth/src/rfcomm/mod.rs
@@ -215,14 +215,26 @@ impl RfcommService {
         #[cfg(target_os = "linux")]
         {
             let cancel = CancellationToken::new();
+            // Shared session-dedup set: a single Arc<Mutex<HashSet<BdAddr>>>
+            // checked atomically by both listener and outbound before they
+            // spawn a session for a given peer. Without this, both sides
+            // can simultaneously dial each other and both can also accept
+            // each other's inbound — yielding 2 sessions per pair, where
+            // the second `register_peer` clobbers the first and the first
+            // session's bridge dies with `Connection reset by peer`. With
+            // it, whichever side acts first (outbound dial OR inbound
+            // accept) wins the slot and the other path skips.
+            let active: std::sync::Arc<tokio::sync::Mutex<std::collections::HashSet<BdAddr>>> =
+                std::sync::Arc::new(tokio::sync::Mutex::new(std::collections::HashSet::new()));
             listener::spawn(
                 cfg.clone(),
                 identity.clone(),
                 events_tx.clone(),
                 cancel.clone(),
+                active.clone(),
             )?;
             if cfg.outbound_enabled {
-                outbound::spawn(cfg, identity, events_tx, cancel.clone());
+                outbound::spawn(cfg, identity, events_tx, cancel.clone(), active);
             }
             Ok(Self { cancel })
         }

--- a/crates/pim-bluetooth/src/rfcomm/outbound.rs
+++ b/crates/pim-bluetooth/src/rfcomm/outbound.rs
@@ -17,14 +17,19 @@ use super::{parse_bdaddr, session, BdAddr, LocalIdentity, RfcommConfig, RfcommEv
 
 /// Spawn the outbound discovery task. Cancels cleanly on the cancel
 /// token; never returns errors directly (errors become RfcommEvent).
+///
+/// `active` is shared with `listener::spawn` so the inbound accept and
+/// the outbound dial cooperate on dedup. Without that, simultaneous
+/// poll cycles on both peers' daemons each insert into their own local
+/// set, both dial through, both accept the inbound, and the resulting
+/// duplicate sessions clobber each other in `register_peer`.
 pub fn spawn(
     cfg: RfcommConfig,
     identity: LocalIdentity,
     events_tx: mpsc::Sender<RfcommEvent>,
     cancel: CancellationToken,
+    active: Arc<Mutex<HashSet<BdAddr>>>,
 ) {
-    let active: Arc<Mutex<HashSet<BdAddr>>> = Arc::new(Mutex::new(HashSet::new()));
-
     tokio::spawn(async move {
         loop {
             tokio::select! {

--- a/crates/pim-bluetooth/src/rfcomm/outbound.rs
+++ b/crates/pim-bluetooth/src/rfcomm/outbound.rs
@@ -10,7 +10,7 @@ use tokio::process::Command;
 use tokio::sync::{mpsc, Mutex};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
 
 use super::socket;
 use super::{parse_bdaddr, session, BdAddr, LocalIdentity, RfcommConfig, RfcommEvent};
@@ -42,6 +42,14 @@ pub fn spawn(
                     continue;
                 }
             };
+            // Diagnostic — without this it's impossible to tell whether
+            // the outbound loop is alive at all. Logged once per poll
+            // tick at INFO so the bench operator sees the cadence.
+            info!(
+                target: "pim-bluetooth-rfcomm",
+                paired_count = paired.len(),
+                "rfcomm outbound poll"
+            );
             for (bd_addr_str, name) in paired {
                 let bd_addr = match parse_bdaddr(&bd_addr_str) {
                     Some(a) => a,
@@ -57,6 +65,13 @@ pub fn spawn(
                     let mut set = active.lock().await;
                     set.insert(bd_addr);
                 }
+                info!(
+                    target: "pim-bluetooth-rfcomm",
+                    bd_addr = %bd_addr_str,
+                    name = %name,
+                    channel = cfg.channel,
+                    "rfcomm dialing peer"
+                );
                 let stream = match socket::connect(bd_addr, cfg.channel).await {
                     Ok(s) => s,
                     Err(e) => {

--- a/crates/pim-bluetooth/src/rfcomm/session.rs
+++ b/crates/pim-bluetooth/src/rfcomm/session.rs
@@ -45,47 +45,39 @@ pub async fn run(
     local_bridge_addr: Option<std::net::SocketAddr>,
 ) {
     let bd_str = format_bdaddr(&peer_addr);
-    if let Err(e) = handshake(&stream, &bd_str, initiator, &identity, &events_tx).await {
-        let _ = events_tx
-            .send(RfcommEvent::Lost {
-                bd_addr: bd_str.clone(),
-                reason: format!("handshake_failed: {e}"),
-            })
-            .await;
-        return;
-    }
+    let peer_node_id = match handshake(&stream, &bd_str, initiator, &identity, &events_tx).await {
+        Ok(id) => id,
+        Err(e) => {
+            let _ = events_tx
+                .send(RfcommEvent::Lost {
+                    bd_addr: bd_str.clone(),
+                    reason: format!("handshake_failed: {e}"),
+                })
+                .await;
+            return;
+        }
+    };
 
     let stream = Arc::new(stream);
     let close_reason = match local_bridge_addr {
         Some(addr) => {
-            // Decode the local node_id (32-char hex) into raw 16 bytes
-            // for the bridge's NodeId prelude. Treat parse failure as a
-            // teardown reason — the daemon-supplied identity should
-            // always be 32 hex chars; if it isn't the bridge can't
-            // identify itself to the peer's listener anyway.
-            let mut self_node_id = [0u8; 16];
-            match hex_to_node_id(&identity.node_id_hex, &mut self_node_id) {
-                Ok(()) => {
-                    debug!(
-                        target: "pim-bluetooth-rfcomm",
-                        peer = %bd_str,
-                        bridge = %addr,
-                        "session: handshake OK, bridging to loopback TCP",
-                    );
-                    match bridge::run(
-                        stream.clone(),
-                        addr,
-                        bd_str.clone(),
-                        self_node_id,
-                        cancel.clone(),
-                    )
-                    .await
-                    {
-                        Ok(()) => "bridge_closed".to_string(),
-                        Err(e) => format!("bridge_io_error: {e}"),
-                    }
-                }
-                Err(e) => format!("identity_decode_error: {e}"),
+            debug!(
+                target: "pim-bluetooth-rfcomm",
+                peer = %bd_str,
+                bridge = %addr,
+                "session: handshake OK, bridging to loopback TCP",
+            );
+            match bridge::run(
+                stream.clone(),
+                addr,
+                bd_str.clone(),
+                peer_node_id,
+                cancel.clone(),
+            )
+            .await
+            {
+                Ok(()) => "bridge_closed".to_string(),
+                Err(e) => format!("bridge_io_error: {e}"),
             }
         }
         None => discovery_only_loop(stream, &bd_str, cancel).await,
@@ -158,13 +150,20 @@ fn hex_to_node_id(hex: &str, out: &mut [u8; 16]) -> Result<(), String> {
     Ok(())
 }
 
+/// Run the RFCOMM session-level Hello / HelloAck handshake. Returns
+/// the peer's 16-byte raw NodeId on success — the caller forwards it
+/// to the bridge so the loopback TCP listener can be told *who* this
+/// connection is from without having to send the bytes back over
+/// RFCOMM (which would race with the post-handshake byte stream and
+/// cause `decode_frame` to choke on binary NodeId bytes that look
+/// like absurd length prefixes).
 async fn handshake(
     stream: &RfcommStream,
     bd_str: &str,
     initiator: bool,
     identity: &LocalIdentity,
     events_tx: &mpsc::Sender<RfcommEvent>,
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<[u8; 16], Box<dyn std::error::Error + Send + Sync>> {
     let local_caps = identity.caps.clone();
     let local_node_hex = identity.node_id_hex.clone();
     let local_name = identity.name.clone();
@@ -245,6 +244,14 @@ async fn handshake(
             let frame = send_msg("hello-ack")?;
             stream.write_all(&frame).await?;
         }
+        // Decode the peer's hex NodeId now so the caller can hand the
+        // raw 16-byte form to the bridge. Errors here mean the peer
+        // sent us a Hello with a malformed `node_id` field; treat as
+        // a handshake failure so we don't bridge with garbage.
+        let mut peer_node_id = [0u8; 16];
+        if let Err(msg) = hex_to_node_id(&their_node, &mut peer_node_id) {
+            return Err(format!("invalid peer node_id `{their_node}`: {msg}").into());
+        }
         let _ = events_tx
             .send(RfcommEvent::Discovered {
                 bd_addr: bd_str.to_string(),
@@ -256,6 +263,6 @@ async fn handshake(
                 since: now_iso(),
             })
             .await;
-        return Ok(());
+        return Ok(peer_node_id);
     }
 }

--- a/crates/pim-bluetooth/src/rfcomm/session.rs
+++ b/crates/pim-bluetooth/src/rfcomm/session.rs
@@ -58,15 +58,34 @@ pub async fn run(
     let stream = Arc::new(stream);
     let close_reason = match local_bridge_addr {
         Some(addr) => {
-            debug!(
-                target: "pim-bluetooth-rfcomm",
-                peer = %bd_str,
-                bridge = %addr,
-                "session: handshake OK, bridging to loopback TCP",
-            );
-            match bridge::run(stream.clone(), addr, bd_str.clone(), cancel.clone()).await {
-                Ok(()) => "bridge_closed".to_string(),
-                Err(e) => format!("bridge_io_error: {e}"),
+            // Decode the local node_id (32-char hex) into raw 16 bytes
+            // for the bridge's NodeId prelude. Treat parse failure as a
+            // teardown reason — the daemon-supplied identity should
+            // always be 32 hex chars; if it isn't the bridge can't
+            // identify itself to the peer's listener anyway.
+            let mut self_node_id = [0u8; 16];
+            match hex_to_node_id(&identity.node_id_hex, &mut self_node_id) {
+                Ok(()) => {
+                    debug!(
+                        target: "pim-bluetooth-rfcomm",
+                        peer = %bd_str,
+                        bridge = %addr,
+                        "session: handshake OK, bridging to loopback TCP",
+                    );
+                    match bridge::run(
+                        stream.clone(),
+                        addr,
+                        bd_str.clone(),
+                        self_node_id,
+                        cancel.clone(),
+                    )
+                    .await
+                    {
+                        Ok(()) => "bridge_closed".to_string(),
+                        Err(e) => format!("bridge_io_error: {e}"),
+                    }
+                }
+                Err(e) => format!("identity_decode_error: {e}"),
             }
         }
         None => discovery_only_loop(stream, &bd_str, cancel).await,
@@ -123,6 +142,20 @@ async fn discovery_only_loop(
             }
         }
     }
+}
+
+/// Decode a 32-char lowercase hex NodeId into 16 bytes. Returns the
+/// concrete `String` reason on parse failure so the caller can pass it
+/// up the `RfcommEvent::Lost` reason field unchanged.
+fn hex_to_node_id(hex: &str, out: &mut [u8; 16]) -> Result<(), String> {
+    if hex.len() != 32 {
+        return Err(format!("expected 32 hex chars, got {}", hex.len()));
+    }
+    for (i, chunk) in hex.as_bytes().chunks_exact(2).enumerate() {
+        let s = std::str::from_utf8(chunk).map_err(|e| e.to_string())?;
+        out[i] = u8::from_str_radix(s, 16).map_err(|e| e.to_string())?;
+    }
+    Ok(())
 }
 
 async fn handshake(

--- a/crates/pim-bluetooth/src/rfcomm/socket.rs
+++ b/crates/pim-bluetooth/src/rfcomm/socket.rs
@@ -146,14 +146,16 @@ pub async fn connect(bd_addr: BdAddr, channel: u8) -> io::Result<RfcommStream> {
         if err.raw_os_error() != Some(libc::EINPROGRESS) {
             return Err(err);
         }
-        let async_fd = AsyncFd::with_interest(fd, Interest::WRITABLE)?;
-        let _ = async_fd.writable().await?;
+        // Watch only WRITABLE while waiting for connect to finish —
+        // the kernel signals connection completion via writability.
+        let waiter = AsyncFd::with_interest(fd, Interest::WRITABLE)?;
+        let _ = waiter.writable().await?;
         // Check SO_ERROR.
         let mut so_error: libc::c_int = 0;
         let mut so_len = mem::size_of::<libc::c_int>() as libc::socklen_t;
         let rc = unsafe {
             libc::getsockopt(
-                async_fd.as_raw_fd(),
+                waiter.as_raw_fd(),
                 libc::SOL_SOCKET,
                 libc::SO_ERROR,
                 &mut so_error as *mut libc::c_int as *mut libc::c_void,
@@ -166,7 +168,19 @@ pub async fn connect(bd_addr: BdAddr, channel: u8) -> io::Result<RfcommStream> {
         if so_error != 0 {
             return Err(io::Error::from_raw_os_error(so_error));
         }
-        return Ok(RfcommStream { fd: async_fd });
+        // Re-register the fd with READABLE | WRITABLE for the
+        // post-connect lifetime. Before this fix the stream stayed
+        // registered as WRITABLE-only and `read()` (via
+        // `self.fd.readable().await`) never resolved — every dialer-
+        // side RFCOMM session deadlocked at the first post-Hello
+        // read, so neither the rfcomm Hello/HelloAck-completion
+        // event nor the bridge::run loop on the dialer side ever
+        // fired. Rewrap by extracting the inner OwnedFd from `waiter`
+        // and creating a fresh AsyncFd with both interests.
+        let inner = waiter.into_inner();
+        return Ok(RfcommStream {
+            fd: AsyncFd::new(inner)?,
+        });
     }
     Ok(RfcommStream {
         fd: AsyncFd::new(fd)?,

--- a/crates/pim-bluetooth/src/rfcomm/socket.rs
+++ b/crates/pim-bluetooth/src/rfcomm/socket.rs
@@ -23,7 +23,17 @@ pub const BTPROTO_RFCOMM: libc::c_int = 3;
 
 /// Linux kernel's `sockaddr_rc` layout — `sa_family_t` + 6-byte
 /// `bdaddr_t` (little-endian) + 1-byte channel.
-#[repr(C, packed)]
+///
+/// MUST be `repr(C)` (not `packed`). The kernel's userspace header
+/// declares only `bdaddr_t` packed; the outer `sockaddr_rc` keeps
+/// natural alignment, so its `sizeof` is 10 bytes (2 + 6 + 1 + 1
+/// trailing pad to align to `sa_family_t`'s alignment of 2).
+/// `rfcomm_sock_connect` enforces `addr_len < sizeof(sockaddr_rc)`
+/// strictly — passing the packed 9-byte size returns EINVAL.
+/// Verified against a header-free C reference: same MAC, same
+/// channel, the C connect succeeds with `sizeof = 10` while the
+/// packed-9 Rust call fails synchronously with `Invalid argument`.
+#[repr(C)]
 struct SockaddrRc {
     rc_family: libc::sa_family_t,
     rc_bdaddr: [u8; 6],

--- a/crates/pim-bluetooth/src/service.rs
+++ b/crates/pim-bluetooth/src/service.rs
@@ -29,6 +29,46 @@ impl BluetoothDiscovery {
         if self.config.radio_discovery_enabled {
             self.prepare_controller().await?;
             self.run_bluetoothctl(["scan", "on"]).await?;
+            // Warm the local controller MAC cache so the very first
+            // scan_interval tick already filters by MAC instead of
+            // alias. Best-effort — failures fall back to alias filter.
+            self.local_controller_mac().await;
+        }
+
+        // Re-arm `discoverable on` well before the controller's
+        // DiscoverableTimeout (default 180 s) expires. Without this, a
+        // peer that comes up minutes after our daemon never finds us
+        // because the controller has stopped responding to inquiry-scan.
+        // Runs as a detached task — the periodic re-arm doesn't need to
+        // coordinate with the main discovery select! loop.
+        #[cfg(target_os = "linux")]
+        if self.config.radio_discovery_enabled {
+            let bluetoothctl = self.bluetoothctl_command.clone();
+            let timeout = self.config.bluetoothctl_timeout_s;
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                let mut ticker = tokio::time::interval(Duration::from_secs(60));
+                ticker.tick().await; // skip the immediate first tick (prepare_controller already armed it)
+                loop {
+                    tokio::select! {
+                        _ = cancel.cancelled() => break,
+                        _ = ticker.tick() => {
+                            let mut cmd = Command::new(&bluetoothctl);
+                            cmd.arg("--timeout")
+                                .arg(timeout.to_string())
+                                .arg("discoverable")
+                                .arg("on")
+                                .stdout(Stdio::null())
+                                .stderr(Stdio::null())
+                                .kill_on_drop(true);
+                            match cmd.spawn() {
+                                Ok(mut child) => { let _ = child.wait().await; }
+                                Err(err) => debug!(%err, "discoverable keepalive spawn failed"),
+                            }
+                        }
+                    }
+                }
+            });
         }
 
         #[cfg(target_os = "linux")]
@@ -170,6 +210,16 @@ impl BluetoothDiscovery {
                     }
                 }
                 _ = scan_interval.tick(), if self.config.radio_discovery_enabled && self.config.connect_pan => {
+                    // Re-arm BlueZ inquiry: `bluetoothctl --timeout N
+                    // scan on` from prepare_controller stops issuing
+                    // StartDiscovery once the bluetoothctl client exits
+                    // (after `bluetoothctl_timeout_s`). Without this
+                    // periodic re-fire, the daemon's "scan started"
+                    // log lines below are misleading — they only read
+                    // the cached device list, no fresh inquiry happens.
+                    #[cfg(target_os = "linux")]
+                    self.run_bluetoothctl_in_background(&["scan", "on"]);
+
                     #[cfg(target_os = "linux")]
                     {
                         pan_clients.retain(|mac, child| match child.try_wait() {

--- a/crates/pim-bluetooth/src/support.rs
+++ b/crates/pim-bluetooth/src/support.rs
@@ -253,6 +253,7 @@ pub(super) fn parse_devices_output(
     output: &str,
     prefix: &str,
     local_alias: &str,
+    local_mac: Option<&str>,
 ) -> Vec<DiscoveredDevice> {
     let mut devices = Vec::new();
     for line in output.lines() {
@@ -264,7 +265,19 @@ pub(super) fn parse_devices_output(
         let _ = parts.next();
         let Some(mac) = parts.next() else { continue };
         let Some(name) = parts.next() else { continue };
-        if !name.starts_with(prefix) || name == local_alias {
+        if !name.starts_with(prefix) {
+            continue;
+        }
+        // MAC-based self-filter is preferred — BD addresses are unique per
+        // controller, while names are stickily cached by BlueZ and can
+        // collide with our local alias when a remote controller previously
+        // broadcast that alias. Alias check stays as a fallback when MAC
+        // discovery hasn't completed yet.
+        if let Some(self_mac) = local_mac {
+            if mac.eq_ignore_ascii_case(self_mac) {
+                continue;
+            }
+        } else if name == local_alias {
             continue;
         }
         devices.push(DiscoveredDevice {
@@ -275,11 +288,31 @@ pub(super) fn parse_devices_output(
     devices
 }
 
+/// Extract a Bluetooth controller BD address from the first line of
+/// `bluetoothctl show`, which looks like
+/// `Controller 00:15:83:3D:0A:57 (public)`. Returns the MAC verbatim
+/// (uppercase, colon-separated) or `None` when the output doesn't match.
+#[cfg(any(test, target_os = "linux", target_os = "macos"))]
+pub(super) fn parse_controller_mac(output: &str) -> Option<String> {
+    for line in output.lines() {
+        let line = line.trim();
+        let Some(rest) = line.strip_prefix("Controller ") else {
+            continue;
+        };
+        let mac = rest.split_whitespace().next()?;
+        if mac.split(':').count() == 6 && mac.len() == 17 {
+            return Some(mac.to_string());
+        }
+    }
+    None
+}
+
 #[cfg(any(test, target_os = "macos"))]
 pub(super) fn parse_blueutil_inquiry_output(
     output: &str,
     prefix: &str,
     local_alias: &str,
+    local_mac: Option<&str>,
 ) -> Vec<DiscoveredDevice> {
     let mut devices = Vec::new();
 
@@ -303,12 +336,20 @@ pub(super) fn parse_blueutil_inquiry_output(
             continue;
         };
         let name = &name_value[..name_end];
-        if !name.starts_with(prefix) || name == local_alias {
+        if !name.starts_with(prefix) {
+            continue;
+        }
+        let normalised_mac = mac.trim().replace('-', ":").to_uppercase();
+        if let Some(self_mac) = local_mac {
+            if normalised_mac.eq_ignore_ascii_case(self_mac) {
+                continue;
+            }
+        } else if name == local_alias {
             continue;
         }
 
         devices.push(DiscoveredDevice {
-            mac: mac.trim().replace('-', ":").to_uppercase(),
+            mac: normalised_mac,
             name: name.to_string(),
         });
     }

--- a/crates/pim-bluetooth/src/tests/parsers.rs
+++ b/crates/pim-bluetooth/src/tests/parsers.rs
@@ -44,10 +44,49 @@ Device AA:BB:CC:DD:EE:01 PIM-gateway
 Device AA:BB:CC:DD:EE:02 Phone
 Device AA:BB:CC:DD:EE:03 PIM-client
 ";
-    let parsed = parse_devices_output(output, "PIM-", "PIM-self");
+    let parsed = parse_devices_output(output, "PIM-", "PIM-self", None);
     assert_eq!(parsed.len(), 2);
     assert_eq!(parsed[0].mac, "AA:BB:CC:DD:EE:01");
     assert_eq!(parsed[1].name, "PIM-client");
+}
+
+#[test]
+fn devices_output_filters_self_by_mac_when_provided() {
+    // Cached name collides with our local alias (the BlueZ-cache bug
+    // we hit linux↔linux). MAC-based self-filter must keep the entry
+    // so we don't drop a real peer.
+    let output = "\
+Device AA:BB:CC:DD:EE:01 PIM-self
+Device AA:BB:CC:DD:EE:02 PIM-other
+";
+    let parsed = parse_devices_output(output, "PIM-", "PIM-self", Some("00:00:00:00:00:01"));
+    assert_eq!(parsed.len(), 2);
+    assert_eq!(parsed[0].mac, "AA:BB:CC:DD:EE:01");
+    assert_eq!(parsed[0].name, "PIM-self");
+}
+
+#[test]
+fn devices_output_drops_self_when_mac_matches() {
+    let output = "\
+Device AA:BB:CC:DD:EE:01 PIM-gateway
+Device AA:BB:CC:DD:EE:02 PIM-other
+";
+    let parsed = parse_devices_output(output, "PIM-", "PIM-self", Some("aa:bb:cc:dd:ee:01"));
+    assert_eq!(parsed.len(), 1);
+    assert_eq!(parsed[0].mac, "AA:BB:CC:DD:EE:02");
+}
+
+#[test]
+fn parse_controller_mac_extracts_first_line_address() {
+    let show_output = "\
+Controller 00:15:83:3D:0A:57 (public)\n\
+\tAlias: PIM-gateway\n\
+\tDiscoverable: yes\n";
+    assert_eq!(
+        parse_controller_mac(show_output),
+        Some("00:15:83:3D:0A:57".to_string())
+    );
+    assert_eq!(parse_controller_mac("nothing useful here"), None);
 }
 
 #[test]
@@ -56,7 +95,7 @@ fn blueutil_inquiry_output_filters_to_matching_prefix() {
 address: aa-bb-cc-dd-ee-01, not connected, not favourite, not paired, name: \"PIM-gateway\", recent access date: -\n\
 address: aa-bb-cc-dd-ee-02, not connected, not favourite, not paired, name: \"Phone\", recent access date: -\n\
 address: aa-bb-cc-dd-ee-03, not connected, not favourite, not paired, name: \"PIM-self\", recent access date: -\n";
-    let parsed = parse_blueutil_inquiry_output(output, "PIM-", "PIM-self");
+    let parsed = parse_blueutil_inquiry_output(output, "PIM-", "PIM-self", None);
     assert_eq!(parsed.len(), 1);
     assert_eq!(parsed[0].mac, "AA:BB:CC:DD:EE:01");
     assert_eq!(parsed[0].name, "PIM-gateway");

--- a/crates/pim-daemon/src/app.rs
+++ b/crates/pim-daemon/src/app.rs
@@ -839,7 +839,11 @@ pub(crate) async fn run() -> Result<()> {
                             RfcommEvent::OpenFailed {
                                 bd_addr, reason, ..
                             } => {
-                                debug!(bd_addr = %bd_addr, reason = %reason, "rfcomm open failed")
+                                // Promoted from debug → warn while debugging the
+                                // linux↔linux RFCOMM bench. Open failures are
+                                // the most useful signal we have right now and
+                                // hiding them at debug stalls iteration.
+                                warn!(bd_addr = %bd_addr, reason = %reason, "rfcomm open failed")
                             }
                             RfcommEvent::Error { code, message } => {
                                 warn!(code = *code, message = %message, "rfcomm error")

--- a/crates/pim-daemon/src/app.rs
+++ b/crates/pim-daemon/src/app.rs
@@ -106,7 +106,7 @@ use ed25519_dalek::VerifyingKey;
 #[cfg(test)]
 use gateway_tasks::PENDING_PING_TTL;
 use gateway_tasks::{ensure_gateway_ipv6_engine, run_gateway_probes, run_gateway_return};
-use handshake::{decode_handshake_wire, handshake_responder};
+use handshake::{decode_handshake_wire, handshake_initiator, handshake_responder};
 use ip_control::{
     apply_dynamic_ip_assignment, cancel_pending_outbound_for_ip, classify_ip_request,
     maybe_request_dynamic_ip, send_routed_control, IpRequestDisposition, PendingOutbound,
@@ -810,6 +810,7 @@ pub(crate) async fn run() -> Result<()> {
         match RfcommService::start(rfcomm_cfg, local_identity, events_tx) {
             Ok(svc) => {
                 info!("Bluetooth RFCOMM service started");
+                let state_for_rfcomm = state.clone();
                 let log_handle = tokio::spawn(async move {
                     while let Some(ev) = events_rx.recv().await {
                         match &ev {
@@ -824,15 +825,21 @@ pub(crate) async fn run() -> Result<()> {
                                 caps,
                                 initiator,
                                 ..
-                            } => info!(
-                                bd_addr = %bd_addr,
-                                node_id = %&node_id[..16.min(node_id.len())],
-                                name = %name,
-                                platform = %platform,
-                                caps = ?caps,
-                                initiator = *initiator,
-                                "rfcomm peer discovered"
-                            ),
+                            } => {
+                                info!(
+                                    bd_addr = %bd_addr,
+                                    node_id = %&node_id[..16.min(node_id.len())],
+                                    name = %name,
+                                    platform = %platform,
+                                    caps = ?caps,
+                                    initiator = *initiator,
+                                    "rfcomm peer discovered"
+                                );
+                                spawn_rfcomm_initiator_if_lower(
+                                    state_for_rfcomm.clone(),
+                                    node_id.clone(),
+                                );
+                            }
                             RfcommEvent::Lost { bd_addr, reason } => {
                                 info!(bd_addr = %bd_addr, reason = %reason, "rfcomm peer lost")
                             }
@@ -900,6 +907,72 @@ pub(crate) async fn run() -> Result<()> {
     }
 
     event_result
+}
+
+/// When an RFCOMM-bridged peer is discovered, only ONE side should
+/// drive the pim-transport Noise initiator handshake — otherwise both
+/// sides idle as responders and the bridge never reaches a registered
+/// peer. We elect the side with the lexicographically lower NodeId.
+///
+/// The bridge already injects each side's local NodeId as the first 16
+/// bytes of the RFCOMM stream (see `pim-bluetooth::rfcomm::bridge`),
+/// so when this fires the loopback TCP listener has typically already
+/// `register_peer`'d the peer in `state.transport`'s session map.
+/// We poll briefly for that registration to land, then call
+/// `handshake_initiator` — exactly what the regular UDP-discovery
+/// dialer path does after `transport.connect`.
+#[cfg(target_os = "linux")]
+fn spawn_rfcomm_initiator_if_lower(state: Arc<DaemonState>, peer_node_id_hex: String) {
+    use std::str::FromStr;
+    tokio::spawn(async move {
+        let peer_node_id = match NodeId::from_str(&peer_node_id_hex) {
+            Ok(id) => id,
+            Err(e) => {
+                warn!(peer = %peer_node_id_hex, "rfcomm: invalid peer NodeId hex: {e}");
+                return;
+            }
+        };
+        if state.self_id.as_bytes() >= peer_node_id.as_bytes() {
+            debug!(
+                %peer_node_id,
+                "rfcomm: not initiator (self id ≥ peer id) — letting responder fire on incoming Init"
+            );
+            return;
+        }
+        info!(%peer_node_id, "rfcomm: electing this side as Noise initiator");
+
+        // Wait for the bridge to deliver the peer's 16-byte NodeId
+        // prelude into our loopback listener and for `register_peer`
+        // to land in transport.session_map.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if state
+                .transport
+                .connected_peers()
+                .iter()
+                .any(|id| id == &peer_node_id)
+            {
+                break;
+            }
+            if Instant::now() >= deadline {
+                warn!(
+                    %peer_node_id,
+                    "rfcomm: peer never registered in transport within 5 s; aborting initiator"
+                );
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        let (tx, rx) = mpsc::channel(8);
+        state.hs_channels.lock().await.insert(peer_node_id, tx);
+        let result = handshake_initiator(&state, peer_node_id, rx).await;
+        state.hs_channels.lock().await.remove(&peer_node_id);
+        match result {
+            Ok(real_id) => info!(%real_id, "rfcomm-bridged handshake_initiator complete"),
+            Err(e) => warn!(%peer_node_id, "rfcomm-bridged handshake_initiator failed: {e}"),
+        }
+    });
 }
 
 // ── Unit tests ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- **fix(bluetooth): re-arm scan/discoverable + MAC-based self-filter**
- **diag(rfcomm): log outbound poll cadence + dial intent + open failures**
- **fix(rfcomm): drop `packed` from SockaddrRc — kernel expects 10 bytes**
- **fix(rfcomm): wire bridged peers into pim-transport handshake**
- **fix(rfcomm): re-register dialer fd with READABLE+WRITABLE after connect**
- **fix(rfcomm): one session per peer pair + TCP-side NodeId injection**
