### PR TITLE
fix(rfcomm): scope per-session cancel so bridge teardown doesn't kill…

### DIFF
--- a/crates/pim-bluetooth/src/rfcomm/listener.rs
+++ b/crates/pim-bluetooth/src/rfcomm/listener.rs
@@ -57,7 +57,13 @@ pub fn spawn(
                         }
                         let identity = identity.clone();
                         let events_tx = events_tx.clone();
-                        let cancel = cancel.clone();
+                        // Defense in depth: hand the session a CHILD
+                        // token. The bridge inside `session::run` may
+                        // cancel its own token to tear down its r2t/t2r
+                        // pumps (see session.rs) — if that token were
+                        // a clone of `cancel`, the cancellation would
+                        // bubble up and shut down THIS acceptor task.
+                        let cancel = cancel.child_token();
                         let active = active.clone();
                         let bridge_addr = cfg.local_bridge_addr;
                         tokio::spawn(async move {

--- a/crates/pim-bluetooth/src/rfcomm/outbound.rs
+++ b/crates/pim-bluetooth/src/rfcomm/outbound.rs
@@ -94,7 +94,11 @@ pub fn spawn(
                 };
                 let identity = identity.clone();
                 let events_tx = events_tx.clone();
-                let cancel = cancel.clone();
+                // Defense in depth: hand the session a CHILD token —
+                // see the matching comment in listener.rs. A clone here
+                // would let the bridge's per-session cancel propagate
+                // back up and kill the outbound poll loop.
+                let cancel = cancel.child_token();
                 let active = active.clone();
                 let bridge_addr = cfg.local_bridge_addr;
                 tokio::spawn(async move {

--- a/crates/pim-bluetooth/src/rfcomm/session.rs
+++ b/crates/pim-bluetooth/src/rfcomm/session.rs
@@ -67,12 +67,22 @@ pub async fn run(
                 bridge = %addr,
                 "session: handshake OK, bridging to loopback TCP",
             );
+            // Hand the bridge a CHILD token, not a clone. `bridge::run`
+            // calls `cancel.cancel()` from inside its r2t/t2r select to
+            // unwind the second pump when the first exits — if that
+            // call landed on the parent token (a clone of the listener
+            // / outbound token), one peer disconnecting would also
+            // cancel the acceptor + outbound poll, and every future
+            // dial against this daemon would hit
+            // `Connection refused (os error 111)` until restart.
+            // Child tokens cascade parent → child cancellation but not
+            // child → parent.
             match bridge::run(
                 stream.clone(),
                 addr,
                 bd_str.clone(),
                 peer_node_id,
-                cancel.clone(),
+                cancel.child_token(),
             )
             .await
             {

--- a/crates/pim-cli/src/commands/config.rs
+++ b/crates/pim-cli/src/commands/config.rs
@@ -259,6 +259,35 @@ fn push_routing(out: &mut String) {
         "# How long learned routes survive before being re-advertised (seconds).",
     );
     push_line(out, "route_expiry_s = 300");
+    push_line(
+        out,
+        "# DNS resolvers handed to the system resolver (`resolvectl dns pim0 \u{2026}`)",
+    );
+    push_line(
+        out,
+        "# while split-default routing is engaged. Without this list the resolver",
+    );
+    push_line(
+        out,
+        "# keeps its DHCP-provided upstream, which becomes unreachable the moment",
+    );
+    push_line(
+        out,
+        "# the local uplink (wifi / wired) goes down — name resolution then fails",
+    );
+    push_line(
+        out,
+        "# even though the IP path through the mesh is live. Empty list = skip DNS",
+    );
+    push_line(
+        out,
+        "# management entirely (corporate VPN tooling / NetworkManager dispatchers /",
+    );
+    push_line(
+        out,
+        "# hand-managed /etc/resolv.conf own the resolver instead).",
+    );
+    push_line(out, "dns_servers = [\"1.1.1.1\", \"1.0.0.1\", \"8.8.8.8\"]");
     push_blank(out);
 }
 

--- a/crates/pim-core/src/config/defaults.rs
+++ b/crates/pim-core/src/config/defaults.rs
@@ -72,6 +72,20 @@ pub(super) fn default_route_expiry_s() -> u64 {
     300
 }
 
+/// Public anycast resolvers handed to the system resolver
+/// (`resolvectl dns pim0 …`) when the daemon engages split-default
+/// routing. Cloudflare 1.1.1.1 + 1.0.0.1 (privacy-conscious, fast,
+/// global anycast) plus Google 8.8.8.8 as a third opinion so a
+/// single-provider outage doesn't break name resolution while the
+/// mesh is the only egress. Lifted from the previous hard-coded
+/// `MESH_DNS_SERVERS` constant in `pim-daemon::route_installer` —
+/// users who want to override (corporate split-DNS, pi-hole on the
+/// gateway, IPv6-only resolvers) edit `[routing].dns_servers` and
+/// the route installer picks them up on the next reconcile tick.
+pub(super) fn default_dns_servers() -> Vec<String> {
+    vec!["1.1.1.1".into(), "1.0.0.1".into(), "8.8.8.8".into()]
+}
+
 pub(super) fn default_nat_interface() -> String {
     "eth0".into()
 }

--- a/crates/pim-core/src/config/model.rs
+++ b/crates/pim-core/src/config/model.rs
@@ -142,6 +142,17 @@ pub struct RoutingConfig {
     /// Lifetime of learned routes before expiry, in seconds.
     #[serde(default = "default_route_expiry_s")]
     pub route_expiry_s: u64,
+    /// DNS resolvers handed to the system resolver (`resolvectl dns
+    /// pim0 …` on Linux/systemd-resolved) when split-default routing
+    /// is engaged. Without this list the resolver keeps its
+    /// DHCP-provided upstream — which becomes unreachable the moment
+    /// the user disables their wifi/wired uplink, so `curl gmail.com`
+    /// fails even though the IP path through the mesh is live.
+    /// Defaults to a small public anycast set; override for corporate
+    /// split-DNS (`["10.0.0.53"]`), pi-hole on the gateway
+    /// (`["10.77.0.1"]`), or IPv6-only resolvers.
+    #[serde(default = "default_dns_servers")]
+    pub dns_servers: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -462,6 +473,10 @@ fn default_route_expiry_s() -> u64 {
     300
 }
 
+fn default_dns_servers() -> Vec<String> {
+    vec!["1.1.1.1".into(), "1.0.0.1".into(), "8.8.8.8".into()]
+}
+
 fn default_nat_interface() -> String {
     "eth0".into()
 }
@@ -632,6 +647,7 @@ impl Default for RoutingConfig {
             max_hops: default_max_hops(),
             algorithm: default_route_algorithm(),
             route_expiry_s: default_route_expiry_s(),
+            dns_servers: default_dns_servers(),
         }
     }
 }

--- a/crates/pim-daemon/src/app.rs
+++ b/crates/pim-daemon/src/app.rs
@@ -153,8 +153,8 @@ use reconnect::ReconnectManager;
 use reconnect_task::run_reconnect_task;
 use reputation::ReputationTracker;
 use runtime_config::{
-    first_host_in_subnet, first_host_in_subnet_v6, icmp_echo_reply, install_signal_handler,
-    node_capabilities, parse_cidr, parse_ipv6_cidr, resolve_configured_peer_targets,
+    icmp_echo_reply, install_signal_handler, node_capabilities, parse_cidr, parse_ipv6_cidr,
+    resolve_configured_peer_targets,
 };
 use send_buffer::{SendBuffer, DEFAULT_CAPACITY, DEFAULT_TIMEOUT};
 use session::Session;
@@ -278,6 +278,14 @@ pub(crate) struct DaemonState {
     /// periodic-broadcast task re-reads the interval immediately
     /// instead of waiting for its current sleep to elapse.
     pub(crate) broadcast_notify: Arc<Notify>,
+    /// Wakes the `route_installer` task whenever `route_on` is mutated
+    /// (via the JSON-RPC `route.set_split_default` handler) so the
+    /// kernel-level split-default routes flip in/out without waiting
+    /// for the next 2 s reconciliation tick. The installer also
+    /// polls on a tick so gateway-selection changes (multi-gateway,
+    /// load / RTT swings, gateway disappearance) get followed
+    /// automatically without an explicit event channel.
+    pub(crate) route_install_notify: Arc<Notify>,
 }
 
 impl DaemonState {
@@ -289,6 +297,7 @@ impl DaemonState {
 // ── Main event loop ───────────────────────────────────────────────────────────
 
 mod event_loop;
+mod route_installer;
 
 use event_loop::run_event_loop;
 
@@ -636,6 +645,7 @@ pub(crate) async fn run() -> Result<()> {
         last_broadcast_ms: Arc::new(AtomicI64::new(i64::MIN)),
         last_broadcast_recipients: Arc::new(AtomicU64::new(0)),
         broadcast_notify: Arc::new(Notify::new()),
+        route_install_notify: Arc::new(Notify::new()),
     });
 
     // ── Identity-broadcast background task ────────────────────────────────
@@ -891,6 +901,9 @@ pub(crate) async fn run() -> Result<()> {
         tokio::spawn(run_gateway_return(state.clone()));
         tokio::spawn(run_conntrack_gc(state.clone()));
     }
+    // Reconciles the kernel's split-default routes against `route_on`
+    // and the routing table's selected gateway. No-op on gateway nodes.
+    route_installer::spawn(state.clone());
 
     // ── Main event loop ───────────────────────────────────────────────────
     let event_result = run_event_loop(state).await;

--- a/crates/pim-daemon/src/app.rs
+++ b/crates/pim-daemon/src/app.rs
@@ -286,6 +286,16 @@ pub(crate) struct DaemonState {
     /// load / RTT swings, gateway disappearance) get followed
     /// automatically without an explicit event channel.
     pub(crate) route_install_notify: Arc<Notify>,
+    /// DNS resolvers the route installer hands to the system resolver
+    /// (`resolvectl dns pim0 …` on Linux/systemd-resolved) when
+    /// split-default routing engages. Cloned once at startup from
+    /// `[routing].dns_servers`. Editing `pim.toml` and saving via
+    /// `config.save` requires a restart for the new list to take
+    /// effect — same restart-required posture as `[transport]` /
+    /// `[bluetooth]`. The empty case is treated as "skip DNS
+    /// management" so users who rely on systemd's DNS-over-pim0 stub
+    /// or a custom resolver setup can opt out.
+    pub(crate) mesh_dns_servers: Vec<String>,
 }
 
 impl DaemonState {
@@ -646,6 +656,7 @@ pub(crate) async fn run() -> Result<()> {
         last_broadcast_recipients: Arc::new(AtomicU64::new(0)),
         broadcast_notify: Arc::new(Notify::new()),
         route_install_notify: Arc::new(Notify::new()),
+        mesh_dns_servers: config.routing.dns_servers.clone(),
     });
 
     // ── Identity-broadcast background task ────────────────────────────────

--- a/crates/pim-daemon/src/app/event_loop.rs
+++ b/crates/pim-daemon/src/app/event_loop.rs
@@ -756,20 +756,7 @@ pub(super) async fn run_event_loop(state: Arc<DaemonState>) -> Result<()> {
     }
     tokio::time::sleep(Duration::from_millis(50)).await; // let Goodbye flush
 
-    if !state.is_gateway {
-        let mesh_ip = Ipv4Addr::from(state.mesh_ip.load(Ordering::Relaxed));
-        let prefix_len = state.mesh_prefix_len.load(Ordering::Relaxed);
-        let gateway_ip = first_host_in_subnet(mesh_ip, prefix_len);
-        if let Err(e) = state.tun.remove_default_route(gateway_ip) {
-            warn!(%gateway_ip, "default route cleanup failed: {e}");
-        }
-        if let Some((mesh_ipv6, prefix_len_v6)) = *state.mesh_ipv6.read().await {
-            let gateway_ipv6 = first_host_in_subnet_v6(mesh_ipv6, prefix_len_v6);
-            if let Err(e) = state.tun.remove_default_ipv6_route(gateway_ipv6) {
-                warn!(%gateway_ipv6, "IPv6 default route cleanup failed: {e}");
-            }
-        }
-    } else {
+    if state.is_gateway {
         // Gateway: reverse the iptables/ip6tables rules installed by
         // `setup_masquerade` so shutting pim down doesn't leave the host
         // dropping its own reply traffic.
@@ -783,6 +770,12 @@ pub(super) async fn run_event_loop(state: Arc<DaemonState>) -> Result<()> {
             gw_v6.teardown_masquerade();
         }
     }
+    // Non-gateway split-default route cleanup is owned by
+    // `route_installer` (app/route_installer.rs) — it tracks the
+    // selected-gateway mesh IP it actually installed (which matters
+    // under multi-gateway: the legacy code here always assumed the
+    // gateway was the .1 of the local subnet, so the wrong route was
+    // attempted on shutdown when a non-.1 gateway was elected).
 
     // Clean up
     for peer in peers {

--- a/crates/pim-daemon/src/app/route_installer.rs
+++ b/crates/pim-daemon/src/app/route_installer.rs
@@ -1,0 +1,158 @@
+//! Background task that reconciles the kernel's split-default routes
+//! against `state.route_on` + the routing table's currently-selected
+//! gateway.
+//!
+//! Reactivity:
+//!   - `state.route_install_notify.notified()` — woken from
+//!     `route.set_split_default` so a UI toggle takes effect within
+//!     one async hop instead of waiting up to 2 s for the tick.
+//!   - 2 s reconciliation tick — picks up gateway-selection changes
+//!     (multi-gateway swings, gateway disappearance) without an
+//!     event channel; gateway moves are rare enough that polling is
+//!     simpler than wiring per-event hooks through the routing engine.
+//!   - `state.cancel.cancelled()` — runs the final removal so the
+//!     daemon doesn't leave orphan `0.0.0.0/1`/`128.0.0.0/1` routes
+//!     pointing at a soon-to-be-gone `pim0` after a clean shutdown.
+//!
+//! Convergence rules (`route_on`, `selected_gateway`) → action:
+//!   - `(false, _)`                       → remove any installed route.
+//!   - `(true,  None)`                    → remove (kill-switch shape:
+//!     UI is asking us to route through the mesh but no gateway is
+//!     reachable, so dropping the routes is safer than letting traffic
+//!     fall back through wifi behind the user's back).
+//!   - `(true,  Some(ip))`, ip == current → no-op.
+//!   - `(true,  Some(ip))`, ip != current → atomic replace (remove old
+//!     via, install new via).
+//!
+//! Gateway nodes (`state.is_gateway`) skip the installer entirely —
+//! the gateway IS the destination, so installing a split-default route
+//! through itself would be a loop.
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tracing::{debug, info, warn};
+
+use crate::app::DaemonState;
+
+/// IPv6 split-default routes are `dev pim0`-only — `pim-tun` ignores
+/// the `gateway_ipv6` parameter on Linux/macOS (see
+/// `pim-tun::TunInterface::add_default_ipv6_route`). All we track is
+/// "are the v6 routes installed", and we use the unspecified `::1` as
+/// the placeholder argument since the API requires *something*.
+const PLACEHOLDER_V6_GATEWAY: Ipv6Addr = Ipv6Addr::LOCALHOST;
+
+/// Reconciliation tick. Bounded so a missed `notify` (concurrent
+/// notify-then-await race) still converges within 2 s, and so
+/// gateway-selection changes that don't go through the RPC handler
+/// (load / RTT swings, peer-loss-triggered route invalidation) get
+/// followed without extra plumbing.
+const RECONCILE_PERIOD: Duration = Duration::from_secs(2);
+
+/// Spawn the route installer. Returns immediately; the task lives
+/// until `state.cancel` fires.
+pub(crate) fn spawn(state: Arc<DaemonState>) {
+    if state.is_gateway {
+        debug!("route installer: skipped (this node is itself a gateway)");
+        return;
+    }
+    tokio::spawn(run(state));
+}
+
+async fn run(state: Arc<DaemonState>) {
+    info!("route installer: started");
+    let mut current_via_v4: Option<Ipv4Addr> = None;
+    let mut current_v6: bool = false;
+
+    loop {
+        tokio::select! {
+            _ = state.route_install_notify.notified() => {
+                debug!("route installer: woken by notify");
+            }
+            _ = tokio::time::sleep(RECONCILE_PERIOD) => {}
+            _ = state.cancel.cancelled() => {
+                if let Some(old) = current_via_v4.take() {
+                    if let Err(e) = state.tun.remove_default_route(old) {
+                        warn!(via = %old, "route installer shutdown: V4 remove failed: {e}");
+                    } else {
+                        info!(via = %old, "route installer shutdown: V4 split-default routes removed");
+                    }
+                }
+                if current_v6 {
+                    if let Err(e) = state.tun.remove_default_ipv6_route(PLACEHOLDER_V6_GATEWAY) {
+                        warn!("route installer shutdown: V6 remove failed: {e}");
+                    } else {
+                        info!("route installer shutdown: V6 split-default routes removed");
+                    }
+                }
+                info!("route installer: stopped");
+                return;
+            }
+        }
+
+        let route_on = state.route_on.load(Ordering::SeqCst);
+
+        // ── V4: route via the SELECTED gateway's mesh IP ─────────────
+        // `nearest_gateway_mesh_ip` follows multi-gateway swings without
+        // a dedicated event channel — gateway_score may pick a different
+        // gateway any tick (load / RTT / hop count drift), and the
+        // installer's atomic-replace below makes that a clean swap.
+        let desired_via_v4: Option<Ipv4Addr> = if route_on {
+            let routing = state.routing.lock().await;
+            routing.nearest_gateway_mesh_ip()
+        } else {
+            None
+        };
+
+        if desired_via_v4 != current_via_v4 {
+            if let Some(old) = current_via_v4.take() {
+                if let Err(e) = state.tun.remove_default_route(old) {
+                    warn!(via = %old, "remove old V4 split-default route failed: {e}");
+                } else {
+                    info!(via = %old, "V4 split-default routes removed");
+                }
+            }
+            if let Some(new) = desired_via_v4 {
+                match state.tun.add_default_route(new) {
+                    Ok(()) => {
+                        info!(via = %new, "V4 split-default routes installed");
+                        current_via_v4 = Some(new);
+                    }
+                    Err(e) => {
+                        warn!(via = %new, "install V4 split-default route failed: {e}");
+                        // Leave current_via_v4=None so the next tick retries.
+                    }
+                }
+            }
+        }
+
+        // ── V6: dev-only routes; install whenever route_on AND we have a
+        //       configured mesh IPv6 (the per-gateway mesh_ipv6 isn't
+        //       yet exposed by the routing table, so we don't switch on
+        //       gateway-selection — the v6 path is single-gateway today).
+        let desired_v6 = route_on && state.mesh_ipv6.read().await.is_some();
+        if desired_v6 != current_v6 {
+            if desired_v6 {
+                match state.tun.add_default_ipv6_route(PLACEHOLDER_V6_GATEWAY) {
+                    Ok(()) => {
+                        info!("V6 split-default routes installed");
+                        current_v6 = true;
+                    }
+                    Err(e) => {
+                        warn!("install V6 split-default route failed: {e}");
+                        // Leave current_v6=false so the next tick retries.
+                    }
+                }
+            } else {
+                if let Err(e) = state.tun.remove_default_ipv6_route(PLACEHOLDER_V6_GATEWAY) {
+                    warn!("remove V6 split-default route failed: {e}");
+                } else {
+                    info!("V6 split-default routes removed");
+                }
+                current_v6 = false;
+            }
+        }
+    }
+}

--- a/crates/pim-daemon/src/app/route_installer.rs
+++ b/crates/pim-daemon/src/app/route_installer.rs
@@ -37,13 +37,6 @@ use tracing::{debug, info, warn};
 
 use crate::app::DaemonState;
 
-/// Public DNS resolvers handed to systemd-resolved when split-default
-/// routing is engaged. Picked because they're (a) anycast — reachable
-/// over any internet uplink the gateway might have, (b) fast on the
-/// global mean, (c) reasonably privacy-conscious. Listing two so a
-/// single resolver outage doesn't break the mesh.
-const MESH_DNS_SERVERS: &[&str] = &["1.1.1.1", "1.0.0.1", "8.8.8.8"];
-
 /// IPv6 split-default routes are `dev pim0`-only — `pim-tun` ignores
 /// the `gateway_ipv6` parameter on Linux/macOS (see
 /// `pim-tun::TunInterface::add_default_ipv6_route`). All we track is
@@ -181,10 +174,15 @@ async fn run(state: Arc<DaemonState>) {
         //        curl by hostname doesn't). Anycast resolvers
         //        (1.1.1.1, 8.8.8.8) flow through the mesh + gateway NAT
         //        like any other internet destination.
-        let desired_dns = current_via_v4.is_some() || current_v6;
+        // Empty `mesh_dns_servers` (operator opted out via config) means
+        // never touch the system resolver — useful when something else
+        // owns DNS (corporate VPN tooling, NetworkManager dispatchers,
+        // a hand-managed `/etc/resolv.conf`).
+        let desired_dns =
+            !state.mesh_dns_servers.is_empty() && (current_via_v4.is_some() || current_v6);
         if desired_dns != current_dns {
             if desired_dns {
-                if set_interface_dns(&iface_name, MESH_DNS_SERVERS) {
+                if set_interface_dns(&iface_name, &state.mesh_dns_servers) {
                     current_dns = true;
                 }
             } else {
@@ -209,9 +207,9 @@ async fn run(state: Arc<DaemonState>) {
 /// daemon today (the route_installer itself is Linux-pim0-only), so
 /// the gating below is mostly defensive.
 #[cfg(target_os = "linux")]
-fn set_interface_dns(iface: &str, servers: &[&str]) -> bool {
+fn set_interface_dns(iface: &str, servers: &[String]) -> bool {
     let mut dns_args: Vec<&str> = vec!["dns", iface];
-    dns_args.extend_from_slice(servers);
+    dns_args.extend(servers.iter().map(String::as_str));
     let dns_status = std::process::Command::new("resolvectl")
         .args(&dns_args)
         .status();
@@ -295,7 +293,7 @@ fn revert_interface_dns(iface: &str) {
 // elsewhere), but keep stub signatures so the rest of the file builds
 // on macOS / Windows daemon configurations.
 #[cfg(not(target_os = "linux"))]
-fn set_interface_dns(_iface: &str, _servers: &[&str]) -> bool {
+fn set_interface_dns(_iface: &str, _servers: &[String]) -> bool {
     false
 }
 

--- a/crates/pim-daemon/src/app/route_installer.rs
+++ b/crates/pim-daemon/src/app/route_installer.rs
@@ -37,6 +37,13 @@ use tracing::{debug, info, warn};
 
 use crate::app::DaemonState;
 
+/// Public DNS resolvers handed to systemd-resolved when split-default
+/// routing is engaged. Picked because they're (a) anycast — reachable
+/// over any internet uplink the gateway might have, (b) fast on the
+/// global mean, (c) reasonably privacy-conscious. Listing two so a
+/// single resolver outage doesn't break the mesh.
+const MESH_DNS_SERVERS: &[&str] = &["1.1.1.1", "1.0.0.1", "8.8.8.8"];
+
 /// IPv6 split-default routes are `dev pim0`-only — `pim-tun` ignores
 /// the `gateway_ipv6` parameter on Linux/macOS (see
 /// `pim-tun::TunInterface::add_default_ipv6_route`). All we track is
@@ -65,6 +72,13 @@ async fn run(state: Arc<DaemonState>) {
     info!("route installer: started");
     let mut current_via_v4: Option<Ipv4Addr> = None;
     let mut current_v6: bool = false;
+    // Tracks whether we've configured pim0's DNS via systemd-resolved.
+    // Coupled to V4 install state — if either the V4 or V6 routes are
+    // up we want apps to resolve names through the mesh; if both are
+    // down we want the default resolver back. We key on `current_via_v4`
+    // OR `current_v6` below.
+    let mut current_dns: bool = false;
+    let iface_name = state.tun.name().to_string();
 
     loop {
         tokio::select! {
@@ -86,6 +100,9 @@ async fn run(state: Arc<DaemonState>) {
                     } else {
                         info!("route installer shutdown: V6 split-default routes removed");
                     }
+                }
+                if current_dns {
+                    revert_interface_dns(&iface_name);
                 }
                 info!("route installer: stopped");
                 return;
@@ -154,5 +171,133 @@ async fn run(state: Arc<DaemonState>) {
                 current_v6 = false;
             }
         }
+
+        // ── DNS: hand systemd-resolved a public resolver pinned to
+        //        pim0 whenever any mesh route is up; revert when both
+        //        come down. Without this, when the user disables wifi
+        //        the system's DHCP-derived nameserver becomes
+        //        unreachable and apps report "no internet" even though
+        //        the IP path through the mesh is live (curl by IP works,
+        //        curl by hostname doesn't). Anycast resolvers
+        //        (1.1.1.1, 8.8.8.8) flow through the mesh + gateway NAT
+        //        like any other internet destination.
+        let desired_dns = current_via_v4.is_some() || current_v6;
+        if desired_dns != current_dns {
+            if desired_dns {
+                if set_interface_dns(&iface_name, MESH_DNS_SERVERS) {
+                    current_dns = true;
+                }
+            } else {
+                revert_interface_dns(&iface_name);
+                current_dns = false;
+            }
+        }
     }
 }
+
+/// Configure systemd-resolved to use `servers` as the DNS upstream for
+/// queries arriving on `iface`, with a wildcard search domain so it
+/// becomes the *default* resolver while routing is engaged. Returns
+/// `true` on success so the caller can flip its `current_dns` flag;
+/// returns `false` (with a warn log) if `resolvectl` isn't installed
+/// or fails — the routes are still useful for IP-only traffic and the
+/// user can resolve manually with `--dns-servers`.
+///
+/// Linux-only because systemd-resolved is the only major resolver that
+/// exposes a per-interface DNS API. macOS uses scutil/scsetup which
+/// has different ergonomics; Windows uses netsh. Neither runs the
+/// daemon today (the route_installer itself is Linux-pim0-only), so
+/// the gating below is mostly defensive.
+#[cfg(target_os = "linux")]
+fn set_interface_dns(iface: &str, servers: &[&str]) -> bool {
+    let mut dns_args: Vec<&str> = vec!["dns", iface];
+    dns_args.extend_from_slice(servers);
+    let dns_status = std::process::Command::new("resolvectl")
+        .args(&dns_args)
+        .status();
+    match dns_status {
+        Ok(s) if s.success() => {}
+        Ok(s) => {
+            warn!(
+                iface,
+                exit = ?s.code(),
+                "resolvectl dns failed; DNS via mesh will not work until set manually"
+            );
+            return false;
+        }
+        Err(e) => {
+            warn!(
+                iface,
+                "resolvectl unavailable ({e}); DNS via mesh will not work until set manually \
+                 (e.g. `resolvectl dns {iface} 1.1.1.1` and `resolvectl domain {iface} '~.'`)"
+            );
+            return false;
+        }
+    }
+    // The wildcard search domain `~.` makes pim0's resolvers the global
+    // fallback for every query, not just for names ending in a
+    // pim-specific suffix. Without this, only mDNS-style local domains
+    // would route through pim0 and global names (gmail.com, etc.) would
+    // still hit the now-broken DHCP resolver.
+    let dom_status = std::process::Command::new("resolvectl")
+        .args(["domain", iface, "~."])
+        .status();
+    match dom_status {
+        Ok(s) if s.success() => {
+            info!(iface, servers = ?servers, "configured pim0 as default DNS resolver");
+            true
+        }
+        Ok(s) => {
+            warn!(
+                iface,
+                exit = ?s.code(),
+                "resolvectl domain '~.' failed; pim0 DNS set but not promoted to default \
+                 — global hostnames may still hit the wifi resolver"
+            );
+            // The dns assignment did succeed; treat as half-success so
+            // we still revert it on teardown.
+            true
+        }
+        Err(e) => {
+            warn!(iface, "resolvectl domain unavailable ({e})");
+            true
+        }
+    }
+}
+
+/// Revert any per-interface DNS configuration we set on `iface`.
+/// Idempotent + tolerant: if `resolvectl` is missing or the interface
+/// has no overrides, the call no-ops and we log at debug.
+#[cfg(target_os = "linux")]
+fn revert_interface_dns(iface: &str) {
+    match std::process::Command::new("resolvectl")
+        .args(["revert", iface])
+        .status()
+    {
+        Ok(s) if s.success() => {
+            info!(iface, "reverted pim0 DNS overrides");
+        }
+        Ok(s) => {
+            debug!(
+                iface,
+                exit = ?s.code(),
+                "resolvectl revert exited non-zero (probably no overrides to revert)"
+            );
+        }
+        Err(e) => {
+            debug!(iface, "resolvectl revert failed ({e})");
+        }
+    }
+}
+
+// On non-Linux targets the route installer never spawns (route_installer
+// is Linux-only by virtue of pim-tun's add_default_route being a no-op
+// elsewhere), but keep stub signatures so the rest of the file builds
+// on macOS / Windows daemon configurations.
+#[cfg(not(target_os = "linux"))]
+fn set_interface_dns(_iface: &str, _servers: &[&str]) -> bool {
+    false
+}
+
+#[cfg(not(target_os = "linux"))]
+fn revert_interface_dns(_iface: &str) {}

--- a/crates/pim-daemon/src/logs_subscriber.rs
+++ b/crates/pim-daemon/src/logs_subscriber.rs
@@ -68,29 +68,35 @@ pub(crate) fn init() -> LogsLayer {
     LogsLayer
 }
 
-/// Atomically take a snapshot of the history buffer AND subscribe to
-/// the live broadcast. Lock ordering is critical:
+/// Subscribe to the live broadcast WITHOUT taking a history snapshot.
+/// Used by the per-connection logs forwarder, which is spawned at
+/// connect time and forwards every event for the lifetime of the
+/// connection. History replay is owned by `logs.subscribe` (gated by a
+/// per-connection `history_replayed` flag so it fires exactly once per
+/// connection regardless of how many subscribers the UI registers).
 ///
-///   * `on_event` holds the history lock for the entire duration of
-///     `push_back` + `broadcast::send`.
-///   * `subscribe_with_history` also holds the history lock from
-///     snapshot until `subscribe()`.
-///
-/// Because `on_event` cannot interleave with `subscribe_with_history`
-/// (they contend on the same mutex), there is NO window in which an
-/// event could be both in the snapshot AND received by the new
-/// receiver — replay and live stream don't overlap, no duplicates.
-///
-/// Returns `None` if `init()` hasn't been called yet (only in tests
-/// that skip tracing setup).
-pub(crate) fn subscribe_with_history() -> Option<(Vec<Value>, broadcast::Receiver<Value>)> {
-    let sender = SENDER.get()?;
+/// Splitting `subscribe_with_history` into "live only" + "history only"
+/// is what lets a single `logs.subscribe` call be a no-op-with-history
+/// instead of spawning a fresh forwarder task — every extra forwarder
+/// per connection used to write a duplicate copy of every log line, so
+/// StrictMode double-mount, HMR module replacement, or any second
+/// `logs.subscribe` call on the same connection multiplied every event
+/// the UI rendered.
+pub(crate) fn live_subscribe() -> Option<broadcast::Receiver<Value>> {
+    SENDER.get().map(|s| s.subscribe())
+}
+
+/// Take a snapshot of the history ring buffer without subscribing to
+/// the live broadcast. Caller is responsible for sequencing this
+/// against the live forwarder if it wants no overlap (the live
+/// forwarder subscribes once at connect time, before the first
+/// `logs.subscribe`, so a tiny overlap window with replay is possible
+/// but the entries are identical and the UI dedupes consecutive
+/// duplicates anyway).
+pub(crate) fn history_snapshot() -> Option<Vec<Value>> {
     let history = HISTORY.get()?;
     let buf = history.lock().ok()?;
-    let snapshot: Vec<Value> = buf.iter().cloned().collect();
-    let rx = sender.subscribe();
-    drop(buf);
-    Some((snapshot, rx))
+    Some(buf.iter().cloned().collect())
 }
 
 pub(crate) struct LogsLayer;
@@ -237,12 +243,13 @@ mod tests {
     }
 
     #[test]
-    fn subscribe_with_history_returns_none_before_init() {
+    fn live_subscribe_and_history_snapshot_return_none_before_init() {
         // SENDER + HISTORY are process-global; this only holds in a
         // fresh test process. `cargo test` provides one per integration
         // test. We skip if SENDER happens to already be set.
         if SENDER.get().is_none() {
-            assert!(subscribe_with_history().is_none());
+            assert!(live_subscribe().is_none());
+            assert!(history_snapshot().is_none());
         }
     }
 }

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -44,7 +44,7 @@
 use std::collections::HashMap;
 use std::net::Ipv4Addr;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -238,6 +238,53 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
         }
     });
 
+    // ONE logs forwarder per connection. Same shape as the status
+    // forwarder above: subscribe to the global `logs_subscriber`
+    // broadcast and pump every event onto this connection's write
+    // channel as a `logs.event` notification. UIs filter by level /
+    // source on their side.
+    //
+    // History replay is owned separately by `logs.subscribe` (see
+    // `start_logs_subscription`) and gated by the per-connection
+    // `logs_history_replayed` AtomicBool below so the daemon emits the
+    // historical buffer exactly once per connection no matter how many
+    // times the UI calls `logs.subscribe` (StrictMode double-mount,
+    // Vite HMR module replacement, simple↔advanced shell remount, …).
+    // Before this refactor each `logs.subscribe` call spawned its own
+    // forwarder + history-replay task — N calls per connection meant
+    // every log line arrived N times in the UI buffer.
+    let logs_history_replayed = Arc::new(AtomicBool::new(false));
+    let logs_forwarder = match logs_subscriber::live_subscribe() {
+        Some(mut logs_rx) => {
+            let logs_write_tx = write_tx.clone();
+            Some(tokio::spawn(async move {
+                loop {
+                    match logs_rx.recv().await {
+                        Ok(event) => {
+                            let notif = json!({
+                                "jsonrpc": "2.0",
+                                "method": "logs.event",
+                                "params": event,
+                            });
+                            if push_value(&logs_write_tx, &notif).is_err() {
+                                break;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            debug!(lagged = n, "logs forwarder lagged; resyncing");
+                            continue;
+                        }
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            }))
+        }
+        None => {
+            warn!("logs_subscriber not initialised; logs.event will be silent on this connection");
+            None
+        }
+    };
+
     // Single per-connection messaging forwarder. Same shape as the status
     // forwarder above: subscribe to the messaging broadcast channel and
     // pump every event onto the write channel as a `messages.event`
@@ -321,7 +368,7 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
             continue;
         }
 
-        let outcome = dispatch(&state, &req, &write_tx).await;
+        let outcome = dispatch(&state, &req, &write_tx, &logs_history_replayed).await;
         let response = match outcome {
             Ok(result) => json!({"jsonrpc": "2.0", "id": id, "result": result}),
             Err((code, message, data)) => error_response(id, code, &message, data),
@@ -339,6 +386,9 @@ async fn handle_connection(stream: UnixStream, state: Arc<DaemonState>) -> Resul
     drop(write_tx);
     status_forwarder.abort();
     messaging_forwarder.abort();
+    if let Some(handle) = logs_forwarder {
+        handle.abort();
+    }
     let _ = writer_handle.await;
     Ok(())
 }
@@ -372,7 +422,12 @@ fn error_response(id: Value, code: i32, message: &str, data: Option<Value>) -> V
 
 type RpcResult = std::result::Result<Value, (i32, String, Option<Value>)>;
 
-async fn dispatch(state: &Arc<DaemonState>, req: &RpcRequest, write_tx: &WriteTx) -> RpcResult {
+async fn dispatch(
+    state: &Arc<DaemonState>,
+    req: &RpcRequest,
+    write_tx: &WriteTx,
+    logs_history_replayed: &Arc<AtomicBool>,
+) -> RpcResult {
     match req.method.as_str() {
         // §2.1
         "rpc.hello" => method_hello(req.params.as_ref()),
@@ -432,10 +487,17 @@ async fn dispatch(state: &Arc<DaemonState>, req: &RpcRequest, write_tx: &WriteTx
         "config.get" => method_config_get(state, req.params.as_ref()).await,
         "config.save" => method_config_save(state, req.params.as_ref()).await,
 
-        // §5.6 logs
+        // §5.6 logs — `logs.event` notifications are pumped by the
+        // per-connection forwarder spawned in `handle_connection`.
+        // `logs.subscribe` only triggers the one-shot history replay
+        // (gated by `logs_history_replayed` so it fires exactly once
+        // per connection no matter how often the UI re-subscribes);
+        // `logs.unsubscribe` is a no-op because the live forwarder is
+        // tied to the connection's lifetime, not to subscription IDs.
         "logs.subscribe" => Ok(start_logs_subscription(
             req.params.as_ref(),
             write_tx.clone(),
+            logs_history_replayed,
         )),
         "logs.unsubscribe" => Ok(Value::Null),
 
@@ -463,81 +525,47 @@ async fn dispatch(state: &Arc<DaemonState>, req: &RpcRequest, write_tx: &WriteTx
 // Subscription forwarders.
 // ────────────────────────────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize, Default)]
-struct LogsSubscribeParams {
-    /// Optional minimum level. One of `trace`, `debug`, `info`, `warn`,
-    /// `error`. Events at levels BELOW this are dropped before sending.
-    /// Used for back-compat / "warn and up" simplicity. If `levels` is
-    /// also set, `levels` wins (explicit beats threshold).
-    min_level: Option<String>,
-    /// Explicit allow-list of levels. When `Some(non_empty)`, ONLY events
-    /// at one of these levels are forwarded. Empty/missing falls back to
-    /// `min_level` semantics. Lets the UI pick e.g. `[info, error]`
-    /// without including warn.
-    levels: Option<Vec<String>>,
-    /// Source-prefix allow-list (matches `event.source` via
-    /// `starts_with`). Empty / missing = any source. Lets the UI pick
-    /// e.g. `["pim_daemon", "pim_transport"]` to focus on specific
-    /// crates while ignoring noise from `tao`, `mio`, etc.
-    #[serde(default)]
-    sources: Vec<String>,
-}
-
-fn level_rank(level: &str) -> u8 {
-    match level {
-        "trace" => 0,
-        "debug" => 1,
-        "info" => 2,
-        "warn" => 3,
-        "error" => 4,
-        _ => 2, // unknown → treat as info
-    }
-}
-
-/// Allocate a `subscription_id`, atomically snapshot the daemon's log
-/// history AND get a live broadcast receiver, replay history first
-/// (filtered) and then forward live events (filtered) as `logs.event`
-/// notifications onto this connection. Closes when the writer channel
-/// closes (peer hung up).
+/// Allocate a `subscription_id` and, on the FIRST call per connection,
+/// replay the daemon's log history buffer onto this connection.
+///
+/// Live `logs.event` notifications are NOT spawned here — they're
+/// pumped by the per-connection forwarder in `handle_connection`, so
+/// extra `logs.subscribe` calls from the same connection (StrictMode
+/// double-mount, Vite HMR, AppShell↔SimpleShell remount, ...) collapse
+/// to a single forwarder + at most one history replay. Before this
+/// refactor each call spawned its own forwarder + replay task, so
+/// every log line arrived N times in the UI buffer.
 ///
 /// The history replay covers the daemon's full startup sequence
 /// ("daemon starting" → "TUN up" → "transport listening" → "rpc
 /// listening" → ...) so the UI's Logs view is populated immediately
 /// even though it subscribes well after those events fired.
-fn start_logs_subscription(params: Option<&Value>, write_tx: WriteTx) -> Value {
+///
+/// The legacy `LogsSubscribeParams` filter (`min_level` / `levels` /
+/// `sources`) is intentionally ignored: there is now ONE forwarder per
+/// connection and per-call filters would need to multiplex the stream
+/// at the wire level, which the UI doesn't actually use (it filters
+/// client-side in `useLogsStream`). The CLI's `pim logs` command tails
+/// the on-disk log file directly and never goes through this RPC.
+fn start_logs_subscription(
+    _params: Option<&Value>,
+    write_tx: WriteTx,
+    history_replayed: &Arc<AtomicBool>,
+) -> Value {
     let id = new_subscription_id();
-    let parsed: LogsSubscribeParams = params
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
-        .unwrap_or_default();
-    let min_rank = parsed
-        .min_level
-        .as_deref()
-        .map(|l| level_rank(&l.to_lowercase()))
-        .unwrap_or(0);
-    // Normalise `levels` to a lowercase HashSet for O(1) lookup. Empty
-    // vec is treated as "no level filter" (allow all) so the UI can
-    // distinguish "select nothing → show nothing" client-side from
-    // server-side filtering.
-    let level_allow_list: Option<std::collections::HashSet<String>> = parsed
-        .levels
-        .map(|v| v.into_iter().map(|s| s.to_lowercase()).collect())
-        .filter(|s: &std::collections::HashSet<String>| !s.is_empty());
-    let sources = parsed.sources;
-
-    let (history, mut rx) = match logs_subscriber::subscribe_with_history() {
-        Some(pair) => pair,
+    if history_replayed.swap(true, Ordering::SeqCst) {
+        // Already replayed history on this connection — no extra work.
+        return json!({ "subscription_id": id });
+    }
+    let history = match logs_subscriber::history_snapshot() {
+        Some(h) => h,
         None => {
-            warn!("logs.subscribe: logs_subscriber not initialised; subscription will be silent");
+            warn!("logs.subscribe: logs_subscriber not initialised; history replay skipped");
             return json!({ "subscription_id": id });
         }
     };
-
     tokio::spawn(async move {
-        // Replay history first.
         for event in history {
-            if !passes_filter(&event, min_rank, level_allow_list.as_ref(), &sources) {
-                continue;
-            }
             let notif = json!({
                 "jsonrpc": "2.0",
                 "method": "logs.event",
@@ -547,74 +575,8 @@ fn start_logs_subscription(params: Option<&Value>, write_tx: WriteTx) -> Value {
                 return;
             }
         }
-        // Then live stream.
-        loop {
-            match rx.recv().await {
-                Ok(event) => {
-                    if !passes_filter(&event, min_rank, level_allow_list.as_ref(), &sources) {
-                        continue;
-                    }
-                    let notif = json!({
-                        "jsonrpc": "2.0",
-                        "method": "logs.event",
-                        "params": event,
-                    });
-                    if push_value(&write_tx, &notif).is_err() {
-                        break;
-                    }
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    debug!("logs.subscribe: lagged, dropped {n} events; resyncing");
-                    continue;
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
-            }
-        }
     });
     json!({ "subscription_id": id })
-}
-
-/// Apply level + source filter to an event. Returns true if it should
-/// be forwarded.
-///
-/// Level rules:
-///   - If `level_allow_list` is `Some`, the event level must be IN the
-///     set (explicit allow-list, no min-level threshold applies).
-///   - If `level_allow_list` is `None`, the event level must be `>=`
-///     `min_rank`.
-///
-/// Source rules: prefix-match against `sources`. Empty `sources` =
-/// allow any source.
-fn passes_filter(
-    event: &Value,
-    min_rank: u8,
-    level_allow_list: Option<&std::collections::HashSet<String>>,
-    sources: &[String],
-) -> bool {
-    if let Some(level) = event.get("level").and_then(|v| v.as_str()) {
-        match level_allow_list {
-            Some(allow) => {
-                if !allow.contains(level) {
-                    return false;
-                }
-            }
-            None => {
-                if level_rank(level) < min_rank {
-                    return false;
-                }
-            }
-        }
-    }
-    if !sources.is_empty() {
-        let source = event
-            .get("source")
-            .and_then(|v| v.as_str())
-            .unwrap_or_default();
-        if !sources.iter().any(|prefix| source.starts_with(prefix)) {
-            return false;
-        }
-    }
-    true
 }
 
 // ── §2.1 ─────────────────────────────────────────────────────────────────

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1589,13 +1589,21 @@ struct RouteSetSplitDefaultParams {
     on: bool,
 }
 
-/// Toggle split-default routing. Currently a state-only operation —
-/// the daemon's IP forwarder doesn't yet observe `state.route_on`, so
-/// this RPC's job is to (a) keep an authoritative atomic flag, (b)
-/// broadcast the corresponding `status.event` so subscribed UIs flip
-/// without re-polling, and (c) return the new state to the caller.
-/// Wiring the actual default-route mutation through the forwarder is
-/// a separate follow-up.
+/// Toggle split-default routing.
+///
+/// Three side-effects (in order):
+///   1. Store `parsed.on` into `state.route_on` atomically.
+///   2. Wake the `route_installer` background task so it reconciles
+///      the kernel's `0.0.0.0/1`/`128.0.0.0/1` routes within one async
+///      hop instead of waiting for its 2 s tick. The installer reads
+///      the same atomic + the routing table's selected gateway and
+///      decides what to install/remove — no per-RPC `ip route` call
+///      from this handler so concurrent RPC calls can't race against
+///      each other.
+///   3. Broadcast a discriminated `status.event` (`route_on` /
+///      `route_off`) so subscribed UIs flip the toggle badge without
+///      a follow-up `status` poll. SendError on no-subscribers is fine
+///      — late connections pick up the state via the next `status`.
 fn method_route_set_split_default(state: &Arc<DaemonState>, params: Option<&Value>) -> RpcResult {
     info!(?params, "route.set_split_default invoked");
     let parsed: RouteSetSplitDefaultParams = match params {
@@ -1613,10 +1621,8 @@ fn method_route_set_split_default(state: &Arc<DaemonState>, params: Option<&Valu
     state
         .route_on
         .store(parsed.on, std::sync::atomic::Ordering::SeqCst);
+    state.route_install_notify.notify_one();
 
-    // Broadcast the discriminated `status.event` per pim-ui's rpc-types
-    // contract. SendError on no-subscribers is fine — UIs that connect
-    // later see the current state via the next `status` RPC.
     let kind = if parsed.on { "route_on" } else { "route_off" };
     let send_result = state.status_events_tx.send(json!({
         "jsonrpc": "2.0",

--- a/crates/pim-daemon/src/runtime_config.rs
+++ b/crates/pim-daemon/src/runtime_config.rs
@@ -102,28 +102,6 @@ pub(crate) fn parse_ipv6_cidr(s: &str) -> Result<(Ipv6Addr, u8)> {
     Ok((ip, prefix))
 }
 
-pub(crate) fn first_host_in_subnet(network: Ipv4Addr, prefix_len: u8) -> Ipv4Addr {
-    let n = u32::from(network);
-    let mask: u32 = if prefix_len >= 32 {
-        0xffff_ffff
-    } else {
-        !((1u32 << (32 - prefix_len)) - 1)
-    };
-    Ipv4Addr::from((n & mask) | 1)
-}
-
-pub(crate) fn first_host_in_subnet_v6(network: Ipv6Addr, prefix_len: u8) -> Ipv6Addr {
-    let n = u128::from(network);
-    let mask: u128 = if prefix_len == 0 {
-        0
-    } else if prefix_len >= 128 {
-        u128::MAX
-    } else {
-        !((1u128 << (128 - prefix_len)) - 1)
-    };
-    Ipv6Addr::from((n & mask) | 1)
-}
-
 pub(crate) async fn install_signal_handler(cancel: CancellationToken) {
     #[cfg(unix)]
     {

--- a/crates/pim-routing/src/table.rs
+++ b/crates/pim-routing/src/table.rs
@@ -538,6 +538,25 @@ impl RoutingTable {
         self.best_gateway_entry().map(|(dst, e)| (dst, e.next_hop))
     }
 
+    /// Mesh IPv4 of the currently-selected best gateway, or `None` when
+    /// this node is itself a gateway / no usable gateway is known / the
+    /// gateway entry doesn't yet carry an advertised `mesh_ip`.
+    ///
+    /// This is the `via <ip>` that the daemon's route installer should
+    /// hand to `ip route replace 0.0.0.0/1 via <ip> dev pim0 onlink`,
+    /// so traffic for the split-default routes lands on the elected
+    /// gateway. Re-reading this on every reconciliation tick is what
+    /// lets the installer follow gateway-selection swings (load /
+    /// RTT changes, hop count drift, gateway disappearance) without
+    /// extra plumbing — no event channel needed because gateway moves
+    /// are rare and the polling cost is one HashMap scan.
+    pub fn nearest_gateway_mesh_ip(&self) -> Option<Ipv4Addr> {
+        if self.is_gateway {
+            return None;
+        }
+        self.best_gateway_entry().and_then(|(_, e)| e.mesh_ip)
+    }
+
     /// All known gateways sorted by composite score (best first).
     pub fn all_gateways(&self) -> Vec<(NodeId, u8)> {
         let mut gateways: Vec<(NodeId, u8)> = self


### PR DESCRIPTION
… listener

When one peer disconnected, `bridge::run`'s internal `cancel.cancel()` (called from the r2t/t2r select to unwind the second pump after the first exits) propagated up the cloned `CancellationToken` and shut down the acceptor + outbound poll tasks. Subsequent dial attempts hit `Connection refused (os error 111)` until the daemon was restarted.

Reproduced on the linux↔linux bench by killing + respawning the client daemon: gateway logged `acceptor shutdown` immediately after `rfcomm peer lost reason=bridge_closed`, then refused every reconnect for the rest of its lifetime.

Hand each session a `child_token()` instead of `clone()` at the three spawn sites (listener.rs, outbound.rs, session.rs → bridge::run). Child tokens cascade parent → child cancellation but not the reverse, so per-session unwind is now contained.