### PR TITLE
develop

### DIFF
--- a/.agent/skills/publish-crates/SKILL.md
+++ b/.agent/skills/publish-crates/SKILL.md
@@ -1,34 +1,36 @@
 # Skill: Publish Crates
 
-Use this skill to automate the publishing of workspace crates to crates.io.
+Use this skill to publish the workspace crates to crates.io after a release has been prepared.
 
 ## Purpose
 
-After a release has been prepared, versions bumped, and changes committed/tagged, the crates in the workspace need to be published to crates.io in their topological dependency order. The `scripts/publish-crates.sh` script automates this process while handling pre-publish checks and rate limiting.
+The repository contains multiple Rust crates as part of a Cargo workspace that must be published in a specific topological dependency order. The `scripts/publish-crates.sh` script automates this process while properly respecting crates.io rate limits and ensuring pre-publish checks are passed.
+
+## Prerequisites
+
+1. You should have already prepared a release (bumped versions, updated lockfiles) and pushed the release tag.
+2. Ensure you have no uncommitted changes in your working directory.
 
 ## Workflow
 
-1. Ensure Prerequisites
-    - Ensure `prepare-release` steps are completed.
-    - Ensure the working tree is clean (no uncommitted changes).
-    - Ensure you are authenticated with crates.io (if running locally or required by the environment).
-
-2. Execute the Publish Script
+1. Execute the Publish Script
     - Run `./scripts/publish-crates.sh` from the repository root.
-    - Environment Variables (Optional):
-        - `DRY_RUN=1`: Performs a dry-run to verify the process without making network writes.
-        - `START_FROM=<crate_name>`: Resumes publishing from a specific crate (e.g., `START_FROM=pim-bluetooth`) if the process was interrupted (e.g., by a rate limit).
-        - `PUBLISH_DELAY=<seconds>`: Configures the wait time between crate publishes. Defaults to 600 seconds (10 minutes) to respect crates.io rate limits for new crates, but can be lowered for subsequent version bumps.
+    - Options:
+        - `DRY_RUN=1`: Perform a dry run without actually publishing to crates.io. Useful for validating pre-publish checks and publish order.
+        - `START_FROM=<crate_name>`: Resume the publish process from a specific crate (e.g., `START_FROM=pim-bluetooth`). This is useful if the publish process was interrupted due to a rate-limit error or network issue.
+        - `PUBLISH_DELAY=<seconds>`: Set a custom delay between publishing each crate. By default, this is 600 seconds (10 minutes) to accommodate crates.io's rate limits for *new* crate registrations. For subsequent version bumps of already registered crates, you can override this with a shorter delay (e.g., `PUBLISH_DELAY=30`).
 
-3. Verify Publish Status
-    - Monitor the script's output to ensure all crates are published successfully without errors.
-    - The script automatically runs `cargo fmt`, `cargo clippy`, and `cargo test` before publishing.
+2. Review Execution
+    - The script will first run formatting, clippy, and tests.
+    - It will then iterate through the predefined topological list of crates and publish each one sequentially.
+    - Wait for the script to finish and emit "All crates published successfully."
 
 ## Expected Output
 
-- Console output detailing the pre-publish checks, the order of published crates, and a final success message.
+- Clean execution of pre-publish checks (fmt, clippy, test).
+- Sequential logging of each crate being published and the delay timer.
 
 ## Done Criteria
 
 - The script exits with code `0`.
-- All crates in the workspace are successfully published to crates.io.
+- All crates are available in their updated versions on crates.io.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -32,3 +32,7 @@
 
 **Learning:** Data and Transport frames were constantly taking ownership of byte buffers via `.to_vec()` instead of using zero-copy `bytes::Bytes`. This caused numerous heap allocations per forwarded packet on relay nodes, unnecessarily straining memory bandwidth.
 **Action:** Replace `Vec<u8>` payloads in protocol frame structs (`TransportFrame`, `MeshDataFrame`, `FragmentFrame`) with `bytes::Bytes` to allow zero-copy parsing and forwarding, drastically cutting allocations per packet.
+## 2024-05-18 - Avoid allocations on uniquely owned `bytes::Bytes` with `try_into_mut()`
+
+**Learning:** `bytes::Bytes` holds a reference-counted buffer but its contents cannot be mutated via `.to_vec()` without forcing a clone and full allocation. However, if the network code owns the sole reference to the buffer (e.g. immediately after decoding), `.try_into_mut()` can safely reclaim mutable access to the underlying `BytesMut` with zero allocations. In high-throughput network daemons like PIM, allocating memory for every frame on the read path becomes a major performance bottleneck.
+**Action:** When a frame buffer needs to be mutated directly (like in `decrypt_in_place_detached`), avoid `.to_vec()`. Instead, attempt to use `.try_into_mut()` when we know the `Bytes` object is uniquely owned to recover zero-copy mutability.

--- a/crates/pim-bluetooth/src/tests/nap_server.rs
+++ b/crates/pim-bluetooth/src/tests/nap_server.rs
@@ -72,7 +72,7 @@ async fn start_nap_server_auto_creates_bridge_and_invokes_bt_network_with_bridge
     let mut child = svc.start_nap_server().await.unwrap();
     child.wait().await.unwrap();
 
-    let args = fs::read_to_string(fake_args).unwrap();
+    let args = fs::read_to_string(&fake_args).unwrap();
     assert_eq!(args, "-s\nnap\nbr-bt\n");
 
     let ip_log = fs::read_to_string(&fake_ip_log).unwrap();

--- a/crates/pim-routing/src/table.rs
+++ b/crates/pim-routing/src/table.rs
@@ -394,7 +394,9 @@ impl RoutingTable {
     pub fn generate_advertisement(&mut self, to_peer: NodeId) -> RouteUpdateFrame {
         self.sequence += 1;
 
-        let mut entries: Vec<RouteEntry> = Vec::new();
+        // OPTIMIZATION: Pre-allocate capacity to prevent multiple vector reallocations
+        // when dealing with large numbers of route entries.
+        let mut entries: Vec<RouteEntry> = Vec::with_capacity(self.routes.len() + 1);
 
         // Advertise our own node (0 hops, possibly as gateway)
         entries.push(RouteEntry {


### PR DESCRIPTION
- **fix(rfcomm): scope per-session cancel so bridge teardown doesn't kill listener**
- **fix(rpc): one logs forwarder per connection + replay history exactly once**
- **feat(routing): wire route.set_split_default to actually install kernel routes**
- **feat(routing): pin pim0 as the system DNS resolver while routing is on**
- **feat(routing): make mesh DNS servers configurable via [routing].dns_servers**
- **docs: add publish-crates skill to .agent workspace**
- **⚡ Bolt: [performance improvement] Optimize decryption allocation and route table generation**
- **fix: pass reference to fs::read_to_string in test**
