### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure file permissions for persisted broadcast config

### DIFF
--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1530,9 +1530,13 @@ async fn persist_broadcast_config_to_disk(state: &Arc<DaemonState>) -> anyhow::R
             options.mode(0o600);
         }
         use std::io::Write;
-        let mut file = options.open(&tmp).with_context(|| format!("open tmp {}", tmp.display()))?;
-        file.write_all(serialized.as_bytes()).with_context(|| format!("write tmp {}", tmp.display()))?;
-        file.flush().with_context(|| format!("flush tmp {}", tmp.display()))?;
+        let mut file = options
+            .open(&tmp)
+            .with_context(|| format!("open tmp {}", tmp.display()))?;
+        file.write_all(serialized.as_bytes())
+            .with_context(|| format!("write tmp {}", tmp.display()))?;
+        file.flush()
+            .with_context(|| format!("flush tmp {}", tmp.display()))?;
 
         std::fs::rename(&tmp, &path_for_task)
             .with_context(|| format!("rename {} -> {}", tmp.display(), path_for_task.display()))?;

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1521,8 +1521,19 @@ async fn persist_broadcast_config_to_disk(state: &Arc<DaemonState>) -> anyhow::R
             .parent()
             .ok_or_else(|| anyhow!("config path has no parent"))?;
         let tmp = tempfile_in_same_dir(parent, &path_for_task)?;
-        std::fs::write(&tmp, serialized.as_bytes())
-            .with_context(|| format!("write tmp {}", tmp.display()))?;
+
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        use std::io::Write;
+        let mut file = options.open(&tmp).with_context(|| format!("open tmp {}", tmp.display()))?;
+        file.write_all(serialized.as_bytes()).with_context(|| format!("write tmp {}", tmp.display()))?;
+        file.flush().with_context(|| format!("flush tmp {}", tmp.display()))?;
+
         std::fs::rename(&tmp, &path_for_task)
             .with_context(|| format!("rename {} -> {}", tmp.display(), path_for_task.display()))?;
         Ok(())


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The daemon's `persist_broadcast_config_to_disk` function in `crates/pim-daemon/src/rpc.rs` used `std::fs::write` to save configuration updates to disk. This relied on the default system umask, which could result in sensitive configuration data being written with overly permissive (world-readable) file permissions. In addition, it did not use `create_new(true)`, creating a minor TOCTOU race condition for symlinks.
🎯 Impact: Unprivileged local users could read the daemon's broadcast configuration file due to overly permissive file permissions.
🔧 Fix: Replaced `std::fs::write` with `std::fs::OpenOptions`. Enabled `.create_new(true)` to prevent TOCTOU attacks, and used `std::os::unix::fs::OpenOptionsExt` to explicitly set `.mode(0o600)` on Unix systems, ensuring the temp file (and thus the final renamed config file) is strictly owner-readable/writable.
✅ Verification: Ensure the daemon builds properly on both Unix and non-Unix (via `#[cfg(unix)]`). Code compiled successfully using `cargo check --workspace` and tests passed using `cargo test --workspace`.

---
*PR created automatically by Jules for task [10696579515729616098](https://jules.google.com/task/10696579515729616098) started by @Rfluid*