### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate vector capacity during payload fragmentation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,8 @@
 
 **Learning:** `bytes::Bytes` holds a reference-counted buffer but its contents cannot be mutated via `.to_vec()` without forcing a clone and full allocation. However, if the network code owns the sole reference to the buffer (e.g. immediately after decoding), `.try_into_mut()` can safely reclaim mutable access to the underlying `BytesMut` with zero allocations. In high-throughput network daemons like PIM, allocating memory for every frame on the read path becomes a major performance bottleneck.
 **Action:** When a frame buffer needs to be mutated directly (like in `decrypt_in_place_detached`), avoid `.to_vec()`. Instead, attempt to use `.try_into_mut()` when we know the `Bytes` object is uniquely owned to recover zero-copy mutability.
+
+## 2024-05-18 - Pre-allocate vector capacity to avoid reallocation
+
+**Learning:** When fragmenting payloads or dynamically appending to arrays, initializing with `Vec::new()` requires the memory allocator to repeatedly resize the array as elements are pushed. This dynamic reallocation overhead introduces unnecessary latency in hot paths.
+**Action:** When the maximum number of elements is known or can be calculated (e.g., using `div_ceil`), pre-allocate the required capacity with `Vec::with_capacity(...)` to ensure a single, contiguous memory allocation.

--- a/crates/pim-protocol/src/fragment_frame.rs
+++ b/crates/pim-protocol/src/fragment_frame.rs
@@ -85,7 +85,9 @@ pub fn fragment_packet(data: &[u8], fragment_id: u32) -> Vec<FragmentFrame> {
     }
 
     let total_length = data.len() as u16;
-    let mut frames = Vec::new();
+    // Pre-allocate the exact number of fragments required to prevent
+    // dynamic reallocation overhead during the fragmentation loop.
+    let mut frames = Vec::with_capacity(data.len().div_ceil(MAX_FRAGMENT_PAYLOAD));
     let mut offset = 0usize;
 
     while offset < data.len() {


### PR DESCRIPTION
### 💡 What
This patch modifies the `fragment_packet` function in `crates/pim-protocol/src/fragment_frame.rs` to pre-allocate the exact vector capacity needed for fragments instead of using `Vec::new()`.

### 🎯 Why
When `fragment_packet` is called on a large payload, `Vec::new()` requires the memory allocator to repeatedly resize the array and copy existing elements as more fragments are pushed in the `while` loop. In a hot network execution path like the data plane router, this dynamic reallocation overhead strains memory bandwidth and introduces unnecessary latency.

### 📊 Impact
Eliminates intermediate vector allocations and capacity resizing per IP packet fragmentation, ensuring exactly one contiguous allocation per packet regardless of fragment count.

### 🔬 Measurement
Run the unit test suite via `cargo test -p pim-protocol` and perform workspace linting via `cargo clippy --workspace -- -D warnings`. Ensure all tests complete without error.

---
*PR created automatically by Jules for task [16703116080971950640](https://jules.google.com/task/16703116080971950640) started by @Rfluid*