### PR TITLE
🛡️ Sentinel: [MEDIUM] Secure file permissions for broadcast config writes

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** The daemon's config generation (`pim-cli/src/main.rs`) and identity key generation (`pim-crypto/src/identity.rs`) checked `path.exists()` before calling `create(true).truncate(true)`. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition where an attacker could replace the file with a symlink between the check and the use, potentially leading to arbitrary file overwrites or key theft.
 **Learning:** Checking for file existence before creating a sensitive file is inherently racy and insecure.
 **Prevention:** Always rely on the filesystem to enforce exclusivity. Use `OpenOptions::new().create_new(true)` to atomically create a file only if it does not already exist, and handle `ErrorKind::AlreadyExists` errors gracefully.
+
+## 2024-05-24 - [Secure File Permissions for Daemon Config Broadcast]
+**Vulnerability:** The daemon's `persist_broadcast_config_to_disk` function in `crates/pim-daemon/src/rpc.rs` used `std::fs::write` to write the updated broadcast configuration to a temporary file before renaming it. This relies on the system's default `umask` and can leave the configuration file world-readable.
+**Learning:** Relying on default file permissions when writing runtime configuration can expose sensitive node information to other local users.
+**Prevention:** Explicitly use `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o600)` on Unix systems to ensure strict file access permissions when saving configuration files.

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1530,7 +1530,8 @@ async fn persist_broadcast_config_to_disk(state: &Arc<DaemonState>) -> anyhow::R
             options.mode(0o600);
         }
 
-        let mut file = options.open(&tmp)
+        let mut file = options
+            .open(&tmp)
             .with_context(|| format!("open tmp {}", tmp.display()))?;
         use std::io::Write;
         file.write_all(serialized.as_bytes())

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1521,8 +1521,23 @@ async fn persist_broadcast_config_to_disk(state: &Arc<DaemonState>) -> anyhow::R
             .parent()
             .ok_or_else(|| anyhow!("config path has no parent"))?;
         let tmp = tempfile_in_same_dir(parent, &path_for_task)?;
-        std::fs::write(&tmp, serialized.as_bytes())
+
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        let mut file = options.open(&tmp)
+            .with_context(|| format!("open tmp {}", tmp.display()))?;
+        use std::io::Write;
+        file.write_all(serialized.as_bytes())
             .with_context(|| format!("write tmp {}", tmp.display()))?;
+        file.sync_all()
+            .with_context(|| format!("sync tmp {}", tmp.display()))?;
+
         std::fs::rename(&tmp, &path_for_task)
             .with_context(|| format!("rename {} -> {}", tmp.display(), path_for_task.display()))?;
         Ok(())


### PR DESCRIPTION
### 🚨 Severity: MEDIUM

### 💡 Vulnerability
The `persist_broadcast_config_to_disk` function in `crates/pim-daemon/src/rpc.rs` used `std::fs::write` to save the updated node configuration to a temporary file before renaming it over the active configuration. `std::fs::write` relies on the system's default `umask`. Under a permissive environment, this can result in the configuration file being world-readable, potentially exposing sensitive node metadata or setup details to other local users.

### 🎯 Impact
If a node runs on a multi-tenant system with a permissive default umask, other unprivileged users could read the `pim.toml` configuration file. While `pim.toml` doesn't typically house the private identity key (usually stored in `node.key`), it does contain internal network topology details, bound ports, static peers, and other sensitive operational configuration.

### 🔧 Fix
Replaced the `std::fs::write` call with a manual file write sequence using `std::fs::OpenOptions`. On Unix systems, this explicitly applies `.mode(0o600)` to ensure the temporary file is created with strict `rw-------` permissions. The fix also incorporates a `sync_all()` call before the atomic rename to prevent zero-length files in the event of an unexpected termination mid-write.

### ✅ Verification
1. Run `cargo test --workspace` and `cargo clippy --workspace -- -D warnings`. All tests should pass.
2. Observe the creation of the temporary file or the final configuration file on a Unix system; its permissions should be strictly `-rw-------`.

---
*PR created automatically by Jules for task [1147029987906106783](https://jules.google.com/task/1147029987906106783) started by @Rfluid*