### PR TITLE
🛡️ Sentinel: [security improvement] Secure temporary file permissions during config persistence

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,8 @@
 **Vulnerability:** The daemon's config generation (`pim-cli/src/main.rs`) and identity key generation (`pim-crypto/src/identity.rs`) checked `path.exists()` before calling `create(true).truncate(true)`. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition where an attacker could replace the file with a symlink between the check and the use, potentially leading to arbitrary file overwrites or key theft.
 **Learning:** Checking for file existence before creating a sensitive file is inherently racy and insecure.
 **Prevention:** Always rely on the filesystem to enforce exclusivity. Use `OpenOptions::new().create_new(true)` to atomically create a file only if it does not already exist, and handle `ErrorKind::AlreadyExists` errors gracefully.
+
+## 2024-05-06 - [Secure File Permissions for Temporary Files]
+**Vulnerability:** The daemon's config persistence fallback used `std::fs::write` to create a temporary file before renaming it into place. `std::fs::write` uses the default umask, meaning the temporary file could be created world-readable, and those insecure permissions are preserved when renamed over the actual config file.
+**Learning:** Atomic rename operations carry the permissions of the source temporary file to the destination. Writing to a temporary file insecurely makes the final file insecure, regardless of the destination's original permissions.
+**Prevention:** When performing atomic file writes using a temporary file and `rename` for sensitive configurations, explicitly set strict permissions (e.g., `0o600` on Unix) on the temporary file using `OpenOptions`.

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1521,8 +1521,25 @@ async fn persist_broadcast_config_to_disk(state: &Arc<DaemonState>) -> anyhow::R
             .parent()
             .ok_or_else(|| anyhow!("config path has no parent"))?;
         let tmp = tempfile_in_same_dir(parent, &path_for_task)?;
-        std::fs::write(&tmp, serialized.as_bytes())
-            .with_context(|| format!("write tmp {}", tmp.display()))?;
+
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        {
+            use std::io::Write;
+            let mut file = options.open(&tmp)
+                .with_context(|| format!("open tmp {}", tmp.display()))?;
+            file.write_all(serialized.as_bytes())
+                .with_context(|| format!("write tmp {}", tmp.display()))?;
+            file.flush()
+                .with_context(|| format!("flush tmp {}", tmp.display()))?;
+        }
+
         std::fs::rename(&tmp, &path_for_task)
             .with_context(|| format!("rename {} -> {}", tmp.display(), path_for_task.display()))?;
         Ok(())

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1532,7 +1532,8 @@ async fn persist_broadcast_config_to_disk(state: &Arc<DaemonState>) -> anyhow::R
 
         {
             use std::io::Write;
-            let mut file = options.open(&tmp)
+            let mut file = options
+                .open(&tmp)
                 .with_context(|| format!("open tmp {}", tmp.display()))?;
             file.write_all(serialized.as_bytes())
                 .with_context(|| format!("write tmp {}", tmp.display()))?;


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The daemon's config persistence fallback used `std::fs::write` to create a temporary file before atomically renaming it over the active configuration file. `std::fs::write` relies on the system's default `umask`, which could result in the temporary file being created world-readable. Because `std::fs::rename` preserves the permissions of the source file, the final configuration file would inherit these insecure permissions, potentially exposing sensitive config data to local unprivileged users.
🎯 **Impact**: Local users could read sensitive configuration values.
🔧 **Fix**: Replaced `std::fs::write` with an explicit `std::fs::OpenOptions` configuration to ensure the temporary file is created with strict `0o600` permissions on Unix platforms. 
✅ **Verification**: Verified using `cargo test --workspace` and `cargo clippy --workspace -- -D warnings`.

---
*PR created automatically by Jules for task [7475132863421761548](https://jules.google.com/task/7475132863421761548) started by @Rfluid*