### PR TITLE
⚡ Bolt: Pre-allocate Vector capacities in hot paths

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -44,3 +44,8 @@
 ## 2026-05-09 - Zero-copy packet fragmentation
 **Learning:** `fragment_packet` previously took a `&[u8]` slice and forced memory allocation for every fragmented packet via `Bytes::copy_from_slice()`. For large packets traversing the mesh, this creates massive memory pressure due to repeated allocation at every network boundary. Passing the original `Bytes` buffer lets us utilize `.slice(offset..end)` to create cheap references.
 **Action:** When designing API boundaries for networking, protocol layers, and fragmentation, pass payloads as `bytes::Bytes` by value instead of `&[u8]`. This preserves the ability to perform O(1) zero-copy slicing (`payload.slice()`) downstream and avoids unnecessary O(N) memory reallocations like `Bytes::copy_from_slice()`.
+
+## 2026-05-09 - Pre-allocate Vector capacities in hot paths when populating collections
+
+**Learning:** `Vec::new()` allocates no heap memory until the first element is pushed, at which point it dynamically allocates and then periodically reallocates. In hot network paths like `fragment_packet`, where we know we will push items, this leads to unnecessary reallocation overhead. However, it is a mistake to aggressively apply `Vec::with_capacity()` to collections that often remain empty (e.g., error queues or retry buffers on the "happy path"), as this will force an unnecessary heap allocation where `Vec::new()` would have remained zero-cost.
+**Action:** Always pre-allocate exact `Vec` capacities (e.g., using `Vec::with_capacity()`) over `Vec::new()` when the final size or an upper bound is known in advance *and* the vector is guaranteed or highly likely to be populated. Avoid `Vec::with_capacity()` for paths that usually remain empty.

--- a/crates/pim-protocol/src/fragment_frame.rs
+++ b/crates/pim-protocol/src/fragment_frame.rs
@@ -85,7 +85,7 @@ pub fn fragment_packet(data: bytes::Bytes, fragment_id: u32) -> Vec<FragmentFram
     }
 
     let total_length = data.len() as u16;
-    let mut frames = Vec::new();
+    let mut frames = Vec::with_capacity(data.len().div_ceil(MAX_FRAGMENT_PAYLOAD));
     let mut offset = 0usize;
 
     while offset < data.len() {


### PR DESCRIPTION
💡 **What:** 
Replaced `Vec::new()` with `Vec::with_capacity(data.len().div_ceil(MAX_FRAGMENT_PAYLOAD))` in `crates/pim-protocol/src/fragment_frame.rs`.

🎯 **Why:** 
The fragmentation function splits data into a predictable number of frames. Using `Vec::new()` forces a dynamic memory allocation on the first push, and periodic reallocations thereafter as the `while` loop progresses. Pre-allocating exact capacity prevents this reallocation overhead in a hot network path.

📊 **Impact:** 
Reduces memory reallocations during packet fragmentation to exactly 1 (or 0 if empty), lowering latency per outbound multi-fragment packet.

🔬 **Measurement:** 
Run packet fragmentation tests. Benchmarks should show reduced variance and memory reallocations. Checked using workspace test commands and ensured no regressions in fragmentation unit tests.

---
*PR created automatically by Jules for task [13966501114325555384](https://jules.google.com/task/13966501114325555384) started by @Rfluid*