### PR TITLE
test(docker): add broadcast + pim-messaging plugin lanes; release-scr…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,12 +15,15 @@ COPY crates/pim-gateway/Cargo.toml    crates/pim-gateway/
 COPY crates/pim-routing/Cargo.toml    crates/pim-routing/
 COPY crates/pim-discovery/Cargo.toml  crates/pim-discovery/
 COPY crates/pim-wifidirect/Cargo.toml crates/pim-wifidirect/
+COPY crates/pim-plugin/Cargo.toml     crates/pim-plugin/
+COPY crates/pim-messaging/Cargo.toml  crates/pim-messaging/
 COPY crates/pim-daemon/Cargo.toml     crates/pim-daemon/
 COPY crates/pim-cli/Cargo.toml        crates/pim-cli/
 
 # Stub sources so `cargo fetch` and the dependency compile step can run.
 RUN for crate in pim-bluetooth pim-core pim-crypto pim-protocol pim-transport pim-tun \
-        pim-gateway pim-routing pim-discovery pim-wifidirect; do \
+        pim-gateway pim-routing pim-discovery pim-wifidirect \
+        pim-plugin pim-messaging; do \
         mkdir -p crates/$crate/src && \
         printf 'pub fn _stub() {}' > crates/$crate/src/lib.rs; \
     done && \
@@ -52,6 +55,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         netcat-openbsd \
         ca-certificates \
         procps \
+        jq \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /build/target/release/pim-daemon /usr/local/bin/pim-daemon

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,8 @@ docker-build:
 .PHONY: test-single-hop test-single-hop-ipv6 test-multi-hop test-peer-discovery \
         test-resilience test-resilience-full test-multi-gateway test-auto-discovery \
         test-auto-ip-chain test-auth test-debug-cli test-route-cli \
-        test-bluetooth test-bluetooth-enx test-rfcomm-discovery test-all
+        test-bluetooth test-bluetooth-enx test-rfcomm-discovery \
+        test-broadcast test-messaging test-all
 
 test-single-hop: docker-build         ## phase 1: TUN, NAT, gateway/client baseline
 	bash $(TEST_DIR)/test-single-hop.sh
@@ -63,6 +64,12 @@ test-bluetooth-enx: docker-build
 test-rfcomm-discovery: docker-build  ## RFCOMM listener + outbound dial-failure resilience
 	bash $(TEST_DIR)/test-rfcomm-discovery.sh
 
+test-broadcast: docker-build         ## identity broadcast across a multi-hop chain
+	bash $(TEST_DIR)/test-broadcast.sh
+
+test-messaging: docker-build         ## end-to-end messaging plugin (direct + routed)
+	bash $(TEST_DIR)/test-messaging.sh
+
 test-all: docker-build
 	@bash $(TEST_DIR)/test-single-hop.sh && \
 	 bash $(TEST_DIR)/test-ipv6.sh && \
@@ -73,14 +80,17 @@ test-all: docker-build
 	 bash $(TEST_DIR)/test-authorization.sh && \
 	 bash $(TEST_DIR)/test-route-cli.sh && \
 	 bash $(TEST_DIR)/test-bluetooth.sh && \
-	 bash $(TEST_DIR)/test-bluetooth-enx.sh
+	 bash $(TEST_DIR)/test-bluetooth-enx.sh && \
+	 bash $(TEST_DIR)/test-broadcast.sh && \
+	 bash $(TEST_DIR)/test-messaging.sh
 
 # ── Manual stack management ───────────────────────────────────────────────────
 # Use these for interactive debugging without the test scripts.
 
 .PHONY: up-single-hop up-single-hop-ipv6 up-multi-hop-relay up-multi-hop-routing \
         up-peer-discovery up-resilience up-flow-control up-multi-gateway \
-        up-auto-discovery up-auto-ip-chain up-bluetooth up-bluetooth-enx
+        up-auto-discovery up-auto-ip-chain up-bluetooth up-bluetooth-enx \
+        up-mesh-broadcast
 
 up-single-hop:
 	docker compose -f $(COMPOSE_DIR)/single-hop.yml up -d --build
@@ -118,9 +128,13 @@ up-bluetooth:
 up-bluetooth-enx:
 	docker compose -f $(COMPOSE_DIR)/bluetooth-seam-enx.yml up -d --build
 
+up-mesh-broadcast:
+	docker compose -f $(COMPOSE_DIR)/mesh-broadcast.yml up -d --build
+
 .PHONY: down-single-hop down-single-hop-ipv6 down-multi-hop-relay down-multi-hop-routing \
         down-peer-discovery down-resilience down-flow-control down-multi-gateway \
-        down-auto-discovery down-auto-ip-chain down-bluetooth down-bluetooth-enx
+        down-auto-discovery down-auto-ip-chain down-bluetooth down-bluetooth-enx \
+        down-mesh-broadcast
 
 down-single-hop:
 	docker compose -f $(COMPOSE_DIR)/single-hop.yml down -v --remove-orphans
@@ -158,11 +172,14 @@ down-bluetooth:
 down-bluetooth-enx:
 	docker compose -f $(COMPOSE_DIR)/bluetooth-seam-enx.yml down -v --remove-orphans
 
+down-mesh-broadcast:
+	docker compose -f $(COMPOSE_DIR)/mesh-broadcast.yml down -v --remove-orphans
+
 # ── Log tailing ───────────────────────────────────────────────────────────────
 
 .PHONY: logs-single-hop logs-single-hop-ipv6 logs-multi-hop-relay logs-multi-hop-routing \
         logs-peer-discovery logs-resilience logs-multi-gateway logs-auto-discovery \
-        logs-auto-ip-chain logs-bluetooth logs-bluetooth-enx
+        logs-auto-ip-chain logs-bluetooth logs-bluetooth-enx logs-mesh-broadcast
 
 logs-single-hop:
 	docker compose -f $(COMPOSE_DIR)/single-hop.yml logs -f
@@ -196,6 +213,9 @@ logs-bluetooth:
 
 logs-bluetooth-enx:
 	docker compose -f $(COMPOSE_DIR)/bluetooth-seam-enx.yml logs -f
+
+logs-mesh-broadcast:
+	docker compose -f $(COMPOSE_DIR)/mesh-broadcast.yml logs -f
 
 # ── Shortcuts for exec ────────────────────────────────────────────────────────
 
@@ -237,7 +257,8 @@ docker-clean:
 	    $(COMPOSE_DIR)/auth-tofu.yml \
 	    $(COMPOSE_DIR)/auth-discovery-key.yml \
 	    $(COMPOSE_DIR)/bluetooth-seam.yml \
-	    $(COMPOSE_DIR)/bluetooth-seam-enx.yml; do \
+	    $(COMPOSE_DIR)/bluetooth-seam-enx.yml \
+	    $(COMPOSE_DIR)/mesh-broadcast.yml; do \
 	    docker compose -f $$f down -v --remove-orphans 2>/dev/null || true; \
 	done
 
@@ -271,6 +292,8 @@ help:
 	@echo "  make test-bluetooth         Bluetooth fake-sysfs seam test in Docker"
 	@echo "  make test-bluetooth-enx     Bluetooth dynamic enx PAN fallback seam test in Docker"
 	@echo "  make test-rfcomm-discovery  RFCOMM listener + outbound dial-failure seam"
+	@echo "  make test-broadcast         Identity broadcast across a 4-node chain"
+	@echo "  make test-messaging         End-to-end messaging plugin (direct + 3-hop)"
 	@echo "  make test-all               All labs (slow tests skipped)"
 	@echo "  make test-unit              Rust unit tests (no Docker)"
 	@echo ""

--- a/docker/compose/mesh-broadcast.yml
+++ b/docker/compose/mesh-broadcast.yml
@@ -1,0 +1,134 @@
+# Plugin/messaging mesh — exercises identity broadcast and the
+# user-to-user messaging plugin across direct + multi-hop paths.
+#
+# Topology:
+#
+#   node-a ──[TCP]── node-b ──[TCP]── node-c ──[TCP]── node-d
+#   .101              .102              .103              .104
+#
+# - node-a and node-b are direct neighbours.
+# - node-a and node-c are two hops apart (via node-b).
+# - node-a and node-d are three hops apart.
+# - LAN UDP discovery is disabled, so peers learn each other's identity
+#   only through routed PeerInfo broadcasts (the daemon's
+#   `messaging.broadcast` cycle) — which is exactly what we want to
+#   exercise.
+#
+# Used by:
+#   docker/tests/test-broadcast.sh   — broadcast → routing-table → peer-directory
+#   docker/tests/test-messaging.sh   — messages.send through direct + routed paths
+
+name: pim-mesh-broadcast
+
+x-pim-base: &pim-base
+    build:
+        context: ../..
+        dockerfile: Dockerfile
+    image: pim:latest
+    cap_add:
+        - NET_ADMIN
+    devices:
+        - /dev/net/tun:/dev/net/tun
+
+services:
+    # Brought up first — D has no statically configured peers (C dials it).
+    node-d:
+        <<: *pim-base
+        container_name: pim-mesh-broadcast-d
+        hostname: node-d
+        volumes:
+            - ../configs/mesh-node-d.toml:/etc/pim/pim.toml:ro
+        networks:
+            pim-net:
+                ipv4_address: 172.40.0.14
+        healthcheck:
+            test:
+                [
+                    "CMD-SHELL",
+                    "test -f /run/pim.pid && kill -0 $(cat /run/pim.pid) 2>/dev/null && ip link show pim0 2>/dev/null | grep -q UP",
+                ]
+            interval: 2s
+            timeout: 4s
+            retries: 25
+            start_period: 5s
+
+    # C dials D at startup. resolve_configured_peer_targets resolves
+    # `node-d:9100` synchronously; bring D up first so the lookup never
+    # hits the brief window where Docker's embedded DNS hasn't published
+    # the record yet (which crashes the daemon at boot).
+    node-c:
+        <<: *pim-base
+        container_name: pim-mesh-broadcast-c
+        hostname: node-c
+        volumes:
+            - ../configs/mesh-node-c.toml:/etc/pim/pim.toml:ro
+        depends_on:
+            node-d:
+                condition: service_healthy
+        networks:
+            pim-net:
+                ipv4_address: 172.40.0.13
+        healthcheck:
+            test:
+                [
+                    "CMD-SHELL",
+                    "test -f /run/pim.pid && kill -0 $(cat /run/pim.pid) 2>/dev/null && ip link show pim0 2>/dev/null | grep -q UP",
+                ]
+            interval: 2s
+            timeout: 4s
+            retries: 25
+            start_period: 8s
+
+    node-b:
+        <<: *pim-base
+        container_name: pim-mesh-broadcast-b
+        hostname: node-b
+        volumes:
+            - ../configs/mesh-node-b.toml:/etc/pim/pim.toml:ro
+        depends_on:
+            node-c:
+                condition: service_healthy
+        networks:
+            pim-net:
+                ipv4_address: 172.40.0.12
+        healthcheck:
+            test:
+                [
+                    "CMD-SHELL",
+                    "test -f /run/pim.pid && kill -0 $(cat /run/pim.pid) 2>/dev/null && ip link show pim0 2>/dev/null | grep -q UP",
+                ]
+            interval: 2s
+            timeout: 4s
+            retries: 25
+            start_period: 10s
+
+    node-a:
+        <<: *pim-base
+        container_name: pim-mesh-broadcast-a
+        hostname: node-a
+        volumes:
+            - ../configs/mesh-node-a.toml:/etc/pim/pim.toml:ro
+        depends_on:
+            node-b:
+                condition: service_healthy
+        networks:
+            pim-net:
+                ipv4_address: 172.40.0.11
+        healthcheck:
+            test:
+                [
+                    "CMD-SHELL",
+                    "test -f /run/pim.pid && kill -0 $(cat /run/pim.pid) 2>/dev/null && ip link show pim0 2>/dev/null | grep -q UP",
+                ]
+            interval: 2s
+            timeout: 4s
+            retries: 25
+            start_period: 12s
+
+networks:
+    pim-net:
+        driver: bridge
+        ipam:
+            driver: default
+            config:
+                - subnet: 172.40.0.0/24

--- a/docker/configs/mesh-node-a.toml
+++ b/docker/configs/mesh-node-a.toml
@@ -1,0 +1,40 @@
+# Mesh chain — node A (left edge).
+#
+# Topology:  A ── B ── C ── D
+#
+# A connects only to B. To reach C and D, A relies on multi-hop routing.
+# Used by docker/tests/test-broadcast.sh and test-messaging.sh.
+
+[node]
+name = "node-a"
+data_dir = "/var/lib/pim"
+
+[interface]
+mesh_ip = "10.77.0.101/24"
+mtu = 1400
+
+[transport]
+listen_port = 9100
+
+[security]
+key_file = "/var/lib/pim/node.key"
+
+# Disable LAN UDP discovery — the chain is held together by static peers
+# only, so we exercise multi-hop routed PeerInfo broadcast rather than
+# direct UDP discovery.
+[discovery]
+enabled = false
+
+# Periodic identity broadcast every 30 s (the floor enforced at the RPC
+# layer). Tests poke `peers.broadcast_identity_now` for deterministic
+# verification, but we leave the periodic task on so future regressions
+# in scheduled broadcasts also surface.
+[messaging.broadcast]
+outgoing_interval_s = 30
+watch_incoming = true
+min_peer_interval_s = 1
+
+[[peers]]
+mechanism = "tcp"
+address = "node-b:9100"
+label = "node-b"

--- a/docker/configs/mesh-node-b.toml
+++ b/docker/configs/mesh-node-b.toml
@@ -1,0 +1,33 @@
+# Mesh chain — node B (interior, between A and C).
+#
+# Topology:  A ── B ── C ── D
+#
+# B has a static link to A and C. From A's perspective B is a direct
+# neighbour; D is two hops away (A → B → C → D).
+
+[node]
+name = "node-b"
+data_dir = "/var/lib/pim"
+
+[interface]
+mesh_ip = "10.77.0.102/24"
+mtu = 1400
+
+[transport]
+listen_port = 9100
+
+[security]
+key_file = "/var/lib/pim/node.key"
+
+[discovery]
+enabled = false
+
+[messaging.broadcast]
+outgoing_interval_s = 30
+watch_incoming = true
+min_peer_interval_s = 1
+
+[[peers]]
+mechanism = "tcp"
+address = "node-c:9100"
+label = "node-c"

--- a/docker/configs/mesh-node-c.toml
+++ b/docker/configs/mesh-node-c.toml
@@ -1,0 +1,30 @@
+# Mesh chain — node C (interior, between B and D).
+#
+# Topology:  A ── B ── C ── D
+
+[node]
+name = "node-c"
+data_dir = "/var/lib/pim"
+
+[interface]
+mesh_ip = "10.77.0.103/24"
+mtu = 1400
+
+[transport]
+listen_port = 9100
+
+[security]
+key_file = "/var/lib/pim/node.key"
+
+[discovery]
+enabled = false
+
+[messaging.broadcast]
+outgoing_interval_s = 30
+watch_incoming = true
+min_peer_interval_s = 1
+
+[[peers]]
+mechanism = "tcp"
+address = "node-d:9100"
+label = "node-d"

--- a/docker/configs/mesh-node-d.toml
+++ b/docker/configs/mesh-node-d.toml
@@ -1,0 +1,31 @@
+# Mesh chain — node D (right edge).
+#
+# Topology:  A ── B ── C ── D
+#
+# D only knows about C; it must learn A and B via routed PeerInfo
+# broadcasts and reach them via multi-hop routing.
+
+[node]
+name = "node-d"
+data_dir = "/var/lib/pim"
+
+[interface]
+mesh_ip = "10.77.0.104/24"
+mtu = 1400
+
+[transport]
+listen_port = 9100
+
+[security]
+key_file = "/var/lib/pim/node.key"
+
+[discovery]
+enabled = false
+
+[messaging.broadcast]
+outgoing_interval_s = 30
+watch_incoming = true
+min_peer_interval_s = 1
+
+# D is the right edge — it does not initiate any outgoing static peer
+# connection. C dials it.

--- a/docker/tests/common.sh
+++ b/docker/tests/common.sh
@@ -258,6 +258,133 @@ wait_for_peers() {
     return 1
 }
 
+# ── JSON-RPC over the daemon's Unix socket ────────────────────────────────────
+#
+# The daemon speaks newline-delimited JSON-RPC 2.0 on
+# `/run/pim/pim.sock`. `rpc.hello` must precede every other request on a
+# fresh connection (docs/RPC.md §1.4), so each helper call here opens a
+# new socket, replays the handshake, then issues a single request.
+#
+# Tools used inside the container: `nc -U` (netcat-openbsd, already
+# installed) and `jq` (added to the image alongside the other test
+# tools). The runtime image bundles both so test scripts only need to
+# `in_svc` into the daemon container.
+#
+# Usage:
+#   resp=$(rpc <file> <svc> <method> [params_json])
+#   rpc_result <file> <svc> <method> [params_json]   # extracts .result
+#   rpc_error  <file> <svc> <method> [params_json]   # extracts .error.message
+
+# rpc <file> <svc> <method> [params_json]
+# Returns the JSON-RPC response to the request (the line whose `id`
+# matches our request id), or empty on transport failure.
+#
+# Implementation notes:
+#   * The handshake response (`id:0`) is discarded; we only care about
+#     the request response (`id:1`).
+#   * The daemon also fans out subscription notifications (`status.event`,
+#     `peers.event`, `logs.event`, `messages.event`) on every connection
+#     — those have no `id` field, so we match by id rather than by line
+#     number to skip them.
+#   * `nc -N -q 2 -w 8` shuts our write side down on stdin EOF, then
+#     waits up to 2 s for the daemon to drain its writer task before
+#     nc exits. The `-w 8` cap stops a wedged daemon from hanging the
+#     whole test.
+rpc() {
+    local file="$1" svc="$2" method="$3" params="${4:-}"
+    local hello='{"jsonrpc":"2.0","id":0,"method":"rpc.hello","params":{"client":"docker-test","rpc_version":1}}'
+    local req
+    if [ -n "$params" ]; then
+        req=$(printf '{"jsonrpc":"2.0","id":1,"method":"%s","params":%s}' "$method" "$params")
+    else
+        req=$(printf '{"jsonrpc":"2.0","id":1,"method":"%s"}' "$method")
+    fi
+    {
+        printf '%s\n%s\n' "$hello" "$req"
+    } | docker compose -f "$COMPOSE_DIR/$file" exec -T "$svc" \
+        nc -N -q 2 -U -w 8 /run/pim/pim.sock \
+        | jq -ec --argjson want_id 1 'select(.id == $want_id)' \
+        | head -n1
+}
+
+# rpc_result <file> <svc> <method> [params_json]
+# Prints the `.result` of the JSON-RPC response. Empty if the call
+# returned an error or if the daemon dropped the connection.
+rpc_result() {
+    local resp
+    resp=$(rpc "$@") || return 1
+    [ -n "$resp" ] || return 1
+    echo "$resp" | jq -ec '.result // empty'
+}
+
+# rpc_error <file> <svc> <method> [params_json]
+# Prints the `.error.message` of the JSON-RPC response (empty when the
+# call succeeded).
+rpc_error() {
+    local resp
+    resp=$(rpc "$@") || return 1
+    [ -n "$resp" ] || return 1
+    echo "$resp" | jq -er '.error.message // empty' 2>/dev/null
+}
+
+# rpc_node_id <file> <svc>
+# Returns the 32-char hex `node_id` reported by `status`.
+rpc_node_id() {
+    local file="$1" svc="$2"
+    rpc_result "$file" "$svc" status | jq -er '.node_id'
+}
+
+# wait_routes <file> <svc> <min_routes> [max_seconds]
+# Block until `pim status --verbose` reports at least `min_routes`
+# entries. Routes propagate through distance-vector advertisements
+# (5 s cadence) plus convergence; multi-hop topologies typically
+# need 2–3 cycles to settle.
+wait_routes() {
+    local file="$1" svc="$2" min="$3" max="${4:-60}"
+    local elapsed=0
+    log_info "Waiting for $svc routing table to reach $min entr(y|ies) (up to ${max}s)..."
+    while [ $elapsed -lt $max ]; do
+        local count
+        count=$(in_svc "$file" "$svc" sh -c "cat /run/pim.stats 2>/dev/null" \
+            | awk -F= '/^routes=/ {print $2; exit}')
+        count="${count:-0}"
+        if [ "${count:-0}" -ge "$min" ]; then
+            log_info "$svc has $count route(s) installed"
+            return 0
+        fi
+        sleep 2
+        elapsed=$((elapsed+2))
+    done
+    log_fail "$svc did not reach $min route(s) within ${max}s"
+    in_svc "$file" "$svc" sh -c "cat /run/pim.stats 2>/dev/null || true" || true
+    return 1
+}
+
+# wait_peer_directory <file> <svc> <expected_peer_node_id> [max_seconds]
+# Block until the daemon's `peers.list` (which enumerates *direct*
+# sessions) contains `expected_peer_node_id`. Note: routed PeerInfo
+# arrivals from a multi-hop peer don't surface here, since they
+# populate the keystore but not `state.sessions`. For multi-hop
+# verification, probe with `messages.send` instead — see
+# `docker/tests/test-broadcast.sh`.
+wait_peer_directory() {
+    local file="$1" svc="$2" target="$3" max="${4:-60}"
+    local elapsed=0
+    log_info "Waiting for $svc peer directory to contain ${target:0:8}... (up to ${max}s)"
+    while [ $elapsed -lt $max ]; do
+        local resp
+        resp=$(rpc_result "$file" "$svc" peers.list 2>/dev/null || true)
+        if [ -n "$resp" ] && echo "$resp" | jq -e --arg id "$target" \
+            '.[] | select(.node_id == $id)' >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 2
+        elapsed=$((elapsed+2))
+    done
+    log_fail "$svc peer directory missing ${target:0:8}... after ${max}s"
+    return 1
+}
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 print_summary() {

--- a/docker/tests/test-broadcast.sh
+++ b/docker/tests/test-broadcast.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# test-broadcast.sh — Daemon identity-broadcast across a multi-hop mesh.
+#
+# Topology (see docker/compose/mesh-broadcast.yml):
+#
+#   node-a ── node-b ── node-c ── node-d
+#
+# What this exercises:
+#   1. Routing convergence: every node ends up with N-1 destinations in
+#      its routing table (here N = 4).
+#   2. Direct PeerInfo (over the Noise session): each node's directly
+#      connected neighbour shows up in `peers.list` with an X25519 key.
+#   3. Routed PeerInfo (the broadcast cycle): non-adjacent peers learn
+#      each other's identities through `peers.broadcast_identity_now`,
+#      not through direct sessions. Verified by sending a `messages.send`
+#      to a 3-hop peer — it would fail with `MESSAGE_PEER_UNKNOWN` if the
+#      X25519 key never reached the keystore.
+#   4. `peers.get_broadcast_state` reflects the most recent cycle:
+#      `last_recipient_count` matches the number of routed destinations.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+COMPOSE_FILE="mesh-broadcast.yml"
+
+cleanup() {
+    if [ "${DUMP_LOGS_ON_FAIL:-0}" = "1" ] && [ "$FAIL" -gt 0 ]; then
+        dump_logs "$COMPOSE_FILE"
+    fi
+    stop_stack "$COMPOSE_FILE"
+}
+trap cleanup EXIT
+
+log_section "Broadcast — multi-hop chain (4 containers)"
+log_info "Compose file: $COMPOSE_FILE"
+
+start_stack "$COMPOSE_FILE"
+wait_all_healthy "$COMPOSE_FILE" 180
+
+# ── 0. Collect node ids ──────────────────────────────────────────────────────
+log_section "0. Collect each node's NodeId"
+
+NODE_A_ID=$(rpc_node_id "$COMPOSE_FILE" node-a)
+NODE_B_ID=$(rpc_node_id "$COMPOSE_FILE" node-b)
+NODE_C_ID=$(rpc_node_id "$COMPOSE_FILE" node-c)
+NODE_D_ID=$(rpc_node_id "$COMPOSE_FILE" node-d)
+
+if [ -z "$NODE_A_ID" ] || [ -z "$NODE_B_ID" ] || [ -z "$NODE_C_ID" ] || [ -z "$NODE_D_ID" ]; then
+    log_fail "couldn't read all four NodeIds via rpc.status"
+    exit 1
+fi
+log_info "node-a id: ${NODE_A_ID:0:8}..."
+log_info "node-b id: ${NODE_B_ID:0:8}..."
+log_info "node-c id: ${NODE_C_ID:0:8}..."
+log_info "node-d id: ${NODE_D_ID:0:8}..."
+
+# ── 1. Routing convergence ───────────────────────────────────────────────────
+log_section "1. Routing convergence"
+
+# 4-node chain → each node should reach 3 others (RouteUpdate cadence is
+# 5 s; allow up to 3 cycles + headroom).
+wait_routes "$COMPOSE_FILE" node-a 3 90
+wait_routes "$COMPOSE_FILE" node-b 3 90
+wait_routes "$COMPOSE_FILE" node-c 3 90
+wait_routes "$COMPOSE_FILE" node-d 3 90
+
+# ── 2. Direct PeerInfo (Noise-session-bound) ─────────────────────────────────
+log_section "2. Direct PeerInfo seeds the keystore for adjacent peers"
+
+# After the Noise handshake, each side emits a PeerInfo to the other, so
+# `peers.list` (which only enumerates *direct sessions*) carries the
+# remote x25519_pubkey straight away.
+DIRECT_KEY=$(rpc_result "$COMPOSE_FILE" node-a peers.list \
+    | jq -er --arg id "$NODE_B_ID" '.[] | select(.node_id == $id) | .x25519_pubkey // empty')
+if [ -n "$DIRECT_KEY" ] && [ "$DIRECT_KEY" != "null" ]; then
+    log_ok "node-a sees node-b's x25519 pubkey from the direct PeerInfo"
+else
+    log_fail "node-a missing node-b's x25519 pubkey from peers.list (got: ${DIRECT_KEY:-<empty>})"
+fi
+
+# Mirror check from node-d's side.
+DIRECT_KEY_D=$(rpc_result "$COMPOSE_FILE" node-d peers.list \
+    | jq -er --arg id "$NODE_C_ID" '.[] | select(.node_id == $id) | .x25519_pubkey // empty')
+if [ -n "$DIRECT_KEY_D" ] && [ "$DIRECT_KEY_D" != "null" ]; then
+    log_ok "node-d sees node-c's x25519 pubkey from the direct PeerInfo"
+else
+    log_fail "node-d missing node-c's x25519 pubkey from peers.list (got: ${DIRECT_KEY_D:-<empty>})"
+fi
+
+# ── 3. Routed PeerInfo (via the broadcast cycle) ─────────────────────────────
+log_section "3. Routed broadcast → multi-hop peers learn each other"
+
+# Trigger one explicit broadcast on each node so the test does not have
+# to wait for the periodic 30 s tick.
+log_info "triggering peers.broadcast_identity_now on every node"
+rpc_result "$COMPOSE_FILE" node-a peers.broadcast_identity_now >/dev/null
+rpc_result "$COMPOSE_FILE" node-b peers.broadcast_identity_now >/dev/null
+rpc_result "$COMPOSE_FILE" node-c peers.broadcast_identity_now >/dev/null
+rpc_result "$COMPOSE_FILE" node-d peers.broadcast_identity_now >/dev/null
+
+# Allow 3 s for the routed PluginPayload-less PeerInfo frames to propagate
+# through the chain (3 hops → ~3 RTT on a local Docker network).
+sleep 3
+
+# ── 3a. peers.get_broadcast_state reports the cycle outcome ──────────────────
+BC_STATE_A=$(rpc_result "$COMPOSE_FILE" node-a peers.get_broadcast_state)
+LAST_RECIPIENTS_A=$(echo "$BC_STATE_A" | jq -r '.last_recipient_count // 0')
+if [ "${LAST_RECIPIENTS_A:-0}" = "3" ]; then
+    log_ok "node-a's last broadcast reached 3 routed peers"
+else
+    log_fail "node-a last_recipient_count=${LAST_RECIPIENTS_A:-?} (expected 3)"
+    echo "$BC_STATE_A" | jq . 2>/dev/null || echo "$BC_STATE_A"
+fi
+
+BC_STATE_D=$(rpc_result "$COMPOSE_FILE" node-d peers.get_broadcast_state)
+LAST_RECIPIENTS_D=$(echo "$BC_STATE_D" | jq -r '.last_recipient_count // 0')
+if [ "${LAST_RECIPIENTS_D:-0}" = "3" ]; then
+    log_ok "node-d's last broadcast reached 3 routed peers"
+else
+    log_fail "node-d last_recipient_count=${LAST_RECIPIENTS_D:-?} (expected 3)"
+fi
+
+# ── 3b. Probe the keystore via messages.send to a 3-hop peer ─────────────────
+#
+# `peers.list` only enumerates direct sessions, so it cannot prove that
+# node-a learned node-d's x25519 from a routed PeerInfo. Instead we use
+# the messaging plugin: `messages.send` requires the recipient's X25519
+# key to be cached locally and a route to exist. If the broadcast cycle
+# never delivered node-d's PeerInfo to node-a, this fails with
+# MESSAGE_PEER_UNKNOWN (-32060).
+PROBE_PARAMS=$(printf '{"peer_node_id":"%s","body":"broadcast-probe"}' "$NODE_D_ID")
+PROBE_ERR=$(rpc_error "$COMPOSE_FILE" node-a messages.send "$PROBE_PARAMS" || true)
+if [ -z "$PROBE_ERR" ]; then
+    log_ok "node-a → node-d (3 hops) messages.send succeeds — keystore was seeded by routed broadcast"
+else
+    log_fail "node-a → node-d messages.send failed: $PROBE_ERR"
+fi
+
+# Probe in the opposite direction too — broadcasts are symmetric.
+PROBE_PARAMS_DA=$(printf '{"peer_node_id":"%s","body":"broadcast-probe"}' "$NODE_A_ID")
+PROBE_ERR_DA=$(rpc_error "$COMPOSE_FILE" node-d messages.send "$PROBE_PARAMS_DA" || true)
+if [ -z "$PROBE_ERR_DA" ]; then
+    log_ok "node-d → node-a (3 hops) messages.send succeeds — keystore was seeded by routed broadcast"
+else
+    log_fail "node-d → node-a messages.send failed: $PROBE_ERR_DA"
+fi
+
+# ── 3c. Routed broadcast hits an interior 2-hop peer too ─────────────────────
+PROBE_PARAMS_AC=$(printf '{"peer_node_id":"%s","body":"broadcast-probe-2hop"}' "$NODE_C_ID")
+PROBE_ERR_AC=$(rpc_error "$COMPOSE_FILE" node-a messages.send "$PROBE_PARAMS_AC" || true)
+if [ -z "$PROBE_ERR_AC" ]; then
+    log_ok "node-a → node-c (2 hops) messages.send succeeds"
+else
+    log_fail "node-a → node-c messages.send failed: $PROBE_ERR_AC"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+print_summary

--- a/docker/tests/test-messaging.sh
+++ b/docker/tests/test-messaging.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# test-messaging.sh — End-to-end user-to-user messaging through direct
+# and routed paths.
+#
+# Topology (see docker/compose/mesh-broadcast.yml):
+#
+#   node-a ── node-b ── node-c ── node-d
+#
+# What this exercises:
+#   1. messages.send to a direct neighbour (node-a → node-b).
+#   2. messages.send across multi-hop routing (node-a → node-d, 3 hops).
+#   3. ECIES round-trip — the recipient's `messages.history` returns the
+#      decrypted plaintext we sent.
+#   4. Delivery acks — sender's outbound message status transitions
+#      `pending` → `sent` → `delivered` after the recipient processes
+#      the `messaging.ack` PluginPayload and the routed reply lands.
+#   5. messages.list_conversations attaches the peer-directory cached
+#      `name` and `x25519_pubkey` to each row.
+#   6. peers.forget triggers the messaging plugin's per-peer wipe via
+#      `DaemonPlugin::on_peer_forgotten`.
+#
+# Note: messaging RPC is only compiled into the daemon when the
+# `messaging` Cargo feature is enabled (default-on).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=common.sh
+source "$SCRIPT_DIR/common.sh"
+
+COMPOSE_FILE="mesh-broadcast.yml"
+
+cleanup() {
+    if [ "${DUMP_LOGS_ON_FAIL:-0}" = "1" ] && [ "$FAIL" -gt 0 ]; then
+        dump_logs "$COMPOSE_FILE"
+    fi
+    stop_stack "$COMPOSE_FILE"
+}
+trap cleanup EXIT
+
+# Polls messages.history on `recv_svc` until a row matching
+# `expected_body` shows up (or `max` seconds elapse). Returns the
+# message id on stdout when found.
+wait_for_received_message() {
+    local recv_svc="$1" peer_id_hex="$2" expected_body="$3" max="${4:-30}"
+    local elapsed=0
+    while [ $elapsed -lt $max ]; do
+        local resp
+        resp=$(rpc_result "$COMPOSE_FILE" "$recv_svc" messages.history \
+            "$(printf '{"peer_node_id":"%s","limit":50}' "$peer_id_hex")" \
+            2>/dev/null || true)
+        if [ -n "$resp" ]; then
+            local id
+            id=$(echo "$resp" | jq -er --arg body "$expected_body" \
+                '.messages[] | select(.body == $body and .direction == "received") | .id' \
+                2>/dev/null | head -n1)
+            if [ -n "$id" ]; then
+                echo "$id"
+                return 0
+            fi
+        fi
+        sleep 1
+        elapsed=$((elapsed+1))
+    done
+    return 1
+}
+
+# Polls messages.history on `send_svc` until the message with `msg_id`
+# transitions to `expected_status`.
+wait_for_status() {
+    local send_svc="$1" peer_id_hex="$2" msg_id="$3" expected_status="$4" max="${5:-15}"
+    local elapsed=0
+    while [ $elapsed -lt $max ]; do
+        local resp
+        resp=$(rpc_result "$COMPOSE_FILE" "$send_svc" messages.history \
+            "$(printf '{"peer_node_id":"%s","limit":50}' "$peer_id_hex")" \
+            2>/dev/null || true)
+        if [ -n "$resp" ]; then
+            local status
+            status=$(echo "$resp" | jq -er --arg id "$msg_id" \
+                '.messages[] | select(.id == $id) | .status' \
+                2>/dev/null | head -n1)
+            if [ "$status" = "$expected_status" ]; then
+                return 0
+            fi
+        fi
+        sleep 1
+        elapsed=$((elapsed+1))
+    done
+    return 1
+}
+
+log_section "Messaging — direct + multi-hop (4 containers)"
+log_info "Compose file: $COMPOSE_FILE"
+
+start_stack "$COMPOSE_FILE"
+wait_all_healthy "$COMPOSE_FILE" 180
+
+# ── Setup: collect ids and wait for routing + broadcast ──────────────────────
+log_section "0. Routing convergence + identity broadcast"
+
+NODE_A_ID=$(rpc_node_id "$COMPOSE_FILE" node-a)
+NODE_B_ID=$(rpc_node_id "$COMPOSE_FILE" node-b)
+NODE_D_ID=$(rpc_node_id "$COMPOSE_FILE" node-d)
+if [ -z "$NODE_A_ID" ] || [ -z "$NODE_B_ID" ] || [ -z "$NODE_D_ID" ]; then
+    log_fail "couldn't read NodeIds via rpc.status"
+    exit 1
+fi
+log_info "node-a id: ${NODE_A_ID:0:8}..."
+log_info "node-b id: ${NODE_B_ID:0:8}..."
+log_info "node-d id: ${NODE_D_ID:0:8}..."
+
+wait_routes "$COMPOSE_FILE" node-a 3 90
+wait_routes "$COMPOSE_FILE" node-d 3 90
+
+# Force one round of identity broadcasts so all nodes have x25519 keys
+# for everyone in the routing table — `messages.send` requires the
+# recipient's key to be cached locally.
+rpc_result "$COMPOSE_FILE" node-a peers.broadcast_identity_now >/dev/null
+rpc_result "$COMPOSE_FILE" node-b peers.broadcast_identity_now >/dev/null
+rpc_result "$COMPOSE_FILE" node-c peers.broadcast_identity_now >/dev/null
+rpc_result "$COMPOSE_FILE" node-d peers.broadcast_identity_now >/dev/null
+sleep 3
+
+# ── 1. Direct-neighbour messaging (node-a → node-b) ──────────────────────────
+log_section "1. messages.send to a direct neighbour"
+
+DIRECT_BODY="hello from a, $(date +%s)"
+SEND_PARAMS=$(printf '{"peer_node_id":"%s","body":%s}' "$NODE_B_ID" "$(printf '%s' "$DIRECT_BODY" | jq -Rs .)")
+SEND_RESULT=$(rpc_result "$COMPOSE_FILE" node-a messages.send "$SEND_PARAMS" || true)
+DIRECT_MSG_ID=$(echo "$SEND_RESULT" | jq -r '.id // empty')
+if [ -n "$DIRECT_MSG_ID" ] && [ "${#DIRECT_MSG_ID}" = "32" ]; then
+    log_ok "messages.send (a→b) returned id ${DIRECT_MSG_ID:0:8}..."
+else
+    log_fail "messages.send (a→b) returned no id (got: $SEND_RESULT)"
+fi
+
+# Recipient picks up the decrypted body.
+RECV_ID=$(wait_for_received_message node-b "$NODE_A_ID" "$DIRECT_BODY" 15 || true)
+if [ -n "$RECV_ID" ] && [ "$RECV_ID" = "$DIRECT_MSG_ID" ]; then
+    log_ok "node-b received the message with matching id and decrypted body"
+elif [ -n "$RECV_ID" ]; then
+    log_fail "node-b received a message but id mismatched (sent ${DIRECT_MSG_ID:0:8}, got ${RECV_ID:0:8})"
+else
+    log_fail "node-b never received '$DIRECT_BODY' from node-a within 15s"
+fi
+
+# Sender sees the delivery ack land.
+if wait_for_status node-a "$NODE_B_ID" "$DIRECT_MSG_ID" "delivered" 15; then
+    log_ok "node-a's outbound row transitions to 'delivered' after node-b acks"
+else
+    log_fail "node-a never observed delivery ack for ${DIRECT_MSG_ID:0:8}..."
+fi
+
+# ── 2. Multi-hop messaging (node-a → node-d, 3 hops) ─────────────────────────
+log_section "2. messages.send across 3 hops"
+
+ROUTED_BODY="multi-hop hi, $(date +%s)"
+SEND_PARAMS_AD=$(printf '{"peer_node_id":"%s","body":%s}' "$NODE_D_ID" "$(printf '%s' "$ROUTED_BODY" | jq -Rs .)")
+SEND_RESULT_AD=$(rpc_result "$COMPOSE_FILE" node-a messages.send "$SEND_PARAMS_AD" || true)
+ROUTED_MSG_ID=$(echo "$SEND_RESULT_AD" | jq -r '.id // empty')
+if [ -n "$ROUTED_MSG_ID" ] && [ "${#ROUTED_MSG_ID}" = "32" ]; then
+    log_ok "messages.send (a→d) returned id ${ROUTED_MSG_ID:0:8}..."
+else
+    log_fail "messages.send (a→d) returned no id (got: $SEND_RESULT_AD)"
+fi
+
+RECV_ID_D=$(wait_for_received_message node-d "$NODE_A_ID" "$ROUTED_BODY" 30 || true)
+if [ -n "$RECV_ID_D" ] && [ "$RECV_ID_D" = "$ROUTED_MSG_ID" ]; then
+    log_ok "node-d received the routed message with matching id"
+else
+    log_fail "node-d never received '$ROUTED_BODY' from node-a within 30s"
+fi
+
+if wait_for_status node-a "$NODE_D_ID" "$ROUTED_MSG_ID" "delivered" 20; then
+    log_ok "node-a sees the multi-hop ack land (status=delivered)"
+else
+    log_fail "node-a never saw delivery ack for the routed message"
+fi
+
+# ── 3. messages.list_conversations attaches the peer-directory data ──────────
+log_section "3. list_conversations enriches rows from the peer directory"
+
+CONV_RESP=$(rpc_result "$COMPOSE_FILE" node-a messages.list_conversations || true)
+CONV_FOR_D=$(echo "$CONV_RESP" | jq -er --arg id "$NODE_D_ID" \
+    '.conversations[] | select(.peer_node_id == $id)' 2>/dev/null || true)
+if [ -n "$CONV_FOR_D" ]; then
+    PUBKEY=$(echo "$CONV_FOR_D" | jq -r '.x25519_pubkey // empty')
+    NAME=$(echo "$CONV_FOR_D" | jq -r '.name // empty')
+    if [ -n "$PUBKEY" ] && [ "$PUBKEY" != "null" ] && [ "${#PUBKEY}" = "64" ]; then
+        log_ok "node-a's conversation with node-d carries a 64-char x25519_pubkey from the keystore"
+    else
+        log_fail "x25519_pubkey missing/invalid in conversation row (got: ${PUBKEY:-<empty>})"
+    fi
+    if [ "$NAME" = "node-d" ]; then
+        log_ok "conversation row uses peer name 'node-d' from the directory"
+    else
+        log_warn "conversation .name is '$NAME' (expected 'node-d' from PeerInfo)"
+    fi
+else
+    log_fail "node-a's conversations list missing entry for ${NODE_D_ID:0:8}"
+fi
+
+# ── 4. peers.forget propagates to the messaging plugin ───────────────────────
+log_section "4. peers.forget wipes the messaging plugin's per-peer state"
+
+FORGET_PARAMS=$(printf '{"node_id":"%s"}' "$NODE_B_ID")
+FORGET_RESULT=$(rpc_result "$COMPOSE_FILE" node-a peers.forget "$FORGET_PARAMS" || true)
+FORGOT=$(echo "$FORGET_RESULT" | jq -r '.forgot_identity // false')
+if [ "$FORGOT" = "true" ]; then
+    log_ok "peers.forget(node-b) acked forgot_identity=true"
+else
+    log_fail "peers.forget(node-b) did not report forgot_identity=true (got: $FORGET_RESULT)"
+fi
+
+# Give the daemon a moment to fan the on_peer_forgotten callback
+# through to the messaging plugin (it wipes the conversation in a
+# spawn_blocking).
+sleep 1
+
+# After forget, node-a's conversations list should no longer contain
+# node-b (the messaging plugin's storage row got dropped).
+CONV_AFTER=$(rpc_result "$COMPOSE_FILE" node-a messages.list_conversations || true)
+STILL_THERE=$(echo "$CONV_AFTER" | jq -er --arg id "$NODE_B_ID" \
+    '.conversations[] | select(.peer_node_id == $id) | .peer_node_id' 2>/dev/null || true)
+if [ -z "$STILL_THERE" ]; then
+    log_ok "node-a's conversation with node-b was wiped via on_peer_forgotten"
+else
+    log_fail "node-a still has a conversation with node-b after peers.forget"
+fi
+
+# ── 5. Reject empty body / unknown peer ──────────────────────────────────────
+log_section "5. messages.send guard rails"
+
+EMPTY_PARAMS=$(printf '{"peer_node_id":"%s","body":""}' "$NODE_D_ID")
+EMPTY_ERR=$(rpc_error "$COMPOSE_FILE" node-a messages.send "$EMPTY_PARAMS" || true)
+if echo "$EMPTY_ERR" | grep -qi "non-empty"; then
+    log_ok "empty body is rejected with INVALID_PARAMS"
+else
+    log_fail "empty body did not produce expected error (got: ${EMPTY_ERR:-<empty>})"
+fi
+
+UNKNOWN_PEER="ffffffffffffffffffffffffffffffff"
+UNKNOWN_PARAMS=$(printf '{"peer_node_id":"%s","body":"hi"}' "$UNKNOWN_PEER")
+UNKNOWN_ERR=$(rpc_error "$COMPOSE_FILE" node-a messages.send "$UNKNOWN_PARAMS" || true)
+if echo "$UNKNOWN_ERR" | grep -qi "no x25519"; then
+    log_ok "unknown peer is rejected with MESSAGE_PEER_UNKNOWN"
+else
+    log_fail "unknown peer did not produce expected error (got: ${UNKNOWN_ERR:-<empty>})"
+fi
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+print_summary

--- a/docs/operations/docker-labs.md
+++ b/docs/operations/docker-labs.md
@@ -47,12 +47,15 @@ docker/
     resilience.yml        — gateway + client (network disruption)
     flow-control.yml      — gateway + flood-sender
     multi-gateway.yml      — gateway1 + gateway2 + relay + client
+    mesh-broadcast.yml       — node-a → node-b → node-c → node-d chain
   tests/
     test-bluetooth.sh           — Bluetooth seam test runner
     test-bluetooth-enx.sh       — Bluetooth dynamic-enx seam test runner
     test-debug-cli.sh           — debug CLI output runner
     test-route-cli.sh           — split-default route CLI runner
-    common.sh                    — shared assertion and lifecycle helpers
+    test-broadcast.sh           — daemon broadcast across a multi-hop chain
+    test-messaging.sh           — pim-messaging plugin end-to-end (direct + routed)
+    common.sh                    — shared assertion + JSON-RPC helpers
     test-single-hop.sh               — phase 1 test runner
     test-multi-hop.sh               — phase 2 test runner
     test-peer-discovery.sh               — phase 3 test runner
@@ -114,6 +117,19 @@ The mesh uses `10.77.0.0/24` for TUN addresses.
   .100         .10
 ```
 
+### Mesh broadcast / messaging — 4-node chain
+
+```
+  node-a ──[TCP]── node-b ──[TCP]── node-c ──[TCP]── node-d
+  10.77.0.101      10.77.0.102      10.77.0.103      10.77.0.104
+```
+
+LAN UDP discovery is disabled. Each node only configures its left
+neighbour as a static peer. Non-adjacent peers learn each other's
+identity exclusively through routed `PeerInfo` broadcasts emitted by
+the daemon's `messaging.broadcast` cycle, which is precisely what the
+broadcast test validates.
+
 ## Quick Start
 
 ```bash
@@ -129,6 +145,8 @@ make test-multi-hop
 make test-debug-cli
 make test-route-cli
 make test-bluetooth
+make test-broadcast
+make test-messaging
 
 # Interactive: bring up a stack and poke around
 make up-single-hop
@@ -381,6 +399,27 @@ plan. Status: **[x] implemented** / **[ ] pending**.
 | 5.1  | Restore gateway1 → routing re-converges                | [x] test-multi-gateway.sh               |
 | 5.2  | Saturate gateway1 → new flows observed on gateway2     | [x] test-multi-gateway.sh (heuristic)   |
 | 5.3  | tc netem latency on gateway1 → client prefers gateway2 | [x] test-multi-gateway.sh (requires tc) |
+
+### Daemon broadcast (mesh-essential identity hygiene)
+
+| Test | Scenario                                                                | Status                  |
+| ---- | ----------------------------------------------------------------------- | ----------------------- |
+| BC.1 | 4-node chain converges so every node has 3 routes                        | [x] test-broadcast.sh   |
+| BC.2 | Direct neighbour x25519 lands in `peers.list` after the Noise handshake | [x] test-broadcast.sh   |
+| BC.3 | `peers.broadcast_identity_now` reports recipients = routes − 1           | [x] test-broadcast.sh   |
+| BC.4 | After broadcast, `messages.send` to a 3-hop peer succeeds (keystore)     | [x] test-broadcast.sh   |
+| BC.5 | Broadcast keystore round-trip is symmetric (`d → a` also works)          | [x] test-broadcast.sh   |
+
+### pim-messaging plugin (end-to-end)
+
+| Test | Scenario                                                                  | Status                  |
+| ---- | ------------------------------------------------------------------------- | ----------------------- |
+| MS.1 | `messages.send` to a direct neighbour → recipient decrypts the body       | [x] test-messaging.sh   |
+| MS.2 | `messages.send` across 3 hops → routed delivery + ack                      | [x] test-messaging.sh   |
+| MS.3 | Sender row transitions `pending` → `sent` → `delivered` after the ack      | [x] test-messaging.sh   |
+| MS.4 | `messages.list_conversations` enriches rows with x25519 + name from keystore | [x] test-messaging.sh |
+| MS.5 | `peers.forget` fans `on_peer_forgotten` and wipes the conversation         | [x] test-messaging.sh   |
+| MS.6 | `messages.send` rejects empty bodies and unknown peers cleanly             | [x] test-messaging.sh   |
 
 ## Pending / Future Scenarios
 

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -37,11 +37,19 @@ cargo +1.94.0 clippy --workspace --all-targets --locked -- -D warnings
 cargo +1.94.0 test --workspace --all-targets --locked
 echo ""
 
-# Topological publish order (each crate after all its internal dependencies)
+# Topological publish order (each crate after all its internal dependencies).
+#
+# pim-plugin    depends on: pim-core, pim-protocol
+# pim-messaging depends on: pim-core, pim-crypto, pim-protocol, pim-plugin
+# pim-daemon    depends on: pim-plugin (and pim-messaging when the
+#                           `messaging` Cargo feature is enabled, which
+#                           is the default)
 CRATES=(
     pim-core
     pim-crypto
     pim-protocol
+    pim-plugin
+    pim-messaging
     pim-gateway
     pim-tun
     pim-bluetooth


### PR DESCRIPTION
…ipt support for new crates

PR 165 introduced two new workspace crates (`pim-plugin`, `pim-messaging`) but left the release plumbing and the integration-test surface unchanged. This follow-up wires both into the existing infrastructure:

* `scripts/publish-crates.sh` now publishes `pim-plugin` (after `pim-protocol`) and `pim-messaging` (after `pim-plugin` + `pim-crypto`) in topological order so a fresh `cargo publish` run from a clean checkout works without manual edits.
* The `Dockerfile` builder layer copies both new manifests + stub sources before the dependency-only compile, keeping the multi-stage cache effective. `jq` is added to the runtime image so test scripts can parse JSON-RPC responses.
* `docker/tests/common.sh` grows a small JSON-RPC helper (`rpc`/`rpc_result`/ `rpc_error`/`rpc_node_id`) over `nc -U /run/pim/pim.sock`. The helper matches responses by `id` so it transparently skips the daemon's per-connection subscription notifications (`status.event`, `peers.event`, …).
* New 4-node chain (`docker/compose/mesh-broadcast.yml` + four configs) where LAN UDP discovery is disabled, so non-adjacent peers can only learn each other's identity through routed `PeerInfo` broadcasts — exactly what the daemon's `messaging.broadcast` cycle is for.
* `docker/tests/test-broadcast.sh` exercises routing convergence, direct + routed PeerInfo, and verifies the keystore was seeded on 2- and 3-hop peers by attempting a `messages.send` to them.
* `docker/tests/test-messaging.sh` covers direct + multi-hop ECIES send/receive, `pending`→`sent`→`delivered` ack roundtrip, `messages.list_conversations` enrichment from the keystore, the `peers.forget` → `DaemonPlugin::on_peer_forgotten` fan-out, and the empty-body / unknown-peer error paths.
* `Makefile` exposes `test-broadcast`, `test-messaging`, `up-mesh-broadcast`, `down-mesh-broadcast`, and `logs-mesh-broadcast`; `test-all` now includes the two new lanes. `docs/operations/docker-labs.md` documents the new topology and scenario checklist.