### PR TITLE
🛡️ Sentinel: [HIGH] Fix secure file permissions for atomic config write

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -25,3 +25,8 @@
 **Vulnerability:** In `pim-crypto`, the `decrypt` and `decrypt_in_place_detached` methods used an unsafe `.unwrap()` on the result of `try_into()` when parsing a slice (`[8..12]`) into an array. If an attacker could feed malformed, truncated, or otherwise corrupted frames to these methods, the program could panic and crash, leading to a Denial of Service (DoS).
 **Learning:** Relying on `.unwrap()` during conversion of dynamic length slices from network or external boundaries can trigger runtime panics.
 **Prevention:** Always use safe slice operations (like `.get()`) with appropriate error mapping (`.ok_or()`) and `.try_into().map_err()` instead of `.unwrap()` to ensure robust error handling without crashing the program.
+
+## 2026-05-09 - [Secure File Permissions for Atomic Replace]
+**Vulnerability:** The daemon's broadcast config was persisted using `std::fs::write` to a temporary file before renaming it over the original file. Since `std::fs::write` falls back to the system's default `umask`, the temporary file could be created world-readable and world-writable. The POSIX `rename` operation preserves the permissions of the source file, causing the sensitive configuration file to end up with insecure permissions.
+**Learning:** When performing atomic file writes using a temporary file and `rename`, the temporary file must be created with explicitly strict permissions (e.g., `0o600`), because its permissions will become the permissions of the final file.
+**Prevention:** Explicitly configure `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o600)` on Unix systems when creating temporary files for atomic replacement, avoiding reliance on system umasks.

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1626,8 +1626,26 @@ async fn persist_broadcast_config_to_disk(state: &Arc<DaemonState>) -> anyhow::R
             .parent()
             .ok_or_else(|| anyhow!("config path has no parent"))?;
         let tmp = tempfile_in_same_dir(parent, &path_for_task)?;
-        std::fs::write(&tmp, serialized.as_bytes())
-            .with_context(|| format!("write tmp {}", tmp.display()))?;
+
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        {
+            use std::io::Write;
+            let mut file = options
+                .open(&tmp)
+                .with_context(|| format!("create tmp {}", tmp.display()))?;
+            file.write_all(serialized.as_bytes())
+                .with_context(|| format!("write tmp {}", tmp.display()))?;
+            file.sync_all()
+                .with_context(|| format!("sync tmp {}", tmp.display()))?;
+        }
+
         std::fs::rename(&tmp, &path_for_task)
             .with_context(|| format!("rename {} -> {}", tmp.display(), path_for_task.display()))?;
         Ok(())


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The daemon's broadcast configuration persistence used `std::fs::write` to create a temporary file, which relied on the system's default `umask` (often resulting in `0o644` or `0o666`). The subsequent POSIX `rename` operation preserves these permissions, resulting in the sensitive configuration file potentially being world-readable and world-writable.
🎯 Impact: Local attackers or unprivileged users could read or maliciously modify the node's broadcast configuration, leading to privilege escalation or network manipulation.
🔧 Fix: Replaced `std::fs::write` with `std::fs::OpenOptions` combined with `std::os::unix::fs::OpenOptionsExt` to explicitly set `mode(0o600)` and `create_new(true)` when creating the temporary file. Also introduced explicit file sync (`sync_all`) before `rename` to prevent data loss.
✅ Verification: Ran `cargo test --workspace` to ensure no regressions. Verified the source code uses `0o600` for the temporary file. Included an entry in `.jules/sentinel.md` documenting this atomic replace permissions pitfall.

---
*PR created automatically by Jules for task [11166926166192144562](https://jules.google.com/task/11166926166192144562) started by @Rfluid*