### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix DoS vulnerability via panic on invalid nonce in crypto decryption

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,7 @@
 **Vulnerability:** The daemon's config generation (`pim-cli/src/main.rs`) and identity key generation (`pim-crypto/src/identity.rs`) checked `path.exists()` before calling `create(true).truncate(true)`. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition where an attacker could replace the file with a symlink between the check and the use, potentially leading to arbitrary file overwrites or key theft.
 **Learning:** Checking for file existence before creating a sensitive file is inherently racy and insecure.
 **Prevention:** Always rely on the filesystem to enforce exclusivity. Use `OpenOptions::new().create_new(true)` to atomically create a file only if it does not already exist, and handle `ErrorKind::AlreadyExists` errors gracefully.
+## 2026-04-23 - [Prevent DoS via Panic on Invalid Nonce Length]
+**Vulnerability:** In `pim-crypto`, the `decrypt` and `decrypt_in_place_detached` methods used an unsafe `.unwrap()` on the result of `try_into()` when parsing a slice (`[8..12]`) into an array. If an attacker could feed malformed, truncated, or otherwise corrupted frames to these methods, the program could panic and crash, leading to a Denial of Service (DoS).
+**Learning:** Relying on `.unwrap()` during conversion of dynamic length slices from network or external boundaries can trigger runtime panics.
+**Prevention:** Always use safe slice operations (like `.get()`) with appropriate error mapping (`.ok_or()`) and `.try_into().map_err()` instead of `.unwrap()` to ensure robust error handling without crashing the program.

--- a/crates/pim-crypto/src/session.rs
+++ b/crates/pim-crypto/src/session.rs
@@ -70,7 +70,14 @@ impl SessionCipher {
     /// Rejects replayed frames: the counter embedded in `frame.nonce[8..12]` must
     /// be strictly greater than the last accepted counter.
     pub fn decrypt(&self, frame: &EncryptedFrame) -> Result<Vec<u8>, SessionError> {
-        let counter = u32::from_be_bytes(frame.nonce[8..12].try_into().unwrap()) as u64;
+        let counter = u32::from_be_bytes(
+            frame
+                .nonce
+                .get(8..12)
+                .ok_or(SessionError::InvalidNonce)?
+                .try_into()
+                .map_err(|_| SessionError::InvalidNonce)?,
+        ) as u64;
         let last = self.last_recv_counter.load(Ordering::SeqCst);
         if last != u64::MAX && counter <= last {
             return Err(SessionError::ReplayedNonce);
@@ -122,7 +129,13 @@ impl SessionCipher {
         payload: &mut [u8],
         tag_bytes: &[u8; 16],
     ) -> Result<(), SessionError> {
-        let counter = u32::from_be_bytes(nonce_bytes[8..12].try_into().unwrap()) as u64;
+        let counter = u32::from_be_bytes(
+            nonce_bytes
+                .get(8..12)
+                .ok_or(SessionError::InvalidNonce)?
+                .try_into()
+                .map_err(|_| SessionError::InvalidNonce)?,
+        ) as u64;
         let last = self.last_recv_counter.load(Ordering::SeqCst);
         if last != u64::MAX && counter <= last {
             return Err(SessionError::ReplayedNonce);
@@ -155,6 +168,9 @@ impl SessionCipher {
 #[derive(Debug, thiserror::Error)]
 /// Errors returned by [`SessionCipher`].
 pub enum SessionError {
+    /// The nonce length or format is invalid.
+    #[error("invalid nonce format")]
+    InvalidNonce,
     /// The nonce counter reached its maximum and the session must be replaced.
     #[error("nonce counter exhausted — session must be rekeyed")]
     NonceExhausted,


### PR DESCRIPTION
🚨 **Severity**: CRITICAL

💡 **Vulnerability**: The `decrypt` and `decrypt_in_place_detached` methods in `crates/pim-crypto/src/session.rs` used an unsafe `.unwrap()` to extract a counter from a 12-byte nonce slice (`frame.nonce[8..12].try_into().unwrap()`). If the nonce array size or format assumption ever mismatched due to internal logic errors or corrupted malformed frames, the `unwrap()` would trigger a panic, causing the application to crash.

🎯 **Impact**: An attacker or an anomalous network event could send malformed packets that cause a runtime panic, leading to an immediate Denial of Service (DoS) of the daemon or gateway processing the packets.

🔧 **Fix**: Replaced the unsafe indexing and `.unwrap()` with a robust and safe `.get(8..12)` combined with `.ok_or(SessionError::InvalidNonce)` and `.try_into().map_err()`. Added a new `InvalidNonce` error variant to the `SessionError` enum to propagate the error gracefully without panicking.

✅ **Verification**: 
1. `cargo test --workspace` passes without errors.
2. Verified that `.unwrap()` no longer exists in `crates/pim-crypto/src/session.rs`.
3. Verified `SessionError` contains the newly added `InvalidNonce` variant.

---
*PR created automatically by Jules for task [9190015648401155635](https://jules.google.com/task/9190015648401155635) started by @Rfluid*