### PR TITLE
⚡ Bolt: Optimize fragment reassembly to avoid redundant allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -36,3 +36,8 @@
 
 **Learning:** `bytes::Bytes` holds a reference-counted buffer but its contents cannot be mutated via `.to_vec()` without forcing a clone and full allocation. However, if the network code owns the sole reference to the buffer (e.g. immediately after decoding), `.try_into_mut()` can safely reclaim mutable access to the underlying `BytesMut` with zero allocations. In high-throughput network daemons like PIM, allocating memory for every frame on the read path becomes a major performance bottleneck.
 **Action:** When a frame buffer needs to be mutated directly (like in `decrypt_in_place_detached`), avoid `.to_vec()`. Instead, attempt to use `.try_into_mut()` when we know the `Bytes` object is uniquely owned to recover zero-copy mutability.
+
+## 2026-05-08 - Fragment reassembly vector allocation optimization
+
+**Learning:** Reassembling fragmented mesh packets created unnecessary memory pressure due to redundant heap allocations. The `try_reassemble` function was allocating a `vec![0u8; self.total_length]` on *every* fragment insertion attempt, even when the fragment stream was incomplete (causing N redundant allocations for a packet needing N fragments).
+**Action:** When optimizing iterative data reassembly, perform a fast O(N) validation pass over the fragment map to ensure data completeness (e.g., all chunks are present and contiguous) *before* allocating the target heap vector. This reduces allocations per packet from N to 1.

--- a/crates/pim-protocol/src/reassembler.rs
+++ b/crates/pim-protocol/src/reassembler.rs
@@ -48,8 +48,12 @@ impl ReassemblyBuffer {
     /// Returns `Some(packet)` when all bytes `[0, total_length)` have been
     /// received, otherwise `None`.
     fn try_reassemble(&self) -> Option<Vec<u8>> {
-        let mut buf = vec![0u8; self.total_length as usize];
+        // PERFORMANCE: Pre-validate that all chunks are present before
+        // allocating the target vector. If we allocate unconditionally,
+        // every fragment arrival costs a redundant `Vec` allocation
+        // equal to `total_length` that gets immediately discarded.
         let mut covered_up_to = 0usize;
+        let total = self.total_length as usize;
 
         for (&offset, chunk) in &self.chunks {
             let start = offset as usize;
@@ -58,21 +62,28 @@ impl ReassemblyBuffer {
                 return None;
             }
             let end = start + chunk.len();
-            if end > buf.len() {
+            if end > total {
                 // Chunk extends past declared total — malformed, bail out.
                 return None;
             }
-            buf[start..end].copy_from_slice(chunk);
             if end > covered_up_to {
                 covered_up_to = end;
             }
         }
 
-        if covered_up_to == self.total_length as usize {
-            Some(buf)
-        } else {
-            None
+        if covered_up_to != total {
+            return None;
         }
+
+        // All bytes present. Perform the final allocation and copy.
+        let mut buf = vec![0u8; total];
+        for (&offset, chunk) in &self.chunks {
+            let start = offset as usize;
+            let end = start + chunk.len();
+            buf[start..end].copy_from_slice(chunk);
+        }
+
+        Some(buf)
     }
 
     fn is_expired(&self, timeout: Duration) -> bool {


### PR DESCRIPTION
💡 **What:** Optimized `try_reassemble` in `crates/pim-protocol/src/reassembler.rs` to validate fragment stream completeness before allocating heap memory.
🎯 **Why:** The previous logic unconditionally allocated a `Vec` sized to the full target packet on *every single* fragment insertion. For an IP packet fragmented into N fragments, this resulted in N heap allocations per packet, where N-1 were instantly discarded because the stream was incomplete, unnecessarily hammering the allocator on the hot path.
📊 **Impact:** Reduces memory allocations for packet reassembly from N down to exactly 1.
🔬 **Measurement:** Verified correctness via `cargo test --workspace`, ensuring all fragmented delivery tests continue to pass perfectly. The impact is measurable via heap profiling tools (like dhat or heaptrack) running against a multi-fragment mesh packet transmission benchmark.

---
*PR created automatically by Jules for task [1689960680300887903](https://jules.google.com/task/1689960680300887903) started by @Rfluid*