### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure file permissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -21,3 +21,7 @@
 **Vulnerability:** The daemon's config generation (`pim-cli/src/main.rs`) and identity key generation (`pim-crypto/src/identity.rs`) checked `path.exists()` before calling `create(true).truncate(true)`. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition where an attacker could replace the file with a symlink between the check and the use, potentially leading to arbitrary file overwrites or key theft.
 **Learning:** Checking for file existence before creating a sensitive file is inherently racy and insecure.
 **Prevention:** Always rely on the filesystem to enforce exclusivity. Use `OpenOptions::new().create_new(true)` to atomically create a file only if it does not already exist, and handle `ErrorKind::AlreadyExists` errors gracefully.
+## 2026-05-09 - [Secure File Permissions for Temporary Configuration Files]
+**Vulnerability:** The daemon's `persist_broadcast_config_to_disk` function used `std::fs::write` to create a temporary configuration file before atomic renaming, which relies on the system's default `umask` and could leave sensitive broadcast configuration data world-readable.
+**Learning:** Using `std::fs::write` for temporary files in an atomic write workflow still exposes the file to insecure default permissions before the rename occurs.
+**Prevention:** Explicitly use `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o600)` on Unix systems and `create_new(true)` to ensure strict permissions and prevent TOCTOU vulnerabilities when writing temporary files prior to atomic renames.

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -1626,8 +1626,24 @@ async fn persist_broadcast_config_to_disk(state: &Arc<DaemonState>) -> anyhow::R
             .parent()
             .ok_or_else(|| anyhow!("config path has no parent"))?;
         let tmp = tempfile_in_same_dir(parent, &path_for_task)?;
-        std::fs::write(&tmp, serialized.as_bytes())
-            .with_context(|| format!("write tmp {}", tmp.display()))?;
+
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+
+        {
+            use std::io::Write;
+            let mut file = options
+                .open(&tmp)
+                .with_context(|| format!("open tmp {}", tmp.display()))?;
+            file.write_all(serialized.as_bytes())
+                .with_context(|| format!("write tmp {}", tmp.display()))?;
+        }
+
         std::fs::rename(&tmp, &path_for_task)
             .with_context(|| format!("rename {} -> {}", tmp.display(), path_for_task.display()))?;
         Ok(())


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `std::fs::write` is used to write configuration to a temporary file, which falls back to the system's default `umask` and can leave the configuration world-readable before renaming it.
🎯 Impact: This could leave the application configuration, including potentially sensitive broadcast states, world-readable or writable.
🔧 Fix: Used `OpenOptions` with `OpenOptionsExt::mode(0o600)` to set strict `0o600` permissions on the temporary file, and used `create_new(true)`.
✅ Verification: Ran `cargo check` and `cargo test --workspace`.

---
*PR created automatically by Jules for task [1031513115565908198](https://jules.google.com/task/1031513115565908198) started by @Rfluid*