### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix blocking sync I/O in rpc server

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -30,3 +30,37 @@
 **Vulnerability:** The daemon's broadcast config was persisted using `std::fs::write` to a temporary file before renaming it over the original file. Since `std::fs::write` falls back to the system's default `umask`, the temporary file could be created world-readable and world-writable. The POSIX `rename` operation preserves the permissions of the source file, causing the sensitive configuration file to end up with insecure permissions.
 **Learning:** When performing atomic file writes using a temporary file and `rename`, the temporary file must be created with explicitly strict permissions (e.g., `0o600`), because its permissions will become the permissions of the final file.
 **Prevention:** Explicitly configure `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o600)` on Unix systems when creating temporary files for atomic replacement, avoiding reliance on system umasks.
+## 2024-05-24 - [Secure File Permissions for Daemon Files]
+**Vulnerability:** The daemon's `atomic_write` function used `tokio::fs::write`, which relies on the system's default `umask`. This function is used to write sensitive files like the trust store, potentially making them world-readable.
+**Learning:** Relying on default file permissions when writing runtime configuration or trust stores creates a risk of exposing sensitive peer identities or network state to other local users.
+**Prevention:** Explicitly use `tokio::fs::OpenOptions` with `mode(0o600)` on Unix systems and `tokio::io::AsyncWriteExt` to ensure strict file access permissions when performing asynchronous writes of sensitive data.
+
+## 2024-06-25 - [Secure File Permissions for System Files]
+**Vulnerability:** The daemon's PID file (`pid_file`) was written using `std::fs::write`, which falls back to the system's default `umask`. Under a permissive umask (e.g., `0000`), this could leave the PID file world-writable, allowing unprivileged users to spoof the PID.
+**Learning:** Relying on default file permissions when writing non-sensitive system files (like PID files) can still create security risks, such as local DoS or privilege escalation, if the files are used by other system services.
+**Prevention:** Explicitly use `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o644)` on Unix systems to ensure strict file access permissions (owner writable, group/others readable) when writing system files.
+
+## 2024-08-16 - [Secure File Creation for Configs]
+**Vulnerability:** The CLI's configuration initialization logic used a non-atomic `path.exists()` check before creating the `config.toml` file with `create(true).truncate(true)`. This creates a Time-of-Check to Time-of-Use (TOCTOU) vulnerability where an attacker could place a symlink at the target path between the check and the file creation.
+**Learning:** Checking for file existence before creation using separate operations is prone to race conditions and symlink attacks.
+**Prevention:** Use atomic operations like `OpenOptions::new().create_new(true)` when creating sensitive files that shouldn't be overwritten, and handle the resulting `ErrorKind::AlreadyExists` to provide safe, race-free user warnings.
+
+## 2026-04-23 - [Prevent TOCTOU via Atomic File Creation]
+**Vulnerability:** The daemon's config generation (`pim-cli/src/main.rs`) and identity key generation (`pim-crypto/src/identity.rs`) checked `path.exists()` before calling `create(true).truncate(true)`. This creates a Time-of-Check to Time-of-Use (TOCTOU) race condition where an attacker could replace the file with a symlink between the check and the use, potentially leading to arbitrary file overwrites or key theft.
+**Learning:** Checking for file existence before creating a sensitive file is inherently racy and insecure.
+**Prevention:** Always rely on the filesystem to enforce exclusivity. Use `OpenOptions::new().create_new(true)` to atomically create a file only if it does not already exist, and handle `ErrorKind::AlreadyExists` errors gracefully.
+
+## 2026-04-23 - [Prevent DoS via Panic on Invalid Nonce Length]
+**Vulnerability:** In `pim-crypto`, the `decrypt` and `decrypt_in_place_detached` methods used an unsafe `.unwrap()` on the result of `try_into()` when parsing a slice (`[8..12]`) into an array. If an attacker could feed malformed, truncated, or otherwise corrupted frames to these methods, the program could panic and crash, leading to a Denial of Service (DoS).
+**Learning:** Relying on `.unwrap()` during conversion of dynamic length slices from network or external boundaries can trigger runtime panics.
+**Prevention:** Always use safe slice operations (like `.get()`) with appropriate error mapping (`.ok_or()`) and `.try_into().map_err()` instead of `.unwrap()` to ensure robust error handling without crashing the program.
+
+## 2026-05-09 - [Secure File Permissions for Atomic Replace]
+**Vulnerability:** The daemon's broadcast config was persisted using `std::fs::write` to a temporary file before renaming it over the original file. Since `std::fs::write` falls back to the system's default `umask`, the temporary file could be created world-readable and world-writable. The POSIX `rename` operation preserves the permissions of the source file, causing the sensitive configuration file to end up with insecure permissions.
+**Learning:** When performing atomic file writes using a temporary file and `rename`, the temporary file must be created with explicitly strict permissions (e.g., `0o600`), because its permissions will become the permissions of the final file.
+**Prevention:** Explicitly configure `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o600)` on Unix systems when creating temporary files for atomic replacement, avoiding reliance on system umasks.
+
+## 2026-05-16 - [Prevent Blocking Async Threads with Sync I/O]
+**Vulnerability:** In `pim-daemon`'s `rpc.rs`, the asynchronous `run_rpc_server` function contained synchronous file system operations (`std::fs::remove_file`, `std::fs::create_dir_all`, `std::fs::set_permissions`). These synchronous calls block the Tokio reactor thread, causing scheduling latency spikes, which can delay task execution and decrease the efficiency of the asynchronous runtime, leading to potential Denial of Service (DoS) in high-load scenarios.
+**Learning:** Using synchronous I/O operations inside an `async fn` blocks the executor thread, preventing it from processing other async tasks, which can severely degrade performance and cause latency spikes in highly concurrent daemons.
+**Prevention:** Always use the asynchronous equivalents from `tokio::fs` (e.g., `tokio::fs::remove_file`, `tokio::fs::create_dir_all`, `tokio::fs::set_permissions`) when performing file system operations inside `async` functions to ensure the runtime remains non-blocking.

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -121,11 +121,11 @@ fn new_subscription_id() -> String {
 
 pub(crate) async fn run_rpc_server(state: Arc<DaemonState>, socket_path: PathBuf) {
     // Best-effort cleanup of a stale socket from a previous run.
-    let _ = std::fs::remove_file(&socket_path);
+    let _ = tokio::fs::remove_file(&socket_path).await;
 
     if let Some(parent) = socket_path.parent() {
         if !parent.as_os_str().is_empty() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
                 warn!(
                     "rpc: create parent dir {} failed: {e} — listener may fail to bind",
                     parent.display()
@@ -150,7 +150,7 @@ pub(crate) async fn run_rpc_server(state: Arc<DaemonState>, socket_path: PathBuf
     {
         use std::os::unix::fs::PermissionsExt;
         if let Err(e) =
-            std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o660))
+            tokio::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o660)).await
         {
             warn!("rpc: chmod 0660 socket failed: {e}");
         }


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Synchronous file system operations (`std::fs::remove_file`, `std::fs::create_dir_all`, `std::fs::set_permissions`) were used inside the asynchronous `run_rpc_server` function. This blocks the Tokio reactor thread, potentially causing latency spikes and degrading the asynchronous runtime's ability to handle concurrent tasks, which could lead to a Denial of Service (DoS) under certain conditions.
🎯 Impact: Heavy load or slow file system operations could starve the async executor, making the daemon unresponsive.
🔧 Fix: Replaced `std::fs` calls with their `tokio::fs` asynchronous counterparts and added `.await`.
✅ Verification: `cargo test --workspace` and `cargo clippy --workspace -- -D warnings` pass. Code has been reviewed.

---
*PR created automatically by Jules for task [15200267064332120888](https://jules.google.com/task/15200267064332120888) started by @Rfluid*