### PR TITLE
fix(.agent): resolve leftover git conflict markers in review-prs.md

### DIFF
--- a/.agent/prompts/review-prs.md
+++ b/.agent/prompts/review-prs.md
@@ -33,7 +33,7 @@ Process every open PR against the target branch in one pass:
     - `.jules/sentinel.md` and `.jules/bolt.md` — accumulated security and
       performance learnings. Newly-added entries from PRs append here, so
       conflicts are common during rebase.
-    - `kernel/CLAUDE.md` for the toolchain pin (Rust 1.94 at the time of
+    - `CLAUDE.md` for the toolchain pin (Rust 1.94 at the time of
       writing) and pre-PR checks.
 
 2. **Inventory.** Run:
@@ -111,17 +111,11 @@ Process every open PR against the target branch in one pass:
     plus any tests not in `test-all` (check the `Makefile`'s
     `.PHONY: test-*` line — typically rfcomm-cleanup/discovery, debug-cli,
     auto-discovery, auto-ip-chain). If a test fails for an environmental
-    <<<<<<< HEAD
-    reason (network blip, port collision, transient docker daemon error),
-    re-run _that single test_. If it fails twice, treat it as a real
-    regression and investigate.
-    =======
     reason (network blip, port collision, transient docker daemon error,
     discovery-convergence timeout), re-run _that single test_ with
     `DUMP_LOGS_ON_FAIL=1` for diagnostics. If it fails on three consecutive
     runs, treat it as a real regression and investigate.
 
-    > > > > > > > 12da7b3 (feat(agent): add review-prs prompt for batch PR triage)
 
 9. **Summary table.** End the session with a markdown table:
 


### PR DESCRIPTION
Removed leftover git merge conflict markers in `.agent/prompts/review-prs.md` that were breaking the markdown layout. Also fixed a broken path reference pointing to `kernel/CLAUDE.md` to `CLAUDE.md`. This change makes the PR review prompt clean and accurate for agents.

---
*PR created automatically by Jules for task [11207245402542522555](https://jules.google.com/task/11207245402542522555) started by @Rfluid*