### PR TITLE
⚡ Bolt: [performance improvement] Zero-copy FragmentFrame deserialization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,8 @@
 
 **Learning:** `Vec::new()` allocates no heap memory until the first element is pushed, at which point it dynamically allocates and then periodically reallocates. In hot network paths like `fragment_packet`, where we know we will push items, this leads to unnecessary reallocation overhead. However, it is a mistake to aggressively apply `Vec::with_capacity()` to collections that often remain empty (e.g., error queues or retry buffers on the "happy path"), as this will force an unnecessary heap allocation where `Vec::new()` would have remained zero-cost.
 **Action:** Always pre-allocate exact `Vec` capacities (e.g., using `Vec::with_capacity()`) over `Vec::new()` when the final size or an upper bound is known in advance *and* the vector is guaranteed or highly likely to be populated. Avoid `Vec::with_capacity()` for paths that usually remain empty.
+
+## 2024-05-20 - Fragment deserialization zero-copy optimization
+
+**Learning:** When parsing network frames, accepting a slice `&[u8]` forces a memory allocation via `Bytes::copy_from_slice` when trying to retain a sub-slice for later use in a struct that owns `Bytes`.
+**Action:** Change deserialization APIs to accept `bytes::Bytes` by value instead of `&[u8]`. This permits `buf.slice(offset..)` which performs an O(1) zero-copy operation instead of an expensive O(N) heap allocation and copy for every parsed packet or fragment.

--- a/crates/pim-daemon/src/app/event_loop.rs
+++ b/crates/pim-daemon/src/app/event_loop.rs
@@ -269,7 +269,7 @@ pub(super) async fn run_event_loop(state: Arc<DaemonState>) -> Result<()> {
                             state.packets_forwarded.fetch_add(1, Ordering::Relaxed);
                             state.bytes_forwarded.fetch_add(mesh.payload.len() as u64, Ordering::Relaxed);
                             let ip_payload = match reassemble_or_deliver(
-                                &state, mesh.src_id, mesh.flags, &mesh.payload,
+                                &state, mesh.src_id, mesh.flags, mesh.payload.clone(),
                             ).await {
                                 Some(p) => p,
                                 None => continue, // waiting for more fragments

--- a/crates/pim-daemon/src/data_plane.rs
+++ b/crates/pim-daemon/src/data_plane.rs
@@ -71,7 +71,7 @@ pub(crate) async fn reassemble_or_deliver(
     state: &Arc<DaemonState>,
     src_id: NodeId,
     flags: DataFlags,
-    payload: &[u8],
+    payload: bytes::Bytes,
 ) -> Option<Vec<u8>> {
     if flags.contains(DataFlags::IS_FRAGMENT) {
         let frag = FragmentFrame::deserialize(payload)?;

--- a/crates/pim-protocol/src/fragment_frame.rs
+++ b/crates/pim-protocol/src/fragment_frame.rs
@@ -45,14 +45,14 @@ impl FragmentFrame {
 
     /// Deserialize from wire bytes.  Returns `None` if the buffer is too short
     /// or the contained offsets are nonsensical.
-    pub fn deserialize(buf: &[u8]) -> Option<Self> {
+    pub fn deserialize(buf: bytes::Bytes) -> Option<Self> {
         if buf.len() < FRAGMENT_HEADER_SIZE {
             return None;
         }
         let fragment_id = u32::from_be_bytes(buf[0..4].try_into().ok()?);
         let fragment_offset = u16::from_be_bytes(buf[4..6].try_into().ok()?);
         let total_length = u16::from_be_bytes(buf[6..8].try_into().ok()?);
-        let payload = bytes::Bytes::copy_from_slice(&buf[8..]);
+        let payload = buf.slice(8..);
 
         // Basic sanity checks.
         let end = (fragment_offset as usize).checked_add(payload.len())?;

--- a/crates/pim-protocol/src/fragment_frame/tests/basics.rs
+++ b/crates/pim-protocol/src/fragment_frame/tests/basics.rs
@@ -40,13 +40,13 @@ fn serialize_deserialize_round_trip() {
         payload: bytes::Bytes::from(vec![1, 2, 3, 4]),
     };
     let bytes = frame.serialize();
-    let decoded = FragmentFrame::deserialize(&bytes).unwrap();
+    let decoded = FragmentFrame::deserialize(bytes::Bytes::from(bytes)).unwrap();
     assert_eq!(frame, decoded);
 }
 
 #[test]
 fn deserialize_too_short_returns_none() {
-    assert!(FragmentFrame::deserialize(&[0u8; 7]).is_none());
+    assert!(FragmentFrame::deserialize(bytes::Bytes::from(vec![0u8; 7])).is_none());
 }
 
 #[test]
@@ -66,7 +66,7 @@ fn deserialize_offset_past_total_returns_none() {
     // We set total_length = 500, which is < 1100. This should fail.
     bad.total_length = 500;
     let bytes3 = bad.serialize();
-    assert!(FragmentFrame::deserialize(&bytes3).is_none());
+    assert!(FragmentFrame::deserialize(bytes::Bytes::from(bytes3)).is_none());
     let _ = bytes2; // suppress warning
 }
 


### PR DESCRIPTION
💡 **What**: Refactored `FragmentFrame::deserialize` in `pim-protocol` to consume a `bytes::Bytes` instead of a `&[u8]`. Updated the caller in `pim-daemon` (`reassemble_or_deliver`) to pass a cloned `Bytes` pointer down from the event loop instead of a reference.
🎯 **Why**: In a hot event loop handling heavy network I/O, allocating a new `Vec<u8>` or `Bytes` buffer for every packet fragment via `Bytes::copy_from_slice` creates tremendous memory pressure and CPU overhead. 
📊 **Impact**: Reduces heap allocations for large payload fragment reception from N (where N is the number of fragments) to 0. `Bytes::slice` is an O(1) operation.
🔬 **Measurement**: Verify via `cargo test --workspace` that all functional parity is maintained. Memory profiling would show a drastic reduction in temporary allocations in the mesh receive loop.

---
*PR created automatically by Jules for task [10523579565346089751](https://jules.google.com/task/10523579565346089751) started by @Rfluid*