### PR TITLE
⚡ Bolt: [performance improvement] Refactor run_rpc_server to use tokio::fs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 
 **Learning:** `Vec::new()` allocates no heap memory until the first element is pushed, at which point it dynamically allocates and then periodically reallocates. In hot network paths like `fragment_packet`, where we know we will push items, this leads to unnecessary reallocation overhead. However, it is a mistake to aggressively apply `Vec::with_capacity()` to collections that often remain empty (e.g., error queues or retry buffers on the "happy path"), as this will force an unnecessary heap allocation where `Vec::new()` would have remained zero-cost.
 **Action:** Always pre-allocate exact `Vec` capacities (e.g., using `Vec::with_capacity()`) over `Vec::new()` when the final size or an upper bound is known in advance *and* the vector is guaranteed or highly likely to be populated. Avoid `Vec::with_capacity()` for paths that usually remain empty.
+## 2024-05-19 - Async File System Operations
+
+**Learning:** In `pim-daemon`, synchronous file system operations (e.g., `std::fs::remove_file`, `std::fs::create_dir_all`, `std::fs::set_permissions`) inside `async` functions like `run_rpc_server` block the Tokio reactor thread and lead to scheduling latency spikes. This is an anti-pattern for performance in an async environment doing heavy network I/O.
+**Action:** Replace synchronous `std::fs` calls inside `async` blocks with their asynchronous `tokio::fs` equivalents (and add `.await`) to prevent blocking the executor and allow proper async task scheduling.

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -120,11 +120,11 @@ fn new_subscription_id() -> String {
 
 pub(crate) async fn run_rpc_server(state: Arc<DaemonState>, socket_path: PathBuf) {
     // Best-effort cleanup of a stale socket from a previous run.
-    let _ = std::fs::remove_file(&socket_path);
+    let _ = tokio::fs::remove_file(&socket_path).await;
 
     if let Some(parent) = socket_path.parent() {
         if !parent.as_os_str().is_empty() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
                 warn!(
                     "rpc: create parent dir {} failed: {e} — listener may fail to bind",
                     parent.display()
@@ -152,7 +152,7 @@ pub(crate) async fn run_rpc_server(state: Arc<DaemonState>, socket_path: PathBuf
     {
         use std::os::unix::fs::PermissionsExt;
         if let Err(e) =
-            std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o660))
+            tokio::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o660)).await
         {
             warn!("rpc: chmod 0660 socket failed: {e}");
         }


### PR DESCRIPTION
💡 What: Replaced synchronous `std::fs` calls with `tokio::fs` calls inside the `run_rpc_server` async function.
🎯 Why: In `pim-daemon`, synchronous file system operations (like `std::fs::remove_file`, `std::fs::create_dir_all`, and `std::fs::set_permissions`) inside `async` functions block the Tokio reactor thread, leading to scheduling latency spikes and degraded performance under load.
📊 Impact: Eliminates blocking operations in the async context, ensuring the Tokio executor isn't stalled and improving task scheduling efficiency.
🔬 Measurement: Verified functionality by running `cargo test -p pim-daemon`. No regressions were found.

---
*PR created automatically by Jules for task [18183499953323188468](https://jules.google.com/task/18183499953323188468) started by @Rfluid*