### PR TITLE
fix(agent): remove evading spaced-out git conflict markers in review-prs.md

### DIFF
--- a/.agent/prompts/review-prs.md
+++ b/.agent/prompts/review-prs.md
@@ -81,6 +81,8 @@ Process every open PR against the target branch in one pass:
    side. Bump the date in the kept entry to the actual merge date if the
    PR's author date is stale.
 
+   **Note on spaced markers:** When resolving conflicts, ensure absolutely no git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) remain. LLMs or formatters sometimes insert spaces (e.g., `> > > > > > >`), evading simple grep checks. Visually confirm the final file is clean.
+
 6. **Verify locally before pushing a fix.** Run the kernel pre-PR gate:
 
     ```bash
@@ -111,17 +113,11 @@ Process every open PR against the target branch in one pass:
     plus any tests not in `test-all` (check the `Makefile`'s
     `.PHONY: test-*` line — typically rfcomm-cleanup/discovery, debug-cli,
     auto-discovery, auto-ip-chain). If a test fails for an environmental
-    <<<<<<< HEAD
-    reason (network blip, port collision, transient docker daemon error),
-    re-run _that single test_. If it fails twice, treat it as a real
-    regression and investigate.
-    =======
     reason (network blip, port collision, transient docker daemon error,
     discovery-convergence timeout), re-run _that single test_ with
     `DUMP_LOGS_ON_FAIL=1` for diagnostics. If it fails on three consecutive
     runs, treat it as a real regression and investigate.
 
-    > > > > > > > 12da7b3 (feat(agent): add review-prs prompt for batch PR triage)
 
 9. **Summary table.** End the session with a markdown table:
 


### PR DESCRIPTION
Fixes a persistent git conflict marker that was evading checks due to added spaces in `.agent/prompts/review-prs.md` and explicitly warns about this pattern in the PR review workflow prompt.

---
*PR created automatically by Jules for task [11208488030033285327](https://jules.google.com/task/11208488030033285327) started by @Rfluid*