### PR TITLE
⚡ Bolt: Use tokio async filesystem methods in RPC listener setup

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,8 @@
 
 **Learning:** `Vec::new()` allocates no heap memory until the first element is pushed, at which point it dynamically allocates and then periodically reallocates. In hot network paths like `fragment_packet`, where we know we will push items, this leads to unnecessary reallocation overhead. However, it is a mistake to aggressively apply `Vec::with_capacity()` to collections that often remain empty (e.g., error queues or retry buffers on the "happy path"), as this will force an unnecessary heap allocation where `Vec::new()` would have remained zero-cost.
 **Action:** Always pre-allocate exact `Vec` capacities (e.g., using `Vec::with_capacity()`) over `Vec::new()` when the final size or an upper bound is known in advance *and* the vector is guaranteed or highly likely to be populated. Avoid `Vec::with_capacity()` for paths that usually remain empty.
+
+## 2024-05-20 - Synchronous file system operations in async functions block Tokio reactor
+
+**Learning:** In Tokio-based async applications (like `pim-daemon`), using synchronous file system operations (e.g., `std::fs::remove_file`, `std::fs::create_dir_all`, `std::fs::set_permissions`) inside an `async` function (e.g., `run_rpc_server`) blocks the underlying executor thread. This can lead to starvation and latency spikes across the entire application, as the thread cannot process other async tasks while waiting for the I/O to complete.
+**Action:** Always replace synchronous `std::fs` operations with their asynchronous `tokio::fs` equivalents and `await` them inside async contexts. This yields the thread back to the executor, maintaining high throughput and low latency.

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -120,11 +120,11 @@ fn new_subscription_id() -> String {
 
 pub(crate) async fn run_rpc_server(state: Arc<DaemonState>, socket_path: PathBuf) {
     // Best-effort cleanup of a stale socket from a previous run.
-    let _ = std::fs::remove_file(&socket_path);
+    let _ = tokio::fs::remove_file(&socket_path).await;
 
     if let Some(parent) = socket_path.parent() {
         if !parent.as_os_str().is_empty() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
                 warn!(
                     "rpc: create parent dir {} failed: {e} — listener may fail to bind",
                     parent.display()
@@ -152,7 +152,7 @@ pub(crate) async fn run_rpc_server(state: Arc<DaemonState>, socket_path: PathBuf
     {
         use std::os::unix::fs::PermissionsExt;
         if let Err(e) =
-            std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o660))
+            tokio::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o660)).await
         {
             warn!("rpc: chmod 0660 socket failed: {e}");
         }


### PR DESCRIPTION
**💡 What:** Replaced synchronous `std::fs` operations (`remove_file`, `create_dir_all`, and `set_permissions`) with their asynchronous `tokio::fs` equivalents in the `run_rpc_server` initialization block in `crates/pim-daemon/src/rpc.rs`.

**🎯 Why:** Performing synchronous file system operations inside an `async` function blocks the underlying Tokio executor thread. In a high-throughput network daemon, this causes thread starvation and scheduling latency spikes. By using asynchronous operations, the thread is yielded back to the executor while waiting for I/O to complete.

**📊 Impact:** Eliminates blocking I/O on the executor thread during RPC listener startup, improving overall application responsiveness and reducing latency spikes.

**🔬 Measurement:** Verify that the code compiles (`cargo check -p pim-daemon`) and tests pass (`cargo test -p pim-daemon`). Profiling the application startup will show no blocking file system calls on the Tokio worker threads during RPC initialization.

---
*PR created automatically by Jules for task [2525524481940550464](https://jules.google.com/task/2525524481940550464) started by @Rfluid*