### PR TITLE
⚡ Bolt: Replace blocking std::fs operations in run_rpc_server with tokio::fs

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 
 **Learning:** `Vec::new()` allocates no heap memory until the first element is pushed, at which point it dynamically allocates and then periodically reallocates. In hot network paths like `fragment_packet`, where we know we will push items, this leads to unnecessary reallocation overhead. However, it is a mistake to aggressively apply `Vec::with_capacity()` to collections that often remain empty (e.g., error queues or retry buffers on the "happy path"), as this will force an unnecessary heap allocation where `Vec::new()` would have remained zero-cost.
 **Action:** Always pre-allocate exact `Vec` capacities (e.g., using `Vec::with_capacity()`) over `Vec::new()` when the final size or an upper bound is known in advance *and* the vector is guaranteed or highly likely to be populated. Avoid `Vec::with_capacity()` for paths that usually remain empty.
+
+## 2024-05-20 - Replace blocking std::fs operations in run_rpc_server with tokio::fs
+**Learning:** Using synchronous `std::fs` operations (like `remove_file`, `create_dir_all`, `set_permissions`) inside an `async fn` like `run_rpc_server` blocks the Tokio reactor thread. This can cause scheduling latency spikes in an async daemon doing network I/O.
+**Action:** Always replace blocking `std::fs` calls with their asynchronous `tokio::fs` equivalents and `await` them when working within an `async` context.

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -120,11 +120,12 @@ fn new_subscription_id() -> String {
 
 pub(crate) async fn run_rpc_server(state: Arc<DaemonState>, socket_path: PathBuf) {
     // Best-effort cleanup of a stale socket from a previous run.
-    let _ = std::fs::remove_file(&socket_path);
+    // ⚡ Bolt: Using `tokio::fs` instead of `std::fs` to prevent blocking the async reactor thread.
+    let _ = tokio::fs::remove_file(&socket_path).await;
 
     if let Some(parent) = socket_path.parent() {
         if !parent.as_os_str().is_empty() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
                 warn!(
                     "rpc: create parent dir {} failed: {e} — listener may fail to bind",
                     parent.display()
@@ -152,7 +153,7 @@ pub(crate) async fn run_rpc_server(state: Arc<DaemonState>, socket_path: PathBuf
     {
         use std::os::unix::fs::PermissionsExt;
         if let Err(e) =
-            std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o660))
+            tokio::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o660)).await
         {
             warn!("rpc: chmod 0660 socket failed: {e}");
         }


### PR DESCRIPTION
💡 What: Replaced blocking `std::fs::remove_file`, `std::fs::create_dir_all`, and `std::fs::set_permissions` with their `tokio::fs` asynchronous equivalents in `run_rpc_server`.

🎯 Why: Using synchronous file system operations within an `async fn` blocks the Tokio reactor thread, causing scheduling latency spikes in the async daemon.

📊 Impact: Prevents the Tokio worker thread from stalling during I/O operations at the start of the RPC server, improving the daemon's responsiveness and scalability.

🔬 Measurement: Verify that the RPC server still starts up correctly and the tests continue to pass (`cargo test -p pim-daemon`). Also verified using code review.

---
*PR created automatically by Jules for task [15764969226249688879](https://jules.google.com/task/15764969226249688879) started by @Rfluid*