### PR TITLE
Update Agent Workspace: Fix leftover git conflict marker in review-prs.md

### DIFF
--- a/.agent/prompts/review-prs.md
+++ b/.agent/prompts/review-prs.md
@@ -111,17 +111,11 @@ Process every open PR against the target branch in one pass:
     plus any tests not in `test-all` (check the `Makefile`'s
     `.PHONY: test-*` line — typically rfcomm-cleanup/discovery, debug-cli,
     auto-discovery, auto-ip-chain). If a test fails for an environmental
-    <<<<<<< HEAD
-    reason (network blip, port collision, transient docker daemon error),
-    re-run _that single test_. If it fails twice, treat it as a real
-    regression and investigate.
-    =======
     reason (network blip, port collision, transient docker daemon error,
     discovery-convergence timeout), re-run _that single test_ with
     `DUMP_LOGS_ON_FAIL=1` for diagnostics. If it fails on three consecutive
     runs, treat it as a real regression and investigate.
 
-    > > > > > > > 12da7b3 (feat(agent): add review-prs prompt for batch PR triage)
 
 9. **Summary table.** End the session with a markdown table:
 


### PR DESCRIPTION
This PR fixes a small syntactical issue in the `.agent/prompts/review-prs.md` documentation file where a git conflict marker (`<<<<<<< HEAD`, `=======`, and a spaced-out `> > > > > > >`) had been left behind. It deletes the markers and keeps the updated block (lines 119-123).

This is a focused and simple fix based on a review of recent changes to the repository.

---
*PR created automatically by Jules for task [10386590834174055670](https://jules.google.com/task/10386590834174055670) started by @Rfluid*