### PR TITLE
⚡ Bolt: Use prepare_cached in SQLite queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,8 @@
 
 **Learning:** `Vec::new()` allocates no heap memory until the first element is pushed, at which point it dynamically allocates and then periodically reallocates. In hot network paths like `fragment_packet`, where we know we will push items, this leads to unnecessary reallocation overhead. However, it is a mistake to aggressively apply `Vec::with_capacity()` to collections that often remain empty (e.g., error queues or retry buffers on the "happy path"), as this will force an unnecessary heap allocation where `Vec::new()` would have remained zero-cost.
 **Action:** Always pre-allocate exact `Vec` capacities (e.g., using `Vec::with_capacity()`) over `Vec::new()` when the final size or an upper bound is known in advance *and* the vector is guaranteed or highly likely to be populated. Avoid `Vec::with_capacity()` for paths that usually remain empty.
+
+## 2024-05-25 - SQLite query parsing latency optimization
+
+**Learning:** `rusqlite`'s `conn.prepare()` incurs parsing and compilation overhead for every execution of static SQL strings, which creates unnecessary latency on hot read paths.
+**Action:** Always prefer using `conn.prepare_cached()` over `conn.prepare()` for static SQL queries. This leverages `rusqlite`'s internal caching to compile the statement once and reuse it, drastically reducing latency in performance-sensitive query execution loops without sacrificing safety.

--- a/crates/pim-daemon/src/peer_directory.rs
+++ b/crates/pim-daemon/src/peer_directory.rs
@@ -384,7 +384,8 @@ impl PeerDirectoryService {
 
     fn list_x25519_blocking(&self) -> Result<std::collections::HashMap<String, String>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare("SELECT node_id, x25519_pub FROM peers_seen")?;
+        // ⚡ Bolt: Use prepare_cached to reduce SQL parsing latency
+        let mut stmt = conn.prepare_cached("SELECT node_id, x25519_pub FROM peers_seen")?;
         let rows = stmt
             .query_map([], |row| {
                 let node_id: String = row.get(0)?;
@@ -407,7 +408,8 @@ impl PeerDirectoryService {
     /// loop reports what it dropped.
     pub fn list_peers_older_than(&self, threshold_ms: i64) -> Result<Vec<(NodeId, i64, String)>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        // ⚡ Bolt: Use prepare_cached to reduce SQL parsing latency
+        let mut stmt = conn.prepare_cached(
             "SELECT node_id, last_seen_ms, last_known_name \
              FROM peers_seen \
              WHERE last_seen_ms < ?1 \
@@ -501,7 +503,8 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn list_rfcomm_lifecycle(&self) -> Result<Vec<RfcommLifecycleRecord>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        // ⚡ Bolt: Use prepare_cached to reduce SQL parsing latency
+        let mut stmt = conn.prepare_cached(
             "SELECT bd_addr, name, first_paired_at_s, last_connected_at_s \
              FROM rfcomm_peer_lifecycle \
              ORDER BY bd_addr ASC",
@@ -568,7 +571,8 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn list_pan_lifecycle(&self) -> Result<Vec<PanLifecycleRecord>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        // ⚡ Bolt: Use prepare_cached to reduce SQL parsing latency
+        let mut stmt = conn.prepare_cached(
             "SELECT bd_addr, name, first_paired_at_s, last_connected_at_s \
              FROM bluetooth_pan_lifecycle \
              ORDER BY bd_addr ASC",
@@ -633,7 +637,8 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn list_wfd_lifecycle(&self) -> Result<Vec<WfdLifecycleRecord>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        // ⚡ Bolt: Use prepare_cached to reduce SQL parsing latency
+        let mut stmt = conn.prepare_cached(
             "SELECT mac, first_seen_at_s, last_connected_at_s \
              FROM wfd_peer_lifecycle \
              ORDER BY mac ASC",

--- a/crates/pim-messaging/src/storage.rs
+++ b/crates/pim-messaging/src/storage.rs
@@ -329,14 +329,16 @@ impl MessagingStorage {
         let limit_plus = limit.saturating_add(1).max(2);
 
         let mut stmt = match before_ts_ms {
-            Some(_) => conn.prepare(
+            // ⚡ Bolt: Use prepare_cached to reduce SQL parsing latency
+            Some(_) => conn.prepare_cached(
                 "SELECT id, peer_node_id, direction, body, timestamp_ms, status, failure_reason, delivered_at_ms, read_at_ms \
                  FROM messages \
                  WHERE peer_node_id = ?1 AND timestamp_ms < ?2 \
                  ORDER BY timestamp_ms DESC, id DESC \
                  LIMIT ?3",
             )?,
-            None => conn.prepare(
+            // ⚡ Bolt: Use prepare_cached to reduce SQL parsing latency
+            None => conn.prepare_cached(
                 "SELECT id, peer_node_id, direction, body, timestamp_ms, status, failure_reason, delivered_at_ms, read_at_ms \
                  FROM messages \
                  WHERE peer_node_id = ?1 \
@@ -363,7 +365,8 @@ impl MessagingStorage {
     /// layer fills them in from the daemon's peer directory.
     pub fn list_conversations_raw(&self) -> Result<Vec<ConversationSummary>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        // ⚡ Bolt: Use prepare_cached to reduce SQL parsing latency
+        let mut stmt = conn.prepare_cached(
             "SELECT peer_node_id, last_message_preview, last_message_ts_ms, unread_count \
              FROM conversations_meta \
              ORDER BY last_message_ts_ms DESC NULLS LAST",


### PR DESCRIPTION
💡 What: Replaced rusqlite `conn.prepare()` with `conn.prepare_cached()` in `pim-daemon` and `pim-messaging`. Added comments explaining the performance benefit.
🎯 Why: Statement caching significantly reduces SQL parsing latency, avoiding query recompilation overhead for frequently run static queries.
📊 Impact: Expected to reduce execution latency of static SQL queries in hot paths.
🔬 Measurement: Verify tests run and statement compilation overhead is reduced using internal benchmark tracing.

---
*PR created automatically by Jules for task [6264985735304682220](https://jules.google.com/task/6264985735304682220) started by @Rfluid*