### PR TITLE
docs(agent): sync DOCS_MAP.md with existing docs folders

### DIFF
--- a/.agent/core/DOCS_MAP.md
+++ b/.agent/core/DOCS_MAP.md
@@ -58,6 +58,18 @@ duplicating them.
 - `docs/operations/docker-labs.md`
     - Docker lab details and usage
 
+## Reference
+
+- `docs/reference/README.md`
+    - API and CLI reference index
+- `docs/troubleshooting/README.md`
+    - debugging common issues
+
+## Research
+
+- `docs/research/`
+    - investigation into platform-specific behaviors
+
 ## Usage Guidance
 
 - For implementation tasks, read the nearest section in `./docs` before editing.


### PR DESCRIPTION
Updated `.agent/core/DOCS_MAP.md` to map missing but existing directories in `docs/` such as `reference`, `troubleshooting`, and `research`. This improves agent context navigation and follows the request to provide a small, single improvement to the agent workspace grounded in repo layout.

---
*PR created automatically by Jules for task [16967844278824835532](https://jules.google.com/task/16967844278824835532) started by @Rfluid*