### PR TITLE
🛡️ Sentinel: [HIGH] Fix command/argument injection in Bluetooth interface commands

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -30,3 +30,8 @@
 **Vulnerability:** The daemon's broadcast config was persisted using `std::fs::write` to a temporary file before renaming it over the original file. Since `std::fs::write` falls back to the system's default `umask`, the temporary file could be created world-readable and world-writable. The POSIX `rename` operation preserves the permissions of the source file, causing the sensitive configuration file to end up with insecure permissions.
 **Learning:** When performing atomic file writes using a temporary file and `rename`, the temporary file must be created with explicitly strict permissions (e.g., `0o600`), because its permissions will become the permissions of the final file.
 **Prevention:** Explicitly configure `std::fs::OpenOptions` with `OpenOptionsExt::mode(0o600)` on Unix systems when creating temporary files for atomic replacement, avoiding reliance on system umasks.
+
+## 2026-05-26 - [Command and Argument Injection via Interface Names]
+**Vulnerability:** In `pim-bluetooth`, untrusted strings intended to be network interfaces or bridge names (like `nap_bridge` from configuration) were passed directly as arguments to external command utilities (like `ip` or `ifconfig`) via `std::process::Command::new()`. This could allow an attacker to inject arbitrary command arguments (e.g., `-exec` or additional flags) to alter the command's behavior.
+**Learning:** Passing untrusted data directly to external shell commands, even without `sh -c`, can still lead to argument injection if the data starts with a dash or contains unsafe characters.
+**Prevention:** Always validate network interface and bridge names using a strict allowlist character check (like `is_safe_interface_name`) before passing them to `Command::new()`.

--- a/crates/pim-bluetooth/src/platform_impl.rs
+++ b/crates/pim-bluetooth/src/platform_impl.rs
@@ -256,6 +256,12 @@ impl BluetoothDiscovery {
 
     #[cfg(target_os = "linux")]
     pub(super) async fn ensure_bridge_ready(&self, bridge: &str) -> Result<(), BluetoothError> {
+        if !crate::support::is_safe_interface_name(bridge) {
+            return Err(BluetoothError::CommandFailed {
+                command: "validation",
+                message: format!("unsafe bridge name: {}", bridge),
+            });
+        }
         let bridge_path = self.sysfs_root.join(bridge);
         if !bridge_path.exists() {
             let output = Command::new(&self.ip_command)
@@ -317,6 +323,12 @@ impl BluetoothDiscovery {
     /// incoming PAN connections on some distros.
     #[cfg(target_os = "linux")]
     pub(super) async fn attach_bnep_to_bridge(&self, bridge: &str) -> Result<(), BluetoothError> {
+        if !crate::support::is_safe_interface_name(bridge) {
+            return Err(BluetoothError::CommandFailed {
+                command: "validation",
+                message: format!("unsafe bridge name: {}", bridge),
+            });
+        }
         if bridge.is_empty() {
             return Ok(());
         }
@@ -486,6 +498,9 @@ impl BluetoothDiscovery {
     /// Best-effort: errors are logged, not propagated.
     #[cfg(target_os = "linux")]
     pub(super) async fn delete_bridge_if_present(&self, bridge: &str) {
+        if !crate::support::is_safe_interface_name(bridge) {
+            return;
+        }
         if bridge.is_empty() {
             return;
         }
@@ -629,6 +644,12 @@ impl BluetoothDiscovery {
 
     #[cfg(target_os = "linux")]
     pub(super) async fn start_dnsmasq(&self, bridge: &str) -> Result<Child, BluetoothError> {
+        if !crate::support::is_safe_interface_name(bridge) {
+            return Err(BluetoothError::CommandFailed {
+                command: "validation",
+                message: format!("unsafe bridge name: {}", bridge),
+            });
+        }
         let (gateway, prefix) = parse_ipv4_cidr(&self.config.nap_bridge_addr).map_err(|msg| {
             BluetoothError::CommandFailed {
                 command: "dnsmasq",
@@ -696,6 +717,12 @@ impl BluetoothDiscovery {
 
     #[cfg(target_os = "linux")]
     pub(super) async fn start_dhclient(&self, interface: &str) -> Result<Child, BluetoothError> {
+        if !crate::support::is_safe_interface_name(interface) {
+            return Err(BluetoothError::CommandFailed {
+                command: "validation",
+                message: format!("unsafe interface name: {}", interface),
+            });
+        }
         let child = Command::new(&self.dhclient_command)
             .args(["-d", "-v", interface])
             .stdout(Stdio::null())
@@ -802,6 +829,9 @@ impl BluetoothDiscovery {
         &self,
     ) -> Result<Vec<ResolvedPanInterface>, BluetoothError> {
         let interface = resolve_macos_pan_interface_hint(&self.config.interface);
+        if !crate::support::is_safe_interface_name(interface) {
+            return Ok(Vec::new());
+        }
         let output = Command::new("ifconfig").arg(interface).output().await?;
         if !output.status.success() {
             return Ok(Vec::new());
@@ -826,6 +856,12 @@ impl BluetoothDiscovery {
         &self,
         interface: &str,
     ) -> Result<Vec<SocketAddr>, BluetoothError> {
+        if !crate::support::is_safe_interface_name(interface) {
+            return Err(BluetoothError::CommandFailed {
+                command: "validation",
+                message: format!("unsafe interface name: {}", interface),
+            });
+        }
         let scope_id = interface_index(interface);
         let output = Command::new(&self.ip_command)
             .args(["neigh", "show", "dev", interface])
@@ -851,6 +887,12 @@ impl BluetoothDiscovery {
         &self,
         interface: &str,
     ) -> Result<Vec<SocketAddr>, BluetoothError> {
+        if !crate::support::is_safe_interface_name(interface) {
+            return Err(BluetoothError::CommandFailed {
+                command: "validation",
+                message: format!("unsafe interface name: {}", interface),
+            });
+        }
         let output = Command::new(&self.ip_command)
             .args(["-an", "-i", interface])
             .output()

--- a/crates/pim-bluetooth/src/support.rs
+++ b/crates/pim-bluetooth/src/support.rs
@@ -2,6 +2,17 @@
 
 use super::*;
 
+pub(super) fn is_safe_interface_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > 15 {
+        return false;
+    }
+    if name.starts_with('-') {
+        return false;
+    }
+    name.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
+
 #[cfg(any(test, target_os = "linux"))]
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
**Severity**: HIGH
**Vulnerability**: Untrusted user configuration for bridge and interface names were passed to shell utilities (`ip`, `ifconfig`, `arp`) via `Command::new()`. This allowed argument injection attacks, e.g., using names starting with `-` or other special characters.
**Impact**: An attacker who can influence the local config or external discovery values could inject flags to these utilities.
**Fix**: Added `is_safe_interface_name` to validate lengths (<16), characters (alphanumeric, -, _, .), and ensure it does not start with `-`. Applied this check before all command execution in `platform_impl.rs`.
**Verification**: Passed `cargo check` and `cargo test`. Verified injection block syntax.

---
*PR created automatically by Jules for task [12737205794628389084](https://jules.google.com/task/12737205794628389084) started by @Rfluid*