### PR TITLE
agent: update ARCHITECTURE_MAP with new crates and JNI bridge

### DIFF
--- a/.agent/core/ARCHITECTURE_MAP.md
+++ b/.agent/core/ARCHITECTURE_MAP.md
@@ -30,6 +30,8 @@ This map is the default orientation for agent work in this repository.
 - `crates/pim-core/src/config.rs`
     - shared configuration model
     - feature toggles and defaults
+- `crates/pim-daemon/src/jni.rs`
+    - Android JNI bridges and VPN service configurations
 
 ## Major Subsystems
 
@@ -52,6 +54,10 @@ This map is the default orientation for agent work in this repository.
     - route computation and advertisement handling
 - `crates/pim-gateway/src/lib.rs`
     - gateway NAT and internet-edge behavior
+- `crates/pim-bluetooth/src/`
+    - Bluetooth RFCOMM and discovery implementation
+- `crates/pim-messaging/src/`
+    - User-to-user encrypted messaging daemon plugin
 
 ## Common Task Routing
 


### PR DESCRIPTION
Analyzed recent repository activity and observed significant additions related to Android JNI, Bluetooth RFCOMM, and Messaging plugin. Updated \`.agent/core/ARCHITECTURE_MAP.md\` to explicitly map these components, making it easier for agents to locate them.

---
*PR created automatically by Jules for task [15017591643300395202](https://jules.google.com/task/15017591643300395202) started by @Rfluid*