### PR TITLE
⚡ Bolt: Cache SQLite prepared statements

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 
 **Learning:** `Vec::new()` allocates no heap memory until the first element is pushed, at which point it dynamically allocates and then periodically reallocates. In hot network paths like `fragment_packet`, where we know we will push items, this leads to unnecessary reallocation overhead. However, it is a mistake to aggressively apply `Vec::with_capacity()` to collections that often remain empty (e.g., error queues or retry buffers on the "happy path"), as this will force an unnecessary heap allocation where `Vec::new()` would have remained zero-cost.
 **Action:** Always pre-allocate exact `Vec` capacities (e.g., using `Vec::with_capacity()`) over `Vec::new()` when the final size or an upper bound is known in advance *and* the vector is guaranteed or highly likely to be populated. Avoid `Vec::with_capacity()` for paths that usually remain empty.
+
+## 2024-05-20 - Cache SQLite prepared statements
+**Learning:** Repetitive execution of SQLite queries using `conn.prepare()` incurs compilation overhead. In high-traffic paths like peer directory and messaging storage, this causes unnecessary CPU load.
+**Action:** Use `conn.prepare_cached()` instead of `conn.prepare()` for static SQL queries to leverage statement caching and minimize execution latency.

--- a/crates/pim-daemon/src/peer_directory.rs
+++ b/crates/pim-daemon/src/peer_directory.rs
@@ -384,7 +384,7 @@ impl PeerDirectoryService {
 
     fn list_x25519_blocking(&self) -> Result<std::collections::HashMap<String, String>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare("SELECT node_id, x25519_pub FROM peers_seen")?;
+        let mut stmt = conn.prepare_cached("SELECT node_id, x25519_pub FROM peers_seen")?;
         let rows = stmt
             .query_map([], |row| {
                 let node_id: String = row.get(0)?;
@@ -407,7 +407,7 @@ impl PeerDirectoryService {
     /// loop reports what it dropped.
     pub fn list_peers_older_than(&self, threshold_ms: i64) -> Result<Vec<(NodeId, i64, String)>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare_cached(
             "SELECT node_id, last_seen_ms, last_known_name \
              FROM peers_seen \
              WHERE last_seen_ms < ?1 \
@@ -501,7 +501,7 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn list_rfcomm_lifecycle(&self) -> Result<Vec<RfcommLifecycleRecord>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare_cached(
             "SELECT bd_addr, name, first_paired_at_s, last_connected_at_s \
              FROM rfcomm_peer_lifecycle \
              ORDER BY bd_addr ASC",
@@ -568,7 +568,7 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn list_pan_lifecycle(&self) -> Result<Vec<PanLifecycleRecord>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare_cached(
             "SELECT bd_addr, name, first_paired_at_s, last_connected_at_s \
              FROM bluetooth_pan_lifecycle \
              ORDER BY bd_addr ASC",
@@ -633,7 +633,7 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn list_wfd_lifecycle(&self) -> Result<Vec<WfdLifecycleRecord>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare_cached(
             "SELECT mac, first_seen_at_s, last_connected_at_s \
              FROM wfd_peer_lifecycle \
              ORDER BY mac ASC",

--- a/crates/pim-messaging/src/storage.rs
+++ b/crates/pim-messaging/src/storage.rs
@@ -329,14 +329,14 @@ impl MessagingStorage {
         let limit_plus = limit.saturating_add(1).max(2);
 
         let mut stmt = match before_ts_ms {
-            Some(_) => conn.prepare(
+            Some(_) => conn.prepare_cached(
                 "SELECT id, peer_node_id, direction, body, timestamp_ms, status, failure_reason, delivered_at_ms, read_at_ms \
                  FROM messages \
                  WHERE peer_node_id = ?1 AND timestamp_ms < ?2 \
                  ORDER BY timestamp_ms DESC, id DESC \
                  LIMIT ?3",
             )?,
-            None => conn.prepare(
+            None => conn.prepare_cached(
                 "SELECT id, peer_node_id, direction, body, timestamp_ms, status, failure_reason, delivered_at_ms, read_at_ms \
                  FROM messages \
                  WHERE peer_node_id = ?1 \
@@ -363,7 +363,7 @@ impl MessagingStorage {
     /// layer fills them in from the daemon's peer directory.
     pub fn list_conversations_raw(&self) -> Result<Vec<ConversationSummary>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let mut stmt = conn.prepare_cached(
             "SELECT peer_node_id, last_message_preview, last_message_ts_ms, unread_count \
              FROM conversations_meta \
              ORDER BY last_message_ts_ms DESC NULLS LAST",


### PR DESCRIPTION
💡 What: Changed conn.prepare to conn.prepare_cached in high-traffic SQLite queries.
🎯 Why: Repetitive execution of SQLite queries using conn.prepare() incurs compilation overhead, causing unnecessary CPU load.
📊 Impact: Reduces query execution latency and CPU overhead.
🔬 Measurement: Run unit tests to verify correctness and profile CPU usage during high database interaction.

---
*PR created automatically by Jules for task [1712688190054119414](https://jules.google.com/task/1712688190054119414) started by @Rfluid*