### PR TITLE
docs(agent): update ARCHITECTURE_MAP with bluetooth and jni

### DIFF
--- a/.agent/core/ARCHITECTURE_MAP.md
+++ b/.agent/core/ARCHITECTURE_MAP.md
@@ -30,9 +30,13 @@ This map is the default orientation for agent work in this repository.
 - `crates/pim-core/src/config.rs`
     - shared configuration model
     - feature toggles and defaults
+- `crates/pim-daemon/src/jni.rs`
+    - Android JNI bridges and VPN service coordination
 
 ## Major Subsystems
 
+- `crates/pim-bluetooth/src/`
+    - Bluetooth and RFCOMM transport capabilities
 - `crates/pim-tun/src/lib.rs`
     - Linux TUN device lifecycle
     - packet ingress and egress with the host OS


### PR DESCRIPTION
Updates the agent architecture map to include the `pim-bluetooth` subsystem and the Android JNI bridge (`crates/pim-daemon/src/jni.rs`). This fills a gap in the agent's structural understanding, reflecting recent project activity in these domains.

---
*PR created automatically by Jules for task [10319608081242703544](https://jules.google.com/task/10319608081242703544) started by @Rfluid*