### PR TITLE
docs(agent): update ARCHITECTURE_MAP.md with Android and Bluetooth paths

### DIFF
--- a/.agent/core/ARCHITECTURE_MAP.md
+++ b/.agent/core/ARCHITECTURE_MAP.md
@@ -31,6 +31,9 @@ This map is the default orientation for agent work in this repository.
     - shared configuration model
     - feature toggles and defaults
 
+- `crates/pim-daemon/src/jni.rs`
+    - Android JNI bridges and VPN service configurations
+
 ## Major Subsystems
 
 - `crates/pim-tun/src/lib.rs`
@@ -52,6 +55,9 @@ This map is the default orientation for agent work in this repository.
     - route computation and advertisement handling
 - `crates/pim-gateway/src/lib.rs`
     - gateway NAT and internet-edge behavior
+
+- `crates/pim-bluetooth/src/lib.rs`
+    - Bluetooth RFCOMM and Android Bluetooth integrations
 
 ## Common Task Routing
 


### PR DESCRIPTION
Updates the agent architecture map based on recent Android and Bluetooth integration work. This aligns the `.agent/core/ARCHITECTURE_MAP.md` with the newly exposed modules (`crates/pim-daemon/src/jni.rs` and `crates/pim-bluetooth/src/lib.rs`).

---
*PR created automatically by Jules for task [671829635097852586](https://jules.google.com/task/671829635097852586) started by @Rfluid*