### PR TITLE
⚡ Bolt: Replace synchronous file operations with tokio::fs in pim-daemon RPC server

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,8 @@
 
 **Learning:** `Vec::new()` allocates no heap memory until the first element is pushed, at which point it dynamically allocates and then periodically reallocates. In hot network paths like `fragment_packet`, where we know we will push items, this leads to unnecessary reallocation overhead. However, it is a mistake to aggressively apply `Vec::with_capacity()` to collections that often remain empty (e.g., error queues or retry buffers on the "happy path"), as this will force an unnecessary heap allocation where `Vec::new()` would have remained zero-cost.
 **Action:** Always pre-allocate exact `Vec` capacities (e.g., using `Vec::with_capacity()`) over `Vec::new()` when the final size or an upper bound is known in advance *and* the vector is guaranteed or highly likely to be populated. Avoid `Vec::with_capacity()` for paths that usually remain empty.
+
+## 2026-05-18 - Avoid synchronous file operations in async paths
+
+**Learning:** Synchronous file system operations (`std::fs::remove_file`, `std::fs::create_dir_all`, etc.) block the executing thread. In a Tokio runtime, calling these directly from an `async fn` blocks the reactor thread, preventing other asynchronous tasks from making progress and causing unpredictable latency spikes.
+**Action:** Always use the asynchronous equivalents found in `tokio::fs` within `async` functions to delegate blocking file operations to the runtime's blocking thread pool, preserving reactor responsiveness.

--- a/crates/pim-daemon/src/rpc.rs
+++ b/crates/pim-daemon/src/rpc.rs
@@ -120,11 +120,12 @@ fn new_subscription_id() -> String {
 
 pub(crate) async fn run_rpc_server(state: Arc<DaemonState>, socket_path: PathBuf) {
     // Best-effort cleanup of a stale socket from a previous run.
-    let _ = std::fs::remove_file(&socket_path);
+    // Optimization: Use tokio::fs instead of std::fs to prevent blocking the async reactor thread
+    let _ = tokio::fs::remove_file(&socket_path).await;
 
     if let Some(parent) = socket_path.parent() {
         if !parent.as_os_str().is_empty() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
+            if let Err(e) = tokio::fs::create_dir_all(parent).await {
                 warn!(
                     "rpc: create parent dir {} failed: {e} — listener may fail to bind",
                     parent.display()
@@ -152,7 +153,7 @@ pub(crate) async fn run_rpc_server(state: Arc<DaemonState>, socket_path: PathBuf
     {
         use std::os::unix::fs::PermissionsExt;
         if let Err(e) =
-            std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o660))
+            tokio::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o660)).await
         {
             warn!("rpc: chmod 0660 socket failed: {e}");
         }


### PR DESCRIPTION
💡 What: Replaced synchronous `std::fs` operations with `tokio::fs` in the RPC server startup.
🎯 Why: Synchronous file operations block the Tokio reactor thread, causing latency spikes in an asynchronous context.
📊 Impact: Eliminates blocking on the main async thread during RPC server startup and socket cleanup.
🔬 Measurement: Code review confirms the use of `.await` and `tokio::fs`.

---
*PR created automatically by Jules for task [1038379533951423549](https://jules.google.com/task/1038379533951423549) started by @Rfluid*