### PR TITLE
⚡ Bolt: Implement rusqlite statement caching

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -49,3 +49,7 @@
 
 **Learning:** `Vec::new()` allocates no heap memory until the first element is pushed, at which point it dynamically allocates and then periodically reallocates. In hot network paths like `fragment_packet`, where we know we will push items, this leads to unnecessary reallocation overhead. However, it is a mistake to aggressively apply `Vec::with_capacity()` to collections that often remain empty (e.g., error queues or retry buffers on the "happy path"), as this will force an unnecessary heap allocation where `Vec::new()` would have remained zero-cost.
 **Action:** Always pre-allocate exact `Vec` capacities (e.g., using `Vec::with_capacity()`) over `Vec::new()` when the final size or an upper bound is known in advance *and* the vector is guaranteed or highly likely to be populated. Avoid `Vec::with_capacity()` for paths that usually remain empty.
+## 2026-05-10 - Prepared statement caching for SQLite performance
+
+**Learning:** In database modules like `pim-daemon`'s `peer_directory` and `pim-messaging`'s `storage`, using `conn.execute()` or `conn.prepare()` without caching parses the static SQL string into a VDBE program on every invocation. For frequent database writes (like processing incoming chat messages or peer discovery events), this adds significant CPU overhead.
+**Action:** Use `conn.prepare_cached()` instead of `conn.execute()` or `conn.prepare()` to leverage `rusqlite`'s statement cache, avoiding redundant SQL compilation in performance-sensitive paths.

--- a/crates/pim-daemon/src/peer_directory.rs
+++ b/crates/pim-daemon/src/peer_directory.rs
@@ -273,19 +273,15 @@ impl PeerDirectoryService {
 
         match existing {
             None => {
-                conn.execute(
-                    "INSERT INTO peers_seen (node_id, x25519_pub, last_known_name, first_seen_ms, last_seen_ms) \
-                     VALUES (?1, ?2, ?3, ?4, ?4)",
-                    params![peer_hex, x25519_pub.as_slice(), name, now_ms],
-                )?;
+                /* PERF: Leverage rusqlite statement cache */
+                conn.prepare_cached("INSERT INTO peers_seen (node_id, x25519_pub, last_known_name, first_seen_ms, last_seen_ms) \
+                     VALUES (?1, ?2, ?3, ?4, ?4)")?.execute(params![peer_hex, x25519_pub.as_slice(), name, now_ms])?;
                 Ok(true)
             }
             Some(_) => {
-                conn.execute(
-                    "UPDATE peers_seen SET x25519_pub = ?2, last_known_name = ?3, last_seen_ms = ?4 \
-                     WHERE node_id = ?1",
-                    params![peer_hex, x25519_pub.as_slice(), name, now_ms],
-                )?;
+                /* PERF: Leverage rusqlite statement cache */
+                conn.prepare_cached("UPDATE peers_seen SET x25519_pub = ?2, last_known_name = ?3, last_seen_ms = ?4 \
+                     WHERE node_id = ?1")?.execute(params![peer_hex, x25519_pub.as_slice(), name, now_ms])?;
                 Ok(false)
             }
         }
@@ -311,24 +307,21 @@ impl PeerDirectoryService {
         match existing {
             None => {
                 let name = name_if_set.unwrap_or("");
-                conn.execute(
-                    "INSERT INTO peers_seen (node_id, x25519_pub, last_known_name, first_seen_ms, last_seen_ms) \
-                     VALUES (?1, ?2, ?3, ?4, ?4)",
-                    params![peer_hex, x25519_pub.as_slice(), name, now_ms],
-                )?;
+                /* PERF: Leverage rusqlite statement cache */
+                conn.prepare_cached("INSERT INTO peers_seen (node_id, x25519_pub, last_known_name, first_seen_ms, last_seen_ms) \
+                     VALUES (?1, ?2, ?3, ?4, ?4)")?.execute(params![peer_hex, x25519_pub.as_slice(), name, now_ms])?;
                 Ok(ImportOutcome::Inserted)
             }
             Some(bytes) if bytes.as_slice() == x25519_pub.as_slice() => {
                 if let Some(name) = name_if_set.filter(|s| !s.is_empty()) {
-                    conn.execute(
-                        "UPDATE peers_seen SET last_known_name = ?2, last_seen_ms = ?3 WHERE node_id = ?1",
-                        params![peer_hex, name, now_ms],
-                    )?;
+                    /* PERF: Leverage rusqlite statement cache */
+                    conn.prepare_cached("UPDATE peers_seen SET last_known_name = ?2, last_seen_ms = ?3 WHERE node_id = ?1")?.execute(params![peer_hex, name, now_ms])?;
                 } else {
-                    conn.execute(
+                    /* PERF: Leverage rusqlite statement cache */
+                    conn.prepare_cached(
                         "UPDATE peers_seen SET last_seen_ms = ?2 WHERE node_id = ?1",
-                        params![peer_hex, now_ms],
-                    )?;
+                    )?
+                    .execute(params![peer_hex, now_ms])?;
                 }
                 Ok(ImportOutcome::Refreshed)
             }
@@ -341,10 +334,8 @@ impl PeerDirectoryService {
     fn forget_blocking(&self, peer: &NodeId) -> Result<ForgetOutcome> {
         let conn = self.conn.lock().unwrap();
         let peer_hex = hex_node_id(peer);
-        let removed = conn.execute(
-            "DELETE FROM peers_seen WHERE node_id = ?1",
-            params![peer_hex],
-        )?;
+        let removed = /* PERF: Leverage rusqlite statement cache */
+conn.prepare_cached("DELETE FROM peers_seen WHERE node_id = ?1")?.execute(params![peer_hex])?;
         Ok(ForgetOutcome {
             forgot_identity: removed > 0,
         })
@@ -384,7 +375,7 @@ impl PeerDirectoryService {
 
     fn list_x25519_blocking(&self) -> Result<std::collections::HashMap<String, String>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare("SELECT node_id, x25519_pub FROM peers_seen")?;
+        let mut stmt = /* PERF: Leverage rusqlite statement cache */ conn.prepare_cached("SELECT node_id, x25519_pub FROM peers_seen")?;
         let rows = stmt
             .query_map([], |row| {
                 let node_id: String = row.get(0)?;
@@ -407,7 +398,7 @@ impl PeerDirectoryService {
     /// loop reports what it dropped.
     pub fn list_peers_older_than(&self, threshold_ms: i64) -> Result<Vec<(NodeId, i64, String)>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let mut stmt = /* PERF: Leverage rusqlite statement cache */ conn.prepare_cached(
             "SELECT node_id, last_seen_ms, last_known_name \
              FROM peers_seen \
              WHERE last_seen_ms < ?1 \
@@ -447,12 +438,13 @@ impl PeerDirectoryService {
     /// untouched. Always idempotent.
     pub fn observe_rfcomm_paired(&self, bd_addr: &str, name: &str, now_s: i64) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached(
             "INSERT INTO rfcomm_peer_lifecycle (bd_addr, name, first_paired_at_s) \
              VALUES (?1, ?2, ?3) \
              ON CONFLICT(bd_addr) DO NOTHING",
-            params![bd_addr, name, now_s],
-        )?;
+        )?
+        .execute(params![bd_addr, name, now_s])?;
         Ok(())
     }
 
@@ -466,13 +458,11 @@ impl PeerDirectoryService {
     /// the timestamp.
     pub fn record_rfcomm_connected(&self, bd_addr: &str, name: &str, now_s: i64) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO rfcomm_peer_lifecycle (bd_addr, name, first_paired_at_s, last_connected_at_s) \
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached("INSERT INTO rfcomm_peer_lifecycle (bd_addr, name, first_paired_at_s, last_connected_at_s) \
              VALUES (?1, ?2, ?3, ?3) \
              ON CONFLICT(bd_addr) DO UPDATE SET \
-                last_connected_at_s = MAX(COALESCE(last_connected_at_s, 0), excluded.last_connected_at_s)",
-            params![bd_addr, name, now_s],
-        )?;
+                last_connected_at_s = MAX(COALESCE(last_connected_at_s, 0), excluded.last_connected_at_s)")?.execute(params![bd_addr, name, now_s])?;
         Ok(())
     }
 
@@ -501,7 +491,7 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn list_rfcomm_lifecycle(&self) -> Result<Vec<RfcommLifecycleRecord>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let mut stmt = /* PERF: Leverage rusqlite statement cache */ conn.prepare_cached(
             "SELECT bd_addr, name, first_paired_at_s, last_connected_at_s \
              FROM rfcomm_peer_lifecycle \
              ORDER BY bd_addr ASC",
@@ -525,10 +515,8 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn forget_rfcomm_peer(&self, bd_addr: &str) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
-        let n = conn.execute(
-            "DELETE FROM rfcomm_peer_lifecycle WHERE bd_addr = ?1",
-            params![bd_addr],
-        )?;
+        let n = /* PERF: Leverage rusqlite statement cache */
+conn.prepare_cached("DELETE FROM rfcomm_peer_lifecycle WHERE bd_addr = ?1")?.execute(params![bd_addr])?;
         Ok(n > 0)
     }
 
@@ -540,12 +528,13 @@ impl PeerDirectoryService {
     /// [`Self::observe_rfcomm_paired`] but for the PAN table.
     pub fn observe_pan_paired(&self, bd_addr: &str, name: &str, now_s: i64) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached(
             "INSERT INTO bluetooth_pan_lifecycle (bd_addr, name, first_paired_at_s) \
              VALUES (?1, ?2, ?3) \
              ON CONFLICT(bd_addr) DO NOTHING",
-            params![bd_addr, name, now_s],
-        )?;
+        )?
+        .execute(params![bd_addr, name, now_s])?;
         Ok(())
     }
 
@@ -553,13 +542,11 @@ impl PeerDirectoryService {
     /// `bd_addr`. Upserts; never rewinds `last_connected_at_s`.
     pub fn record_pan_connected(&self, bd_addr: &str, name: &str, now_s: i64) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO bluetooth_pan_lifecycle (bd_addr, name, first_paired_at_s, last_connected_at_s) \
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached("INSERT INTO bluetooth_pan_lifecycle (bd_addr, name, first_paired_at_s, last_connected_at_s) \
              VALUES (?1, ?2, ?3, ?3) \
              ON CONFLICT(bd_addr) DO UPDATE SET \
-                last_connected_at_s = MAX(COALESCE(last_connected_at_s, 0), excluded.last_connected_at_s)",
-            params![bd_addr, name, now_s],
-        )?;
+                last_connected_at_s = MAX(COALESCE(last_connected_at_s, 0), excluded.last_connected_at_s)")?.execute(params![bd_addr, name, now_s])?;
         Ok(())
     }
 
@@ -568,7 +555,7 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn list_pan_lifecycle(&self) -> Result<Vec<PanLifecycleRecord>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let mut stmt = /* PERF: Leverage rusqlite statement cache */ conn.prepare_cached(
             "SELECT bd_addr, name, first_paired_at_s, last_connected_at_s \
              FROM bluetooth_pan_lifecycle \
              ORDER BY bd_addr ASC",
@@ -591,10 +578,8 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn forget_pan_peer(&self, bd_addr: &str) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
-        let n = conn.execute(
-            "DELETE FROM bluetooth_pan_lifecycle WHERE bd_addr = ?1",
-            params![bd_addr],
-        )?;
+        let n = /* PERF: Leverage rusqlite statement cache */
+conn.prepare_cached("DELETE FROM bluetooth_pan_lifecycle WHERE bd_addr = ?1")?.execute(params![bd_addr])?;
         Ok(n > 0)
     }
 
@@ -605,12 +590,13 @@ impl PeerDirectoryService {
     /// untouched.
     pub fn observe_wfd_peer(&self, mac: &str, now_s: i64) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached(
             "INSERT INTO wfd_peer_lifecycle (mac, first_seen_at_s) \
              VALUES (?1, ?2) \
              ON CONFLICT(mac) DO NOTHING",
-            params![mac, now_s],
-        )?;
+        )?
+        .execute(params![mac, now_s])?;
         Ok(())
     }
 
@@ -618,13 +604,11 @@ impl PeerDirectoryService {
     /// with `mac`. Upserts; never rewinds `last_connected_at_s`.
     pub fn record_wfd_connected(&self, mac: &str, now_s: i64) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO wfd_peer_lifecycle (mac, first_seen_at_s, last_connected_at_s) \
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached("INSERT INTO wfd_peer_lifecycle (mac, first_seen_at_s, last_connected_at_s) \
              VALUES (?1, ?2, ?2) \
              ON CONFLICT(mac) DO UPDATE SET \
-                last_connected_at_s = MAX(COALESCE(last_connected_at_s, 0), excluded.last_connected_at_s)",
-            params![mac, now_s],
-        )?;
+                last_connected_at_s = MAX(COALESCE(last_connected_at_s, 0), excluded.last_connected_at_s)")?.execute(params![mac, now_s])?;
         Ok(())
     }
 
@@ -633,7 +617,7 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn list_wfd_lifecycle(&self) -> Result<Vec<WfdLifecycleRecord>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let mut stmt = /* PERF: Leverage rusqlite statement cache */ conn.prepare_cached(
             "SELECT mac, first_seen_at_s, last_connected_at_s \
              FROM wfd_peer_lifecycle \
              ORDER BY mac ASC",
@@ -655,10 +639,8 @@ impl PeerDirectoryService {
     #[allow(dead_code)]
     pub fn forget_wfd_peer(&self, mac: &str) -> Result<bool> {
         let conn = self.conn.lock().unwrap();
-        let n = conn.execute(
-            "DELETE FROM wfd_peer_lifecycle WHERE mac = ?1",
-            params![mac],
-        )?;
+        let n = /* PERF: Leverage rusqlite statement cache */
+conn.prepare_cached("DELETE FROM wfd_peer_lifecycle WHERE mac = ?1")?.execute(params![mac])?;
         Ok(n > 0)
     }
 }

--- a/crates/pim-messaging/src/storage.rs
+++ b/crates/pim-messaging/src/storage.rs
@@ -190,11 +190,10 @@ impl MessagingStorage {
     /// for inbound).
     pub fn insert_message(&self, m: &MessageRecord) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT OR REPLACE INTO messages \
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached("INSERT OR REPLACE INTO messages \
              (id, peer_node_id, direction, body, timestamp_ms, status, failure_reason, delivered_at_ms, read_at_ms) \
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
-            params![
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)")?.execute(params![
                 m.id,
                 m.peer_node_id,
                 m.direction.as_str(),
@@ -204,8 +203,7 @@ impl MessagingStorage {
                 m.failure_reason,
                 m.delivered_at_ms,
                 m.read_at_ms,
-            ],
-        )?;
+            ])?;
         Ok(())
     }
 
@@ -219,7 +217,8 @@ impl MessagingStorage {
     ) -> Result<()> {
         let preview = preview_of(body);
         let conn = self.conn.lock().unwrap();
-        conn.execute(
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached(
             "INSERT INTO conversations_meta (peer_node_id, unread_count, last_read_message_id, \
                 last_message_id, last_message_preview, last_message_ts_ms) \
              VALUES (?1, 0, NULL, ?2, ?3, ?4) \
@@ -227,8 +226,8 @@ impl MessagingStorage {
                 last_message_id = excluded.last_message_id, \
                 last_message_preview = excluded.last_message_preview, \
                 last_message_ts_ms = excluded.last_message_ts_ms",
-            params![peer_id_hex, message_id_hex, preview, ts_ms],
-        )?;
+        )?
+        .execute(params![peer_id_hex, message_id_hex, preview, ts_ms])?;
         Ok(())
     }
 
@@ -245,7 +244,8 @@ impl MessagingStorage {
         let preview = preview_of(body);
         let conn = self.conn.lock().unwrap();
 
-        conn.execute(
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached(
             "INSERT INTO conversations_meta (peer_node_id, unread_count, last_message_id, \
                 last_message_preview, last_message_ts_ms) \
              VALUES (?1, 1, ?2, ?3, ?4) \
@@ -254,14 +254,11 @@ impl MessagingStorage {
                 last_message_id = excluded.last_message_id, \
                 last_message_preview = excluded.last_message_preview, \
                 last_message_ts_ms = excluded.last_message_ts_ms",
-            params![peer_id_hex, message_id_hex, preview, ts_ms],
-        )?;
+        )?
+        .execute(params![peer_id_hex, message_id_hex, preview, ts_ms])?;
 
-        let unread_count: i64 = conn.query_row(
-            "SELECT unread_count FROM conversations_meta WHERE peer_node_id = ?1",
-            params![peer_id_hex],
-            |row| row.get::<_, i64>(0),
-        )?;
+        let unread_count: i64 = /* PERF: Leverage rusqlite statement cache */
+conn.prepare_cached("SELECT unread_count FROM conversations_meta WHERE peer_node_id = ?1")?.query_row(params![peer_id_hex], |row| row.get::<_,i64>(0),)?;
 
         Ok(ConversationBump {
             preview,
@@ -281,28 +278,21 @@ impl MessagingStorage {
         let conn = self.conn.lock().unwrap();
         match (delivered_at_ms, read_at_ms) {
             (Some(d), Some(r)) => {
-                conn.execute(
-                    "UPDATE messages SET status = ?1, delivered_at_ms = ?2, read_at_ms = ?3 WHERE id = ?4",
-                    params![status.as_str(), d, r, message_id_hex],
-                )?;
+                /* PERF: Leverage rusqlite statement cache */
+                conn.prepare_cached("UPDATE messages SET status = ?1, delivered_at_ms = ?2, read_at_ms = ?3 WHERE id = ?4")?.execute(params![status.as_str(), d, r, message_id_hex])?;
             }
             (Some(d), None) => {
-                conn.execute(
-                    "UPDATE messages SET status = ?1, delivered_at_ms = COALESCE(delivered_at_ms, ?2) WHERE id = ?3",
-                    params![status.as_str(), d, message_id_hex],
-                )?;
+                /* PERF: Leverage rusqlite statement cache */
+                conn.prepare_cached("UPDATE messages SET status = ?1, delivered_at_ms = COALESCE(delivered_at_ms, ?2) WHERE id = ?3")?.execute(params![status.as_str(), d, message_id_hex])?;
             }
             (None, Some(r)) => {
-                conn.execute(
-                    "UPDATE messages SET status = ?1, read_at_ms = COALESCE(read_at_ms, ?2) WHERE id = ?3",
-                    params![status.as_str(), r, message_id_hex],
-                )?;
+                /* PERF: Leverage rusqlite statement cache */
+                conn.prepare_cached("UPDATE messages SET status = ?1, read_at_ms = COALESCE(read_at_ms, ?2) WHERE id = ?3")?.execute(params![status.as_str(), r, message_id_hex])?;
             }
             (None, None) => {
-                conn.execute(
-                    "UPDATE messages SET status = ?1 WHERE id = ?2",
-                    params![status.as_str(), message_id_hex],
-                )?;
+                /* PERF: Leverage rusqlite statement cache */
+                conn.prepare_cached("UPDATE messages SET status = ?1 WHERE id = ?2")?
+                    .execute(params![status.as_str(), message_id_hex])?;
             }
         }
         Ok(())
@@ -311,10 +301,8 @@ impl MessagingStorage {
     /// Set `status = failed` and persist a human-readable reason.
     pub fn set_message_failed(&self, message_id_hex: &str, reason: &str, at_ms: i64) -> Result<()> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "UPDATE messages SET status = 'failed', failure_reason = ?1, delivered_at_ms = COALESCE(delivered_at_ms, ?2) WHERE id = ?3",
-            params![reason, at_ms, message_id_hex],
-        )?;
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached("UPDATE messages SET status = 'failed', failure_reason = ?1, delivered_at_ms = COALESCE(delivered_at_ms, ?2) WHERE id = ?3")?.execute(params![reason, at_ms, message_id_hex])?;
         Ok(())
     }
 
@@ -329,14 +317,14 @@ impl MessagingStorage {
         let limit_plus = limit.saturating_add(1).max(2);
 
         let mut stmt = match before_ts_ms {
-            Some(_) => conn.prepare(
+            Some(_) => /* PERF: Leverage rusqlite statement cache */ conn.prepare_cached(
                 "SELECT id, peer_node_id, direction, body, timestamp_ms, status, failure_reason, delivered_at_ms, read_at_ms \
                  FROM messages \
                  WHERE peer_node_id = ?1 AND timestamp_ms < ?2 \
                  ORDER BY timestamp_ms DESC, id DESC \
                  LIMIT ?3",
             )?,
-            None => conn.prepare(
+            None => /* PERF: Leverage rusqlite statement cache */ conn.prepare_cached(
                 "SELECT id, peer_node_id, direction, body, timestamp_ms, status, failure_reason, delivered_at_ms, read_at_ms \
                  FROM messages \
                  WHERE peer_node_id = ?1 \
@@ -363,7 +351,7 @@ impl MessagingStorage {
     /// layer fills them in from the daemon's peer directory.
     pub fn list_conversations_raw(&self) -> Result<Vec<ConversationSummary>> {
         let conn = self.conn.lock().unwrap();
-        let mut stmt = conn.prepare(
+        let mut stmt = /* PERF: Leverage rusqlite statement cache */ conn.prepare_cached(
             "SELECT peer_node_id, last_message_preview, last_message_ts_ms, unread_count \
              FROM conversations_meta \
              ORDER BY last_message_ts_ms DESC NULLS LAST",
@@ -397,14 +385,10 @@ impl MessagingStorage {
     pub fn delete_conversation(&self, peer_id_hex: &str) -> Result<(usize, bool)> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
-        let deleted_messages = tx.execute(
-            "DELETE FROM messages WHERE peer_node_id = ?1",
-            params![peer_id_hex],
-        )?;
-        let deleted_meta = tx.execute(
-            "DELETE FROM conversations_meta WHERE peer_node_id = ?1",
-            params![peer_id_hex],
-        )?;
+        let deleted_messages = /* PERF: Leverage rusqlite statement cache */
+tx.prepare_cached("DELETE FROM messages WHERE peer_node_id = ?1")?.execute(params![peer_id_hex])?;
+        let deleted_meta = /* PERF: Leverage rusqlite statement cache */
+tx.prepare_cached("DELETE FROM conversations_meta WHERE peer_node_id = ?1")?.execute(params![peer_id_hex])?;
         tx.commit()?;
         Ok((deleted_messages, deleted_meta > 0))
     }
@@ -413,8 +397,10 @@ impl MessagingStorage {
     pub fn delete_all_messages(&self) -> Result<(usize, usize)> {
         let mut conn = self.conn.lock().unwrap();
         let tx = conn.transaction()?;
-        let deleted_messages = tx.execute("DELETE FROM messages", [])?;
-        let deleted_meta = tx.execute("DELETE FROM conversations_meta", [])?;
+        let deleted_messages = /* PERF: Leverage rusqlite statement cache */
+tx.prepare_cached("DELETE FROM messages")?.execute([])?;
+        let deleted_meta = /* PERF: Leverage rusqlite statement cache */
+tx.prepare_cached("DELETE FROM conversations_meta")?.execute([])?;
         tx.commit()?;
         Ok((deleted_messages, deleted_meta))
     }
@@ -423,15 +409,14 @@ impl MessagingStorage {
     /// Returns the new `unread_count` (always 0).
     pub fn mark_read_up_to(&self, peer_id_hex: &str, up_to_ts_ms: i64) -> Result<i64> {
         let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "UPDATE messages SET status = 'read', read_at_ms = COALESCE(read_at_ms, ?2) \
-             WHERE peer_node_id = ?1 AND direction = 'received' AND timestamp_ms <= ?2 AND status != 'read'",
-            params![peer_id_hex, up_to_ts_ms],
-        )?;
-        conn.execute(
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached("UPDATE messages SET status = 'read', read_at_ms = COALESCE(read_at_ms, ?2) \
+             WHERE peer_node_id = ?1 AND direction = 'received' AND timestamp_ms <= ?2 AND status != 'read'")?.execute(params![peer_id_hex, up_to_ts_ms])?;
+        /* PERF: Leverage rusqlite statement cache */
+        conn.prepare_cached(
             "UPDATE conversations_meta SET unread_count = 0 WHERE peer_node_id = ?1",
-            params![peer_id_hex],
-        )?;
+        )?
+        .execute(params![peer_id_hex])?;
         Ok(0)
     }
 


### PR DESCRIPTION
What: Use rusqlite prepare_cached instead of prepare or execute. Why: In database modules like pim-daemon's peer_directory and pim-messaging's storage, using conn.execute() or conn.prepare() without caching parses the static SQL string into a VDBE program on every invocation. For frequent database writes (like processing incoming chat messages or peer discovery events), this adds significant CPU overhead. Impact: Improves SQLite query execution latency. Measurement: Benchmarks of message insertion and peer directory ops.

---
*PR created automatically by Jules for task [9342440810398301072](https://jules.google.com/task/9342440810398301072) started by @Rfluid*